### PR TITLE
[AGENT] Add reusable hallucination audit learnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ yarn-debug.log*
 yarn-error.log*
 
 minio-data/
+
+__pycache__/
+*.pyc
+.husky/_

--- a/analysis/hallucination-audit/README.md
+++ b/analysis/hallucination-audit/README.md
@@ -1,0 +1,21 @@
+# Hallucination audit workspace
+
+This folder contains reusable scripts for transcription hallucination audits.
+
+Key doc
+
+- docs/hallucination-audit-20260210.md
+
+Scripts
+
+- analysis/hallucination-audit/run_audit.py
+- analysis/hallucination-audit/compute_audio_volume.py
+- analysis/hallucination-audit/download_full_audio.py
+- analysis/hallucination-audit/transcribe_full_audio.py
+- analysis/hallucination-audit/align_with_full_transcript.py
+- analysis/hallucination-audit/create_langfuse_dataset_sample.py
+
+Notes
+
+- Raw meeting artifacts are intentionally not stored in this branch.
+- Keep large audio files and raw trace dumps in dedicated audit branches or local workspace storage.

--- a/analysis/hallucination-audit/align_with_full_transcript.py
+++ b/analysis/hallucination-audit/align_with_full_transcript.py
@@ -1,0 +1,201 @@
+import argparse
+import csv
+import json
+import re
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+
+def normalize_text(value: str) -> str:
+    lowered = value.lower()
+    stripped = re.sub(r"[^a-z0-9\s]", " ", lowered)
+    collapsed = re.sub(r"\s+", " ", stripped).strip()
+    return collapsed
+
+
+def levenshtein_distance(a: str, b: str) -> int:
+    if a == b:
+        return 0
+    if not a:
+        return len(b)
+    if not b:
+        return len(a)
+    if len(a) < len(b):
+        a, b = b, a
+    previous = list(range(len(b) + 1))
+    for i, ca in enumerate(a, start=1):
+        current = [i]
+        for j, cb in enumerate(b, start=1):
+            insert_cost = current[j - 1] + 1
+            delete_cost = previous[j] + 1
+            replace_cost = previous[j - 1] + (0 if ca == cb else 1)
+            current.append(min(insert_cost, delete_cost, replace_cost))
+        previous = current
+    return previous[-1]
+
+
+def build_index(words: List[str]) -> Dict[str, List[int]]:
+    index: Dict[str, List[int]] = {}
+    for pos, word in enumerate(words):
+        if len(word) < 4:
+            continue
+        index.setdefault(word, []).append(pos)
+    return index
+
+
+def find_subsequence_window(
+    snippet_words: List[str],
+    full_words: List[str],
+) -> Optional[Tuple[int, int]]:
+    if not snippet_words or not full_words or len(snippet_words) > len(full_words):
+        return None
+    snippet_length = len(snippet_words)
+    last_start = len(full_words) - snippet_length
+    for start in range(last_start + 1):
+        if full_words[start : start + snippet_length] == snippet_words:
+            return (start, start + snippet_length)
+    return None
+
+
+def best_match(
+    snippet_text: str,
+    snippet_words: List[str],
+    full_text: str,
+    full_words: List[str],
+    index: Dict[str, List[int]],
+) -> Tuple[Optional[float], str, Optional[Tuple[int, int]]]:
+    if not snippet_text:
+        return None, "empty", None
+    if snippet_text in full_text:
+        return 1.0, "substring", find_subsequence_window(snippet_words, full_words)
+
+    unique_words = sorted(set(snippet_words), key=len, reverse=True)
+    candidates = [word for word in unique_words if len(word) >= 4][:3]
+    if not candidates:
+        return None, "no_candidates", None
+
+    window_size = max(8, min(len(full_words), len(snippet_words) + 6))
+    snippet_word_set = set(snippet_words)
+    best_score: Optional[float] = None
+    best_window: Optional[Tuple[int, int]] = None
+    for word in candidates:
+        positions = index.get(word, [])
+        if len(positions) > 100:
+            positions = positions[:100]
+        for pos in positions:
+            start = max(0, pos - 3)
+            end = min(len(full_words), start + window_size)
+            window_text = " ".join(full_words[start:end])
+            if not window_text:
+                continue
+
+            if best_score is not None:
+                max_possible = 1 - (
+                    abs(len(snippet_text) - len(window_text))
+                    / max(len(snippet_text), len(window_text))
+                )
+                if max_possible <= best_score:
+                    continue
+
+            window_word_set = set(full_words[start:end])
+            if snippet_word_set and window_word_set:
+                overlap_ratio = len(snippet_word_set & window_word_set) / len(
+                    snippet_word_set
+                )
+                if overlap_ratio < 0.25:
+                    continue
+
+            dist = levenshtein_distance(snippet_text, window_text)
+            ratio = dist / max(len(snippet_text), len(window_text))
+            score = 1 - ratio
+            if best_score is None or score > best_score:
+                best_score = score
+                best_window = (start, end)
+    return best_score, "fuzzy", best_window
+
+
+def get_fieldnames(records: List[Dict[str, object]]) -> List[str]:
+    fieldnames: List[str] = []
+    seen = set()
+    for record in records:
+        for key in record.keys():
+            if key in seen:
+                continue
+            seen.add(key)
+            fieldnames.append(key)
+    return fieldnames
+
+
+def normalize_csv_value(value: object) -> str:
+    if isinstance(value, list):
+        return "|".join(str(item) for item in value)
+    if isinstance(value, dict):
+        return json.dumps(value)
+    if value is None:
+        return ""
+    return str(value)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Align snippet transcripts with full transcript text.",
+    )
+    parser.add_argument("--meeting-id", required=True)
+    parser.add_argument("--input", default="")
+    parser.add_argument("--threshold", type=float, default=0.85)
+    args = parser.parse_args()
+
+    meeting_dir = Path("analysis/hallucination-audit") / args.meeting_id
+    input_path = (
+        Path(args.input)
+        if args.input
+        else meeting_dir / "transcriptions_classified_with_audio.json"
+    )
+    full_path = meeting_dir / "full_transcript.txt"
+
+    if not input_path.exists():
+        raise SystemExit(f"Missing {input_path}")
+    if not full_path.exists():
+        raise SystemExit(f"Missing {full_path}")
+
+    records = json.loads(input_path.read_text(encoding="utf-8"))
+    full_text_raw = full_path.read_text(encoding="utf-8")
+    full_text = normalize_text(full_text_raw)
+    full_words = full_text.split()
+    index = build_index(full_words)
+
+    for record in records:
+        snippet_text_raw = record.get("output_text") or ""
+        snippet_text = normalize_text(snippet_text_raw)
+        snippet_words = snippet_text.split()
+        score, method, window = best_match(
+            snippet_text,
+            snippet_words,
+            full_text,
+            full_words,
+            index,
+        )
+        record["full_transcript_match_score"] = score
+        record["full_transcript_match_method"] = method
+        record["full_transcript_match_window"] = list(window) if window else None
+        record["full_transcript_match_found"] = bool(
+            score is not None and score >= args.threshold
+        )
+
+    output_json = meeting_dir / "transcriptions_classified_with_audio_and_full.json"
+    output_json.write_text(json.dumps(records, indent=2), encoding="utf-8")
+
+    output_csv = meeting_dir / "transcriptions_classified_with_audio_and_full.csv"
+    if records:
+        fields = get_fieldnames(records)
+        with output_csv.open("w", encoding="utf-8", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=fields)
+            writer.writeheader()
+            for record in records:
+                writer.writerow(
+                    {field: normalize_csv_value(record.get(field)) for field in fields}
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/hallucination-audit/compute_audio_volume.py
+++ b/analysis/hallucination-audit/compute_audio_volume.py
@@ -1,0 +1,261 @@
+import argparse
+import json
+import os
+import re
+import subprocess
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+import requests
+
+
+ENV_PATH = Path(__file__).resolve().parents[2] / ".env"
+DEFAULT_BASE_URL = "https://cloud.langfuse.com"
+
+
+def load_env(path: Path) -> None:
+    if not path.exists():
+        return
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, value = stripped.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
+def fetch_media_url(
+    base_url: str,
+    public_key: str,
+    secret_key: str,
+    media_id: str,
+    retries: int = 5,
+) -> str:
+    delay = 1.0
+    for attempt in range(retries):
+        response = requests.get(
+            f"{base_url.rstrip('/')}/api/public/media/{media_id}",
+            auth=(public_key, secret_key),
+            timeout=60,
+        )
+        if response.status_code == 429:
+            retry_after = response.headers.get("Retry-After")
+            wait_seconds = float(retry_after) if retry_after else delay
+            time.sleep(wait_seconds)
+            delay = min(delay * 2, 30)
+            continue
+        response.raise_for_status()
+        payload = response.json()
+        return payload["url"]
+    raise RuntimeError(f"rate_limited media_id={media_id}")
+
+
+def download_media(url: str, target: Path) -> None:
+    response = requests.get(url, timeout=120)
+    response.raise_for_status()
+    target.write_bytes(response.content)
+
+
+def parse_volume(output: str) -> Tuple[Optional[float], Optional[float], Optional[str]]:
+    mean_match = re.search(r"mean_volume:\s*([-\w.]+) dB", output)
+    max_match = re.search(r"max_volume:\s*([-\w.]+) dB", output)
+    mean_value = mean_match.group(1) if mean_match else None
+    max_value = max_match.group(1) if max_match else None
+
+    status = None
+    mean_db: Optional[float]
+    max_db: Optional[float]
+    if mean_value is None:
+        mean_db = None
+    elif mean_value == "-inf":
+        mean_db = None
+        status = "silence"
+    else:
+        mean_db = float(mean_value)
+    if max_value is None:
+        max_db = None
+    elif max_value == "-inf":
+        max_db = None
+        status = status or "silence"
+    else:
+        max_db = float(max_value)
+
+    return mean_db, max_db, status
+
+
+def compute_volume(
+    file_path: Path,
+) -> Tuple[Optional[float], Optional[float], Optional[str]]:
+    result = subprocess.run(
+        [
+            "ffmpeg",
+            "-hide_banner",
+            "-nostats",
+            "-i",
+            str(file_path),
+            "-filter:a",
+            "volumedetect",
+            "-f",
+            "null",
+            "-",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return parse_volume(result.stderr)
+
+
+def process_media_id(
+    media_id: str,
+    base_url: str,
+    public_key: str,
+    secret_key: str,
+    cache_dir: Path,
+    request_delay: float,
+) -> Tuple[str, Dict[str, Any]]:
+    target = cache_dir / f"{media_id}.mp3"
+    if not target.exists():
+        url = fetch_media_url(base_url, public_key, secret_key, media_id)
+        download_media(url, target)
+        if request_delay > 0:
+            time.sleep(request_delay)
+    mean_db, max_db, status = compute_volume(target)
+    return media_id, {
+        "audio_mean_volume_db": mean_db,
+        "audio_max_volume_db": max_db,
+        "audio_volume_status": status,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compute mean volume (dB) for Langfuse audio media.",
+    )
+    parser.add_argument("--meeting-id", required=True)
+    parser.add_argument("--workers", type=int, default=4)
+    parser.add_argument("--limit", type=int, default=0)
+    parser.add_argument("--offset", type=int, default=0)
+    parser.add_argument("--retry-errors", action="store_true")
+    parser.add_argument("--min-delay", type=float, default=0.0)
+    parser.add_argument("--base-url", default="")
+    args = parser.parse_args()
+
+    load_env(ENV_PATH)
+    public_key = os.getenv("LANGFUSE_PUBLIC_KEY", "").strip()
+    secret_key = os.getenv("LANGFUSE_SECRET_KEY", "").strip()
+    base_url = (
+        args.base_url or os.getenv("LANGFUSE_BASE_URL", "").strip() or DEFAULT_BASE_URL
+    )
+    if not public_key or not secret_key:
+        raise SystemExit("Missing LANGFUSE_PUBLIC_KEY or LANGFUSE_SECRET_KEY in env.")
+
+    meeting_dir = Path("analysis/hallucination-audit") / args.meeting_id
+    input_path = meeting_dir / "transcriptions_classified.json"
+    if not input_path.exists():
+        raise SystemExit(f"Missing {input_path}")
+
+    records = json.loads(input_path.read_text(encoding="utf-8"))
+    seen = set()
+    media_ids = []
+    for record in records:
+        media_id = record.get("audio_media_id")
+        if not media_id or media_id in seen:
+            continue
+        seen.add(media_id)
+        media_ids.append(media_id)
+
+    if args.offset and args.offset > 0:
+        media_ids = media_ids[args.offset :]
+    if args.limit and args.limit > 0:
+        media_ids = media_ids[: args.limit]
+
+    cache_dir = Path("analysis/hallucination-audit/audio_cache")
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    metrics_path = meeting_dir / "audio_volume_metrics.json"
+    metrics: Dict[str, Dict[str, Any]] = {}
+    if metrics_path.exists():
+        metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+
+    remaining = []
+    for media_id in media_ids:
+        if media_id not in metrics:
+            remaining.append(media_id)
+            continue
+        if args.retry_errors:
+            status = metrics[media_id].get("audio_volume_status") or ""
+            if isinstance(status, str) and status.startswith("error:"):
+                remaining.append(media_id)
+    if remaining:
+        with ThreadPoolExecutor(max_workers=args.workers) as executor:
+            futures = {
+                executor.submit(
+                    process_media_id,
+                    media_id,
+                    base_url,
+                    public_key,
+                    secret_key,
+                    cache_dir,
+                    args.min_delay,
+                ): media_id
+                for media_id in remaining
+            }
+            completed = 0
+            for future in as_completed(futures):
+                media_id = futures[future]
+                try:
+                    media_id, data = future.result()
+                    metrics[media_id] = data
+                except Exception as exc:
+                    metrics[media_id] = {
+                        "audio_mean_volume_db": None,
+                        "audio_max_volume_db": None,
+                        "audio_volume_status": f"error:{exc}",
+                    }
+                completed += 1
+                if completed % 25 == 0:
+                    metrics_path.write_text(
+                        json.dumps(metrics, indent=2),
+                        encoding="utf-8",
+                    )
+                time.sleep(0.05)
+    metrics_path.write_text(json.dumps(metrics, indent=2), encoding="utf-8")
+
+    for record in records:
+        media_id = record.get("audio_media_id")
+        data = metrics.get(media_id, {}) if media_id else {}
+        record.update(data)
+
+    output_json = meeting_dir / "transcriptions_classified_with_audio.json"
+    output_json.write_text(json.dumps(records, indent=2), encoding="utf-8")
+
+    output_csv = meeting_dir / "transcriptions_classified_with_audio.csv"
+    fields = list(records[0].keys()) if records else []
+    if records:
+        with output_csv.open("w", encoding="utf-8", newline="") as handle:
+            handle.write(",".join(fields) + "\n")
+            for record in records:
+                row = []
+                for field in fields:
+                    value = record.get(field)
+                    if isinstance(value, list):
+                        value = "|".join(str(item) for item in value)
+                    elif isinstance(value, dict):
+                        value = json.dumps(value)
+                    elif value is None:
+                        value = ""
+                    text = str(value)
+                    if "," in text or "\n" in text or '"' in text:
+                        text = '"' + text.replace('"', '""') + '"'
+                    row.append(text)
+                handle.write(",".join(row) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/hallucination-audit/create_langfuse_dataset_sample.py
+++ b/analysis/hallucination-audit/create_langfuse_dataset_sample.py
@@ -1,0 +1,213 @@
+import argparse
+import json
+import os
+import random
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+
+ENV_PATH = Path(__file__).resolve().parents[2] / ".env"
+DEFAULT_BASE_URL = "https://cloud.langfuse.com"
+DEFAULT_COUNT_WEIGHTS = {
+    "hallucinated": 0.4,
+    "unknown": 0.4,
+    "legit": 0.2,
+}
+
+
+def load_env(path: Path) -> None:
+    if not path.exists():
+        return
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, value = stripped.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
+def load_records(meeting_dir: Path) -> List[Dict[str, Any]]:
+    candidates = [
+        meeting_dir / "transcriptions_classified_with_audio_and_full.json",
+        meeting_dir / "transcriptions_classified_with_audio.json",
+        meeting_dir / "transcriptions_classified.json",
+    ]
+    for path in candidates:
+        if path.exists():
+            return json.loads(path.read_text(encoding="utf-8"))
+    raise SystemExit("No classified transcripts file found")
+
+
+def load_observation_map(meeting_dir: Path) -> Dict[str, Optional[str]]:
+    raw_path = meeting_dir / "transcriptions_raw.json"
+    if not raw_path.exists():
+        return {}
+    raw_traces = json.loads(raw_path.read_text(encoding="utf-8"))
+    mapping = {}
+    for trace in raw_traces:
+        trace_id = trace.get("id")
+        observations = trace.get("observations") or []
+        observation_id = observations[0] if observations else None
+        if trace_id:
+            mapping[trace_id] = observation_id
+    return mapping
+
+
+def compute_default_counts(total: int) -> Dict[str, int]:
+    raw_counts = {key: total * weight for key, weight in DEFAULT_COUNT_WEIGHTS.items()}
+    counts = {key: int(value) for key, value in raw_counts.items()}
+    remainder = total - sum(counts.values())
+    order = sorted(
+        raw_counts.keys(),
+        key=lambda key: raw_counts[key] - counts[key],
+        reverse=True,
+    )
+    for index in range(remainder):
+        counts[order[index % len(order)]] += 1
+    return counts
+
+
+def parse_counts(raw: str, total: int) -> Dict[str, int]:
+    if not raw:
+        return compute_default_counts(total)
+    parts = raw.split(",")
+    counts: Dict[str, int] = {key: 0 for key in DEFAULT_COUNT_WEIGHTS.keys()}
+    for part in parts:
+        if "=" not in part:
+            continue
+        key, value = part.split("=", 1)
+        key = key.strip()
+        if key not in counts:
+            raise SystemExit(f"Unknown class in --counts: {key}")
+        counts[key] = int(value)
+    if sum(counts.values()) != total:
+        raise SystemExit("Counts must sum to sample size")
+    return counts
+
+
+def ensure_dataset(base_url: str, auth: Tuple[str, str], name: str) -> None:
+    response = requests.post(
+        f"{base_url.rstrip('/')}/api/public/v2/datasets",
+        auth=auth,
+        json={"name": name},
+        timeout=30,
+    )
+    if response.status_code in (200, 201):
+        return
+    if response.status_code in (400, 409):
+        return
+    response.raise_for_status()
+
+
+def create_dataset_item(
+    base_url: str,
+    auth: Tuple[str, str],
+    payload: Dict[str, Any],
+    retries: int = 5,
+) -> None:
+    delay = 0.5
+    for attempt in range(retries):
+        response = requests.post(
+            f"{base_url.rstrip('/')}/api/public/dataset-items",
+            auth=auth,
+            json=payload,
+            timeout=30,
+        )
+        if response.status_code == 429:
+            retry_after = response.headers.get("Retry-After")
+            wait_seconds = float(retry_after) if retry_after else delay
+            time.sleep(wait_seconds)
+            delay = min(delay * 2, 10)
+            continue
+        if response.status_code in (200, 201):
+            return
+        if response.status_code in (400, 409):
+            return
+        response.raise_for_status()
+    raise RuntimeError("rate_limited dataset-items")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Create a Langfuse dataset sample for manual labeling.",
+    )
+    parser.add_argument("--meeting-id", required=True)
+    parser.add_argument("--dataset-name", required=True)
+    parser.add_argument("--sample-size", type=int, default=100)
+    parser.add_argument("--counts", default="")
+    parser.add_argument("--seed", type=int, default=26)
+    parser.add_argument("--base-url", default="")
+    args = parser.parse_args()
+
+    load_env(ENV_PATH)
+    public_key = os.getenv("LANGFUSE_PUBLIC_KEY", "").strip()
+    secret_key = os.getenv("LANGFUSE_SECRET_KEY", "").strip()
+    base_url = (
+        args.base_url or os.getenv("LANGFUSE_BASE_URL", "").strip() or DEFAULT_BASE_URL
+    )
+    if not public_key or not secret_key:
+        raise SystemExit("Missing LANGFUSE_PUBLIC_KEY or LANGFUSE_SECRET_KEY in env.")
+
+    meeting_dir = Path("analysis/hallucination-audit") / args.meeting_id
+    records = load_records(meeting_dir)
+    observation_map = load_observation_map(meeting_dir)
+
+    buckets = {"hallucinated": [], "unknown": [], "legit": []}
+    for record in records:
+        bucket = record.get("classification")
+        if bucket in buckets:
+            buckets[bucket].append(record)
+
+    random.seed(args.seed)
+    counts = parse_counts(args.counts, args.sample_size)
+    sample: List[Dict[str, Any]] = []
+    for bucket, count in counts.items():
+        available = buckets.get(bucket, [])
+        if len(available) < count:
+            raise SystemExit(f"Not enough records in {bucket}")
+        sample.extend(random.sample(available, count))
+
+    auth = (public_key, secret_key)
+    ensure_dataset(base_url, auth, args.dataset_name)
+
+    for record in sample:
+        trace_id = record.get("trace_id")
+        if not trace_id:
+            continue
+        dataset_item_id = f"{args.meeting_id}-{trace_id}"
+        payload = {
+            "datasetName": args.dataset_name,
+            "input": {
+                "text": record.get("output_text"),
+                "traceId": trace_id,
+                "traceUrlPath": record.get("trace_url_path"),
+                "audioMediaId": record.get("audio_media_id"),
+                "snippetTimestamp": record.get("snippet_timestamp"),
+            },
+            "metadata": {
+                "classification": record.get("classification"),
+                "classificationReasons": record.get("classification_reasons"),
+                "transcriptionFlags": record.get("transcription_flags"),
+                "logprobAvg": record.get("logprob_avg"),
+                "logprobMin": record.get("logprob_min"),
+                "noiseGateMetrics": record.get("noise_gate_metrics"),
+                "audioMeanVolumeDb": record.get("audio_mean_volume_db"),
+                "audioMaxVolumeDb": record.get("audio_max_volume_db"),
+            },
+            "sourceTraceId": trace_id,
+            "sourceObservationId": observation_map.get(trace_id),
+            "id": dataset_item_id,
+            "status": "ACTIVE",
+        }
+        create_dataset_item(base_url, auth, payload)
+        time.sleep(0.2)
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/hallucination-audit/download_full_audio.py
+++ b/analysis/hallucination-audit/download_full_audio.py
@@ -1,0 +1,101 @@
+import argparse
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+import boto3
+
+
+ENV_PATH = Path(__file__).resolve().parents[2] / ".env"
+
+
+def load_env(path: Path) -> None:
+    if not path.exists():
+        return
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, value = stripped.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
+def get_audio_key(meeting_dir: Path) -> str:
+    match_path = meeting_dir / "meeting_history_match.json"
+    if not match_path.exists():
+        raise SystemExit(f"Missing {match_path}")
+    payload = json.loads(match_path.read_text(encoding="utf-8"))
+    if not payload:
+        raise SystemExit("meeting_history_match.json is empty")
+    audio_key = payload[0].get("audioS3Key")
+    if not audio_key:
+        raise SystemExit("audioS3Key missing in meeting_history_match.json")
+    return audio_key
+
+
+def get_duration_seconds(file_path: Path) -> Optional[float]:
+    result = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=nw=1:nk=1",
+            str(file_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    value = result.stdout.strip()
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Download full meeting audio from S3.",
+    )
+    parser.add_argument("--meeting-id", required=True)
+    parser.add_argument("--bucket", default="")
+    args = parser.parse_args()
+
+    load_env(ENV_PATH)
+    bucket = args.bucket or os.getenv("TRANSCRIPTS_BUCKET")
+    if not bucket:
+        raise SystemExit("Missing TRANSCRIPTS_BUCKET in env or --bucket")
+
+    meeting_dir = Path("analysis/hallucination-audit") / args.meeting_id
+    meeting_dir.mkdir(parents=True, exist_ok=True)
+    audio_key = get_audio_key(meeting_dir)
+
+    target = meeting_dir / "audio_combined.mp3"
+    if not target.exists():
+        client = boto3.client("s3", region_name=os.getenv("AWS_REGION", "us-east-1"))
+        client.download_file(bucket, audio_key, str(target))
+
+    duration = get_duration_seconds(target)
+    metadata = {
+        "bucket": bucket,
+        "audioS3Key": audio_key,
+        "local_path": str(target),
+        "file_size_bytes": target.stat().st_size,
+        "duration_seconds": duration,
+    }
+    (meeting_dir / "full_audio_metadata.json").write_text(
+        json.dumps(metadata, indent=2),
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/hallucination-audit/run_audit.py
+++ b/analysis/hallucination-audit/run_audit.py
@@ -1,0 +1,493 @@
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+
+ENV_PATH = Path(__file__).resolve().parents[2] / ".env"
+DEFAULT_WINDOW = "19:00-20:00"
+DEFAULT_TZ_OFFSET = "-05:00"
+DEFAULT_NAME = "transcription"
+DEFAULT_FIELDS = "core,io"
+DEFAULT_LIMIT = 100
+DEFAULT_BASE_URL = "https://cloud.langfuse.com"
+
+
+def load_env(path: Path) -> None:
+    if not path.exists():
+        return
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, value = stripped.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
+def get_ny_dates() -> Tuple[str, str]:
+    try:
+        from zoneinfo import ZoneInfo
+
+        tz = ZoneInfo("America/New_York")
+        now_ny = dt.datetime.now(tz)
+        today = now_ny.date()
+        yesterday = today - dt.timedelta(days=1)
+        return today.isoformat(), yesterday.isoformat()
+    except Exception:
+        today = dt.date.today().isoformat()
+        yesterday = (dt.date.today() - dt.timedelta(days=1)).isoformat()
+        return today, yesterday
+
+
+def window_to_range(date_str: str, window: str, tz_offset: str) -> Tuple[str, str]:
+    if "-" not in window:
+        raise ValueError("window must be in HH:MM-HH:MM format")
+    start_time, end_time = window.split("-", 1)
+    start_time = start_time.strip()
+    end_time = end_time.strip()
+    if len(start_time) == 5:
+        start_time = f"{start_time}:00"
+    if len(end_time) == 5:
+        end_time = f"{end_time}:00"
+    start_ts = f"{date_str}T{start_time}{tz_offset}"
+    end_ts = f"{date_str}T{end_time}{tz_offset}"
+    return start_ts, end_ts
+
+
+def parse_audio_media_id(audio_input: Any) -> Optional[str]:
+    if not isinstance(audio_input, str):
+        return None
+    match = re.search(r"id=([^|]+)", audio_input)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def normalize_text(value: str) -> str:
+    lowered = value.lower()
+    stripped = re.sub(r"[^a-z0-9\s]", " ", lowered)
+    collapsed = re.sub(r"\s+", " ", stripped).strip()
+    return collapsed
+
+
+def levenshtein_distance(a: str, b: str) -> int:
+    if a == b:
+        return 0
+    if not a:
+        return len(b)
+    if not b:
+        return len(a)
+    if len(a) < len(b):
+        a, b = b, a
+    previous = list(range(len(b) + 1))
+    for i, ca in enumerate(a, start=1):
+        current = [i]
+        for j, cb in enumerate(b, start=1):
+            insert_cost = current[j - 1] + 1
+            delete_cost = previous[j] + 1
+            replace_cost = previous[j - 1] + (0 if ca == cb else 1)
+            current.append(min(insert_cost, delete_cost, replace_cost))
+        previous = current
+    return previous[-1]
+
+
+def build_duplicate_groups(records: List[Dict[str, Any]]) -> Dict[str, int]:
+    groups: Dict[str, int] = {}
+    group_id = 1
+    occurrences: Dict[str, List[int]] = defaultdict(list)
+    for index, record in enumerate(records):
+        text = record.get("normalized_text")
+        if not text:
+            continue
+        occurrences[text].append(index)
+    for indices in occurrences.values():
+        if len(indices) < 2:
+            continue
+        for idx in indices:
+            groups[records[idx]["trace_id"]] = group_id
+        group_id += 1
+    return groups
+
+
+def build_near_duplicate_groups(records: List[Dict[str, Any]]) -> Dict[str, int]:
+    candidates: List[Tuple[str, str]] = []
+    for record in records:
+        norm = record.get("normalized_text")
+        if not norm or len(norm) < 12:
+            continue
+        candidates.append((record["trace_id"], norm))
+    if not candidates:
+        return {}
+
+    buckets: Dict[Tuple[int, str], List[Tuple[str, str]]] = defaultdict(list)
+    for trace_id, norm in candidates:
+        length_bucket = len(norm) // 20
+        prefix = norm[:5]
+        buckets[(length_bucket, prefix)].append((trace_id, norm))
+
+    parent: Dict[str, str] = {}
+
+    def find(x: str) -> str:
+        root = parent.get(x, x)
+        if root != x:
+            parent[x] = find(root)
+        return parent.get(x, x)
+
+    def union(a: str, b: str) -> None:
+        ra = find(a)
+        rb = find(b)
+        if ra != rb:
+            parent[rb] = ra
+
+    for items in buckets.values():
+        if len(items) < 2:
+            continue
+        if len(items) > 200:
+            continue
+        for i in range(len(items)):
+            trace_a, text_a = items[i]
+            for j in range(i + 1, len(items)):
+                trace_b, text_b = items[j]
+                if abs(len(text_a) - len(text_b)) > 20:
+                    continue
+                dist = levenshtein_distance(text_a, text_b)
+                ratio = dist / max(len(text_a), len(text_b))
+                if ratio <= 0.2:
+                    union(trace_a, trace_b)
+
+    groups: Dict[str, int] = {}
+    group_id = 1
+    clusters: Dict[str, List[str]] = defaultdict(list)
+    for trace_id, _ in candidates:
+        root = find(trace_id)
+        clusters[root].append(trace_id)
+    for trace_ids in clusters.values():
+        if len(trace_ids) < 2:
+            continue
+        for trace_id in trace_ids:
+            groups[trace_id] = group_id
+        group_id += 1
+    return groups
+
+
+def classify_record(record: Dict[str, Any]) -> Tuple[str, List[str]]:
+    hallucination_reasons: List[str] = []
+    suspicious_reasons: List[str] = []
+    text = record.get("output_text", "")
+    text_trimmed = text.strip()
+    flags = set(record.get("transcription_flags") or [])
+    prompt_echo_detected = bool(record.get("prompt_echo_detected"))
+    suppressed = bool(record.get("suppressed"))
+    quiet_audio = bool(record.get("quiet_audio"))
+    hard_silence = bool(record.get("hard_silence_detected"))
+    rate_mismatch = bool(record.get("rate_mismatch_detected"))
+    avg_logprob = record.get("logprob_avg")
+    min_logprob = record.get("logprob_min")
+
+    contains_timestamp = bool(re.search(r"\b\d{1,2}:\d{2}(?::\d{2})?\b", text))
+    contains_date = bool(re.search(r"\b\d{4}-\d{2}-\d{2}\b", text))
+    contains_bracket_time = bool(re.search(r"\[\s*\d{1,2}:\d{2}(?::\d{2})?\s*\]", text))
+    contains_vket = bool(re.search(r"\bv\s*cat\b|\bvket\b", text, re.IGNORECASE))
+    contains_prompt_tokens = bool(
+        re.search(
+            r"(attendees:|server name:|channel:|dictionary terms|transcript instruction|<glossary>|bot names)",
+            text,
+            re.IGNORECASE,
+        )
+    )
+    contains_bot_names = bool(
+        re.search(
+            r"(chronote|meeting notes bot|meetingnotesbot|keeper of voices)",
+            text,
+            re.IGNORECASE,
+        )
+    )
+
+    if not text_trimmed:
+        if (
+            prompt_echo_detected
+            or "prompt_echo_substring" in flags
+            or "suppressed_prompt_echo" in flags
+        ):
+            hallucination_reasons.append("prompt_echo_detected")
+            return "hallucinated", hallucination_reasons
+        suspicious_reasons.append("no_output")
+        return "unknown", suspicious_reasons
+
+    if contains_prompt_tokens:
+        suspicious_reasons.append("contains_prompt_tokens")
+    if rate_mismatch and text_trimmed:
+        hallucination_reasons.append("rate_mismatch_nonempty")
+    if contains_vket:
+        hallucination_reasons.append("contains_vket")
+    if (
+        prompt_echo_detected
+        or "prompt_echo_substring" in flags
+        or "suppressed_prompt_echo" in flags
+    ):
+        hallucination_reasons.append("prompt_echo_detected")
+
+    if contains_timestamp:
+        suspicious_reasons.append("contains_timestamp")
+    if contains_date:
+        suspicious_reasons.append("contains_date")
+    if contains_bracket_time:
+        suspicious_reasons.append("contains_bracket_timestamp")
+    if contains_bot_names:
+        suspicious_reasons.append("contains_bot_name")
+    if suppressed:
+        suspicious_reasons.append("suppressed")
+    if quiet_audio:
+        suspicious_reasons.append("quiet_audio")
+    if hard_silence:
+        suspicious_reasons.append("hard_silence")
+    if rate_mismatch:
+        suspicious_reasons.append("rate_mismatch")
+
+    if hallucination_reasons:
+        return "hallucinated", hallucination_reasons
+
+    is_clean = (
+        not suppressed
+        and not flags
+        and not prompt_echo_detected
+        and not quiet_audio
+        and not hard_silence
+        and not rate_mismatch
+        and isinstance(avg_logprob, (int, float))
+        and isinstance(min_logprob, (int, float))
+        and avg_logprob > -1.2
+        and min_logprob > -2.5
+    )
+    if is_clean:
+        return "legit", ["clean_metrics"]
+
+    if suspicious_reasons:
+        return "unknown", suspicious_reasons
+
+    return "unknown", ["mixed_signals"]
+
+
+def list_traces(
+    base_url: str,
+    public_key: str,
+    secret_key: str,
+    params: Dict[str, Any],
+    limit: int,
+) -> List[Dict[str, Any]]:
+    results: List[Dict[str, Any]] = []
+    page = 1
+    while True:
+        query = dict(params)
+        query["page"] = page
+        query["limit"] = limit
+        response = requests.get(
+            f"{base_url.rstrip('/')}/api/public/traces",
+            params=query,
+            auth=(public_key, secret_key),
+            timeout=60,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        data = payload.get("data") if isinstance(payload, dict) else payload
+        if not data:
+            break
+        results.extend(data)
+        if len(data) < limit:
+            break
+        page += 1
+        time.sleep(0.2)
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Audit Langfuse transcription traces for hallucinations.",
+    )
+    parser.add_argument("--date", help="Date in YYYY-MM-DD (EST).")
+    parser.add_argument("--window", default=DEFAULT_WINDOW)
+    parser.add_argument("--tz-offset", default=DEFAULT_TZ_OFFSET)
+    parser.add_argument("--name", default=DEFAULT_NAME)
+    parser.add_argument("--meeting-id", default="")
+    parser.add_argument("--base-url", default="")
+    parser.add_argument("--out-dir", default="analysis/hallucination-audit")
+    parser.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
+    args = parser.parse_args()
+
+    load_env(ENV_PATH)
+    public_key = os.getenv("LANGFUSE_PUBLIC_KEY", "").strip()
+    secret_key = os.getenv("LANGFUSE_SECRET_KEY", "").strip()
+    base_url = (
+        args.base_url or os.getenv("LANGFUSE_BASE_URL", "").strip() or DEFAULT_BASE_URL
+    )
+    if not public_key or not secret_key:
+        raise SystemExit("Missing LANGFUSE_PUBLIC_KEY or LANGFUSE_SECRET_KEY in env.")
+
+    if args.date:
+        dates = [args.date]
+    else:
+        today, yesterday = get_ny_dates()
+        dates = [today, yesterday]
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    window_results: Dict[str, List[Dict[str, Any]]] = {}
+    for date_str in dates:
+        from_ts, to_ts = window_to_range(date_str, args.window, args.tz_offset)
+        params = {
+            "name": args.name,
+            "fromTimestamp": from_ts,
+            "toTimestamp": to_ts,
+            "fields": DEFAULT_FIELDS,
+            "orderBy": "timestamp.asc",
+        }
+        traces = list_traces(base_url, public_key, secret_key, params, args.limit)
+        window_key = f"{date_str}_{args.window.replace(':', '')}"
+        window_results[window_key] = traces
+        raw_path = out_dir / f"raw_traces_{window_key}.json"
+        raw_path.write_text(json.dumps(traces, indent=2), encoding="utf-8")
+
+    chosen_window = max(window_results.keys(), key=lambda k: len(window_results[k]))
+    traces = window_results[chosen_window]
+    if not traces:
+        raise SystemExit("No traces found in the specified window(s).")
+
+    meeting_counts: Dict[str, int] = defaultdict(int)
+    for trace in traces:
+        meeting_id = (trace.get("metadata") or {}).get("meetingId")
+        if meeting_id:
+            meeting_counts[meeting_id] += 1
+    if not meeting_counts:
+        raise SystemExit("No meetingId found in trace metadata.")
+
+    meeting_id = args.meeting_id.strip()
+    if not meeting_id:
+        meeting_id = max(meeting_counts.items(), key=lambda item: item[1])[0]
+    filtered = [
+        t for t in traces if (t.get("metadata") or {}).get("meetingId") == meeting_id
+    ]
+
+    records: List[Dict[str, Any]] = []
+    for trace in filtered:
+        metadata = trace.get("metadata") or {}
+        input_data = trace.get("input") or {}
+        output = trace.get("output")
+        output_text = (
+            output
+            if isinstance(output, str)
+            else json.dumps(output)
+            if output is not None
+            else ""
+        )
+        audio_id = parse_audio_media_id(input_data.get("audio"))
+        record = {
+            "trace_id": trace.get("id"),
+            "trace_timestamp": trace.get("timestamp"),
+            "meeting_id": metadata.get("meetingId"),
+            "guild_id": metadata.get("guildId"),
+            "channel_id": metadata.get("channelId"),
+            "snippet_user_id": metadata.get("snippetUserId"),
+            "snippet_timestamp": metadata.get("snippetTimestamp"),
+            "audio_seconds": metadata.get("audioSeconds"),
+            "audio_bytes": metadata.get("audioBytes"),
+            "audio_attachment_bytes": metadata.get("audioAttachmentBytes"),
+            "audio_media_id": audio_id,
+            "output_text": output_text,
+            "normalized_text": normalize_text(output_text) if output_text else "",
+            "transcription_flags": metadata.get("transcriptionFlags") or [],
+            "suppressed": metadata.get("suppressed"),
+            "quiet_audio": metadata.get("quietAudio"),
+            "quiet_by_peak": metadata.get("quietByPeak"),
+            "quiet_by_activity": metadata.get("quietByActivity"),
+            "hard_silence_detected": metadata.get("hardSilenceDetected"),
+            "rate_mismatch_detected": metadata.get("rateMismatchDetected"),
+            "prompt_echo_detected": metadata.get("promptEchoDetected"),
+            "prompt_echo_metrics": metadata.get("promptEchoMetrics"),
+            "logprob_avg": (metadata.get("logprobMetrics") or {}).get("avgLogprob"),
+            "logprob_min": (metadata.get("logprobMetrics") or {}).get("minLogprob"),
+            "logprob_tokens": (metadata.get("logprobMetrics") or {}).get("tokenCount"),
+            "transcript_char_count": metadata.get("transcriptCharCount"),
+            "transcript_word_count": metadata.get("transcriptWordCount"),
+            "transcript_syllable_count": metadata.get("transcriptSyllableCount"),
+            "words_per_second": metadata.get("wordsPerSecond"),
+            "syllables_per_second": metadata.get("syllablesPerSecond"),
+            "noise_gate_metrics": metadata.get("noiseGateMetrics"),
+            "trace_url_path": trace.get("htmlPath"),
+        }
+        classification, reasons = classify_record(record)
+        record["classification"] = classification
+        record["classification_reasons"] = reasons
+        records.append(record)
+
+    duplicate_groups = build_duplicate_groups(records)
+    near_duplicate_groups = build_near_duplicate_groups(records)
+    for record in records:
+        record["duplicate_group_id"] = duplicate_groups.get(record["trace_id"])
+        record["near_duplicate_group_id"] = near_duplicate_groups.get(
+            record["trace_id"]
+        )
+
+    meeting_dir = out_dir / meeting_id
+    meeting_dir.mkdir(parents=True, exist_ok=True)
+    raw_filtered_path = meeting_dir / "transcriptions_raw.json"
+    raw_filtered_path.write_text(json.dumps(filtered, indent=2), encoding="utf-8")
+    classified_path = meeting_dir / "transcriptions_classified.json"
+    classified_path.write_text(json.dumps(records, indent=2), encoding="utf-8")
+
+    counts = defaultdict(int)
+    for record in records:
+        counts[record["classification"]] += 1
+
+    summary_lines = [
+        f"Meeting ID: {meeting_id}",
+        f"Trace window: {chosen_window}",
+        f"Base URL: {base_url}",
+        "",
+        "Counts:",
+        f"- Total traces: {len(records)}",
+        f"- Hallucinated: {counts['hallucinated']}",
+        f"- Legit: {counts['legit']}",
+        f"- Unknown: {counts['unknown']}",
+        "",
+        "Top duplicate groups (exact):",
+    ]
+
+    group_counts: Dict[int, int] = defaultdict(int)
+    for record in records:
+        group_id = record.get("duplicate_group_id")
+        if group_id:
+            group_counts[group_id] += 1
+    for group_id, count in sorted(
+        group_counts.items(), key=lambda item: item[1], reverse=True
+    )[:10]:
+        summary_lines.append(f"- Group {group_id}: {count} entries")
+
+    summary_lines.append("")
+    summary_lines.append("Top near-duplicate groups:")
+    near_group_counts: Dict[int, int] = defaultdict(int)
+    for record in records:
+        group_id = record.get("near_duplicate_group_id")
+        if group_id:
+            near_group_counts[group_id] += 1
+    for group_id, count in sorted(
+        near_group_counts.items(), key=lambda item: item[1], reverse=True
+    )[:10]:
+        summary_lines.append(f"- Group {group_id}: {count} entries")
+
+    summary_path = meeting_dir / "summary.md"
+    summary_path.write_text("\n".join(summary_lines), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/hallucination-audit/transcribe_full_audio.py
+++ b/analysis/hallucination-audit/transcribe_full_audio.py
@@ -1,0 +1,133 @@
+import argparse
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import requests
+
+
+ENV_PATH = Path(__file__).resolve().parents[2] / ".env"
+OPENAI_TRANSCRIBE_URL = "https://api.openai.com/v1/audio/transcriptions"
+
+
+def load_env(path: Path) -> None:
+    if not path.exists():
+        return
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, value = stripped.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
+def segment_audio(input_path: Path, segment_dir: Path, seconds: int) -> List[Path]:
+    segment_dir.mkdir(parents=True, exist_ok=True)
+    if list(segment_dir.glob("segment_*.mp3")):
+        return sorted(segment_dir.glob("segment_*.mp3"))
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-hide_banner",
+            "-nostats",
+            "-i",
+            str(input_path),
+            "-vn",
+            "-ac",
+            "1",
+            "-ar",
+            "16000",
+            "-b:a",
+            "64k",
+            "-f",
+            "segment",
+            "-segment_time",
+            str(seconds),
+            "-reset_timestamps",
+            "1",
+            str(segment_dir / "segment_%03d.mp3"),
+        ],
+        check=True,
+    )
+    return sorted(segment_dir.glob("segment_*.mp3"))
+
+
+def transcribe_segment(
+    api_key: str, file_path: Path, model: str
+) -> Dict[str, Optional[str]]:
+    with file_path.open("rb") as handle:
+        response = requests.post(
+            OPENAI_TRANSCRIBE_URL,
+            headers={"Authorization": f"Bearer {api_key}"},
+            files={"file": handle},
+            data={
+                "model": model,
+                "response_format": "json",
+                "temperature": "0",
+            },
+            timeout=600,
+        )
+    if response.status_code >= 400:
+        return {"error": response.text}
+    payload = response.json()
+    return {"text": payload.get("text")}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Transcribe full meeting audio using OpenAI.",
+    )
+    parser.add_argument("--meeting-id", required=True)
+    parser.add_argument("--audio", default="")
+    parser.add_argument("--chunk-seconds", type=int, default=600)
+    parser.add_argument("--model", default="gpt-4o-transcribe")
+    parser.add_argument("--min-delay", type=float, default=1.0)
+    args = parser.parse_args()
+
+    load_env(ENV_PATH)
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise SystemExit("Missing OPENAI_API_KEY in env")
+
+    meeting_dir = Path("analysis/hallucination-audit") / args.meeting_id
+    meeting_dir.mkdir(parents=True, exist_ok=True)
+    audio_path = Path(args.audio) if args.audio else meeting_dir / "audio_combined.mp3"
+    if not audio_path.exists():
+        raise SystemExit(f"Missing audio file {audio_path}")
+
+    segment_dir = meeting_dir / "full_audio_segments"
+    segments = segment_audio(audio_path, segment_dir, args.chunk_seconds)
+
+    results = []
+    for index, segment in enumerate(segments):
+        start_seconds = index * args.chunk_seconds
+        end_seconds = (index + 1) * args.chunk_seconds
+        result = transcribe_segment(api_key, segment, args.model)
+        results.append(
+            {
+                "index": index,
+                "start_seconds": start_seconds,
+                "end_seconds": end_seconds,
+                "file": str(segment),
+                "text": result.get("text"),
+                "error": result.get("error"),
+            }
+        )
+        time.sleep(args.min_delay)
+
+    (meeting_dir / "full_transcript_segments.json").write_text(
+        json.dumps(results, indent=2),
+        encoding="utf-8",
+    )
+    combined = "\n".join(item["text"] or "" for item in results).strip()
+    (meeting_dir / "full_transcript.txt").write_text(combined, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/hallucination-audit-20260210.md
+++ b/docs/hallucination-audit-20260210.md
@@ -1,0 +1,63 @@
+# Hallucination audit 2026-02-10
+
+Meeting
+
+- ID: 3837e4e0-64e9-44ba-b5de-c3a6849832d6
+- Window: 2026-02-09 19:00-20:00 EST (UTC-05:00)
+- Traces: 2052
+- Full raw artifacts: archived in audit PR #116
+
+Classification counts
+
+- Hallucinated: 379
+- Legit: 495
+- Unknown: 1178
+
+Reason counts (top)
+
+- Hallucinated: prompt_echo_detected 300, contains_vket 79
+- Unknown: no_output 1031, mixed_signals 124, quiet_audio 17
+
+Syllables per second (SPS)
+
+- SPS is present for all traces in this meeting.
+- Guard logic today: audio <= 3s, wordCount >= 4, syllableCount >= 8, sps > 7.
+- Max legit SPS in short clips (audio <= 3s, non-empty output): 5.217.
+- Short clip SPS > 7 with non-empty output:
+  - Hallucinated: 0
+  - Legit: 0
+  - Unknown: 1
+- The only unknown short clip above 7 SPS was "Hey, everyone!" (0.48s, SPS 8.33). It does not meet min word or syllable counts so the guard does not fire.
+- Max legit SPS overall: 11.36 in a 9.86s clip with repeated "No". This does not hit the rate mismatch guard because audio > 3s.
+
+Audio mean dB (full coverage)
+
+- Computed mean dB for 1322 of 1322 unique snippet clips.
+- Hallucinated mean dB (n=367): -61.25, stdev 15.76, min -91.0, max -22.4
+- Legit mean dB (n=462): -30.35, stdev 8.41, min -67.3, max -13.3
+- Unknown mean dB (n=1145): -65.78, stdev 16.89, min -91.0, max -14.2
+
+Mean dB threshold sensitivity (all clips, using mean dB)
+
+- Threshold -45: hallucinated 308/367, legit 23/462, unknown 982/1145
+- Threshold -50: hallucinated 262/367, legit 15/462, unknown 921/1145
+- Threshold -55: hallucinated 229/367, legit 12/462, unknown 831/1145
+- Threshold -60: hallucinated 201/367, legit 4/462, unknown 752/1145
+
+Mean dB threshold sensitivity (non-empty output only)
+
+- Threshold -45: hallucinated 55/73, legit 23/462, unknown 60/135
+- Threshold -50: hallucinated 40/73, legit 15/462, unknown 49/135
+- Threshold -55: hallucinated 35/73, legit 12/462, unknown 41/135
+- Threshold -60: hallucinated 30/73, legit 4/462, unknown 33/135
+
+Notes
+
+- Mean dB is not the same as peak dB. Current noise gate peak default is -45 dBFS and hard silence is -60 dBFS.
+- This audit uses Langfuse trace metadata plus audio media; no production behavior changes are included here.
+
+Follow-ups
+
+- Vote transcription: run multiple transcriptions on the same snippet, for example prompt and no-prompt, and select the best with an arbiter.
+- Gate the vote path to keep cost low, for example only when prompt echo triggers, low logprob confidence, or large divergence between fast and slow transcripts.
+- Consider an arbiter that uses logprob stats and anti-repetition guidance, not just raw length.

--- a/docs/hallucination-mitigation-plan-20260213.md
+++ b/docs/hallucination-mitigation-plan-20260213.md
@@ -1,0 +1,60 @@
+# Hallucination mitigation plan 2026-02-13
+
+Scope
+
+- Source audit: meeting `3837e4e0-64e9-44ba-b5de-c3a6849832d6` (2052 traces).
+- Goal: carry forward durable mitigation learnings without shipping large raw artifacts.
+
+Evidence summary
+
+- Classified outputs: hallucinated 379, legit 495, unknown 1178.
+- Dominant hallucination mode is prompt echo (`300/379`).
+- Secondary hallucination mode is recurring content pattern (`contains_vket`, `79/379`).
+- Current short-clip syllable-rate gate appears safe for this sample.
+  - For clips <=3 seconds with non-empty output, max legit SPS was 5.217.
+  - No legit clips in that short-clip set exceeded the current threshold (7).
+- Audio loudness separates classes strongly in this sample, but this analysis used mean dB from offline ffmpeg and should not be copied directly into runtime thresholds.
+
+Config recommendations (immediate)
+
+- Keep `transcription.promptEcho.enabled=true` as the default and primary protection.
+- Keep current rate gate defaults for now.
+  - `transcription.suppression.rateMaxSeconds=3`
+  - `transcription.suppression.minWords=4`
+  - `transcription.suppression.minSyllables=8`
+  - `transcription.suppression.maxSyllablesPerSecond=7`
+- Keep `transcription.suppression.hardSilenceDbfs=-60` until a broader multi-meeting validation run confirms a safer change.
+
+Config improvements to add
+
+- Add prompt-echo tuning keys so thresholds can be tuned without code edits.
+  - `transcription.promptEcho.minChars` (default 12)
+  - `transcription.promptEcho.minWords` (default 2)
+  - `transcription.promptEcho.similarityThreshold` (default 0.2)
+- Add optional server-level override controls for the above keys in config registry.
+
+System improvements to add
+
+- Add a vote transcription path for suspicious snippets.
+  - Trigger only on guard failures/signals (prompt echo, low confidence, rate mismatch non-empty, high repetition).
+  - Run at least two variants (for example prompt and no-prompt), then choose with an arbiter.
+  - Arbiter should score anti-repetition, confidence/logprob, and plausibility, not just output length.
+- Add a repetition-pattern guard signal (for example repeated token ratio or repeated n-gram ratio) to catch non-prompt hallucinations.
+- Split metrics by reason and intent to avoid mixing behaviors.
+  - Keep manual user dismissals separate from low-content auto-cancellations.
+
+Evaluation loop
+
+- Use `analysis/hallucination-audit/create_langfuse_dataset_sample.py` to create balanced labeled samples from classified traces.
+- Run transcription evals with `src/evals/transcriptionEval.ts` using Langfuse datasets and experiment names.
+- Track at least:
+  - Prompt-like rate
+  - Top stability
+  - WER (where references exist)
+  - Suppression reason distribution over time
+
+Rollout strategy
+
+- Phase 1: ship prompt-echo tunable config keys and dashboards (no behavior change by default).
+- Phase 2: ship gated vote-transcription for suspicious snippets at low traffic percentage.
+- Phase 3: evaluate and then tune hard-silence/noise thresholds only if metrics improve across multiple meetings.


### PR DESCRIPTION
[AGENT] Extracts permanent, low-footprint learnings from the hallucination audit into reusable tooling and docs, without carrying large raw artifacts into mainline history.

## What this PR includes
- Adds reusable audit scripts under `analysis/hallucination-audit/`.
- Adds the audit findings summary doc `docs/hallucination-audit-20260210.md`.
- Adds a concrete mitigation plan doc `docs/hallucination-mitigation-plan-20260213.md`.
- Updates `.gitignore` for Python cache and husky internal files.

## Script hardening included
- `align_with_full_transcript.py`
  - returns word-window for exact substring matches
  - uses `csv.DictWriter` with full field union for robust CSV output
  - adds lightweight pruning before expensive similarity checks
- `create_langfuse_dataset_sample.py`
  - default class counts now respect `--sample-size`
  - validates unknown class keys in `--counts`

## Intentionally excluded
- No large meeting artifacts, raw trace dumps, or audio blobs.
- No production runtime behavior changes in bot paths.

## Context
- This branch is the durable successor for learnings from the archive PR #116.