### PR TITLE
Stop recording join/leave events once meeting end begins

### DIFF
--- a/apps/docs-site/docs/whats-new/join-leave-cleanup-after-meeting-end.md
+++ b/apps/docs-site/docs/whats-new/join-leave-cleanup-after-meeting-end.md
@@ -1,0 +1,12 @@
+---
+title: Join and leave timeline cleanup after meeting end
+slug: /whats-new/join-leave-cleanup-after-meeting-end
+---
+
+Chronote now stops recording join and leave timeline events once a meeting has moved into processing or finished state.
+
+## What changed
+
+- Join and leave events are captured only while a meeting is actively in progress.
+- Once meeting end processing begins, late channel activity is no longer appended to the meeting timeline.
+- Meeting timelines now stay aligned with the actual meeting window.

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -828,7 +828,11 @@ async function handleUserLeave(oldState: VoiceState) {
 
     unsubscribeToVoiceUponLeaving(meeting, oldState.member!.user.id);
 
-    if (meeting.voiceChannel.members.size <= 1 && !meeting.finishing) {
+    if (
+      meeting.voiceChannel.members.size <= 1 &&
+      !meeting.finishing &&
+      !meeting.finished
+    ) {
       if (!meeting.endReason) {
         meeting.endReason = MEETING_END_REASONS.CHANNEL_EMPTY;
       }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -828,11 +828,7 @@ async function handleUserLeave(oldState: VoiceState) {
 
     unsubscribeToVoiceUponLeaving(meeting, oldState.member!.user.id);
 
-    if (
-      meeting.voiceChannel.members.size <= 1 &&
-      !meeting.finishing &&
-      !meeting.finished
-    ) {
+    if (meeting.voiceChannel.members.size <= 1) {
       if (!meeting.endReason) {
         meeting.endReason = MEETING_END_REASONS.CHANNEL_EMPTY;
       }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -117,6 +117,7 @@ import {
   MEETING_START_REASONS,
   type AutoRecordRule,
 } from "./types/meetingLifecycle";
+import { isMeetingCollectingEvents } from "./utils/meetingLifecycle";
 import {
   DISMISS_AUTORECORD_COMMAND_NAME,
   dismissAutoRecordCommand,
@@ -620,7 +621,7 @@ async function handleBotVoiceUpdate(
   newState: VoiceState,
 ) {
   const meeting = getMeeting(oldState.guild.id);
-  if (!meeting || meeting.finishing || meeting.finished) return;
+  if (!isMeetingCollectingEvents(meeting)) return;
   const wasInMeetingChannel = oldState.channelId === meeting.voiceChannel.id;
   const stillInMeetingChannel = newState.channelId === meeting.voiceChannel.id;
   if (wasInMeetingChannel && !stillInMeetingChannel) {
@@ -659,7 +660,7 @@ async function handleUserJoin(newState: VoiceState) {
 
   // Handle existing meeting attendance
   if (
-    meeting &&
+    isMeetingCollectingEvents(meeting) &&
     newState.member &&
     newState.member.user.id !== client.user!.id &&
     meeting.voiceChannel.id === newState.channelId
@@ -806,7 +807,7 @@ async function handleUserJoin(newState: VoiceState) {
 async function handleUserLeave(oldState: VoiceState) {
   const meeting = getMeeting(oldState.guild.id);
   if (
-    meeting &&
+    isMeetingCollectingEvents(meeting) &&
     oldState.member &&
     oldState.member.user.id !== client.user!.id &&
     meeting.voiceChannel.id === oldState.channelId

--- a/src/utils/meetingLifecycle.ts
+++ b/src/utils/meetingLifecycle.ts
@@ -5,6 +5,7 @@ import {
   type MeetingEndReason,
   type MeetingStartReason,
 } from "../types/meetingLifecycle";
+import type { MeetingData } from "../types/meeting-data";
 
 export const MEETING_START_REASON_LABELS: Record<MeetingStartReason, string> = {
   [MEETING_START_REASONS.MANUAL_COMMAND]: "Started via /startmeeting",
@@ -40,4 +41,10 @@ export function describeAutoRecordRule(
   }
   const channelLabel = voiceChannelName ? ` (#${voiceChannelName})` : "";
   return `Auto-record rule: this channel${channelLabel}`;
+}
+
+export function isMeetingCollectingEvents(
+  meeting: MeetingData | undefined,
+): meeting is MeetingData {
+  return meeting !== undefined && !meeting.finishing && !meeting.finished;
 }

--- a/test/utils/meetingLifecycle.test.ts
+++ b/test/utils/meetingLifecycle.test.ts
@@ -31,4 +31,12 @@ describe("isMeetingCollectingEvents", () => {
       isMeetingCollectingEvents(buildMeetingState({ finished: true })),
     ).toBe(false);
   });
+
+  test("returns false when finishing and finished are both true", () => {
+    expect(
+      isMeetingCollectingEvents(
+        buildMeetingState({ finishing: true, finished: true }),
+      ),
+    ).toBe(false);
+  });
 });

--- a/test/utils/meetingLifecycle.test.ts
+++ b/test/utils/meetingLifecycle.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "@jest/globals";
+import type { MeetingData } from "../../src/types/meeting-data";
+import { isMeetingCollectingEvents } from "../../src/utils/meetingLifecycle";
+
+const buildMeetingState = (
+  overrides: Partial<Pick<MeetingData, "finishing" | "finished">> = {},
+): MeetingData =>
+  ({
+    finishing: false,
+    finished: false,
+    ...overrides,
+  }) as MeetingData;
+
+describe("isMeetingCollectingEvents", () => {
+  test("returns true while a meeting is in progress", () => {
+    expect(isMeetingCollectingEvents(buildMeetingState())).toBe(true);
+  });
+
+  test("returns false after end starts processing", () => {
+    expect(
+      isMeetingCollectingEvents(buildMeetingState({ finishing: true })),
+    ).toBe(false);
+  });
+
+  test("returns false once a meeting is finished", () => {
+    expect(
+      isMeetingCollectingEvents(buildMeetingState({ finished: true })),
+    ).toBe(false);
+  });
+});

--- a/test/utils/meetingLifecycle.test.ts
+++ b/test/utils/meetingLifecycle.test.ts
@@ -12,6 +12,10 @@ const buildMeetingState = (
   }) as MeetingData;
 
 describe("isMeetingCollectingEvents", () => {
+  test("returns false when meeting is undefined", () => {
+    expect(isMeetingCollectingEvents(undefined)).toBe(false);
+  });
+
   test("returns true while a meeting is in progress", () => {
     expect(isMeetingCollectingEvents(buildMeetingState())).toBe(true);
   });


### PR DESCRIPTION
[AGENT]
## Summary
- Stop join/leave presence capture as soon as a meeting enters processing (`finishing`) or finished state.
- Reuse a shared lifecycle helper in voice state handlers so join, leave, and bot disconnect paths follow the same active-meeting check.
- Add unit tests that cover the in-progress to processing transition and finished-state suppression behavior.

## Testing
- `yarn test --coverage=false test/utils/meetingLifecycle.test.ts`
- `yarn lint:check src/bot.ts src/utils/meetingLifecycle.ts test/utils/meetingLifecycle.test.ts`

## Issue
- Closes #149