### PR TITLE
[AGENT] Fix docs deploy environment wiring

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -481,6 +481,33 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ vars.AWS_REGION }}
 
+      - name: Preflight docs publish targets
+        env:
+          DOCS_BUCKET: ${{ vars.DOCS_BUCKET }}
+          DOCS_DISTRIBUTION_ID: ${{ vars.DOCS_DISTRIBUTION_ID }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$DOCS_BUCKET" ]; then
+            echo "ERROR: DOCS_BUCKET is not set in the GitHub Actions environment."
+            exit 1
+          fi
+
+          if [ -z "$DOCS_DISTRIBUTION_ID" ]; then
+            echo "ERROR: DOCS_DISTRIBUTION_ID is not set in the GitHub Actions environment."
+            exit 1
+          fi
+
+          if ! aws s3api head-bucket --bucket "$DOCS_BUCKET" >/dev/null 2>&1; then
+            echo "ERROR: DOCS_BUCKET '$DOCS_BUCKET' is not accessible with the configured AWS credentials."
+            exit 1
+          fi
+
+          if ! aws cloudfront get-distribution --id "$DOCS_DISTRIBUTION_ID" >/dev/null 2>&1; then
+            echo "ERROR: DOCS_DISTRIBUTION_ID '$DOCS_DISTRIBUTION_ID' is not accessible with the configured AWS credentials."
+            exit 1
+          fi
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -575,7 +602,7 @@ jobs:
             exit 1
           fi
 
-          aws s3 sync build/docs-site s3://$DOCS_BUCKET --delete --exclude "assets/*" --cache-control "public,max-age=600"
+          aws s3 sync build/docs-site s3://$DOCS_BUCKET --delete --cache-control "public,max-age=600"
 
           if [ -d build/docs-site/assets ]; then
             aws s3 sync build/docs-site/assets s3://$DOCS_BUCKET/assets --cache-control "public,max-age=31536000,immutable"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -548,6 +548,33 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ vars.AWS_REGION }}
 
+      - name: Preflight docs publish targets
+        env:
+          DOCS_BUCKET: ${{ vars.DOCS_BUCKET }}
+          DOCS_DISTRIBUTION_ID: ${{ vars.DOCS_DISTRIBUTION_ID }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$DOCS_BUCKET" ]; then
+            echo "ERROR: DOCS_BUCKET is not set in the GitHub Actions environment."
+            exit 1
+          fi
+
+          if [ -z "$DOCS_DISTRIBUTION_ID" ]; then
+            echo "ERROR: DOCS_DISTRIBUTION_ID is not set in the GitHub Actions environment."
+            exit 1
+          fi
+
+          if ! aws s3api head-bucket --bucket "$DOCS_BUCKET" >/dev/null 2>&1; then
+            echo "ERROR: DOCS_BUCKET '$DOCS_BUCKET' is not accessible with the configured AWS credentials."
+            exit 1
+          fi
+
+          if ! aws cloudfront get-distribution --id "$DOCS_DISTRIBUTION_ID" >/dev/null 2>&1; then
+            echo "ERROR: DOCS_DISTRIBUTION_ID '$DOCS_DISTRIBUTION_ID' is not accessible with the configured AWS credentials."
+            exit 1
+          fi
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -645,7 +672,7 @@ jobs:
             exit 1
           fi
 
-          aws s3 sync build/docs-site s3://$DOCS_BUCKET --delete --exclude "assets/*" --cache-control "public,max-age=600"
+          aws s3 sync build/docs-site s3://$DOCS_BUCKET --delete --cache-control "public,max-age=600"
 
           if [ -d build/docs-site/assets ]; then
             aws s3 sync build/docs-site/assets s3://$DOCS_BUCKET/assets --cache-control "public,max-age=31536000,immutable"

--- a/README.md
+++ b/README.md
@@ -227,10 +227,10 @@ Terraform uses a GitHub provider to manage the Actions environment and variables
 1. Generate a fine-grained token using the GitHub URL template (pre-fills the form):
 
    ```text
-   https://github.com/settings/personal-access-tokens/new?name=Chronote+Terraform&description=Terraform+GitHub+provider&target_name=BASIC-BIT&expires_in=90
+   https://github.com/settings/personal-access-tokens/new?name=Chronote+Terraform&description=Terraform+GitHub+provider&target_name=Chronote-gg&expires_in=90
    ```
 
-2. In the token UI, set **Repository access** to **Only select repositories** and choose `meeting-notes-discord-bot` (manual step), then grant these **Repository permissions**:
+2. In the token UI, set **Repository access** to **Only select repositories** and choose `Chronote` (manual step), then grant these **Repository permissions**:
    - **Actions**: Read (Terraform reads environments).
    - **Administration**: Read and write (Terraform creates/updates environments).
    - **Environments**: Read and write (Terraform manages environment variables).
@@ -238,7 +238,7 @@ Terraform uses a GitHub provider to manage the Actions environment and variables
 3. Set the new token in the active Terraform vars file:
    - `_infra/terraform.tfvars` for prod.
    - `_infra/terraform.staging.tfvars` if you use a separate staging var file.
-4. Re-run `yarn terraform:plan` and `yarn terraform:apply` (or `terraform -chdir=_infra plan` and `terraform -chdir=_infra apply`) to confirm the GitHub provider can read the repo and update Actions env variables.
+4. Re-run `yarn terraform:plan` and `yarn terraform:apply` (or `terraform -chdir=_infra plan` and `terraform -chdir=_infra apply`) to confirm the GitHub provider can read `Chronote-gg/Chronote` and update Actions env variables.
 
 ### Observability (hosted)
 

--- a/_infra/main.tf
+++ b/_infra/main.tf
@@ -402,7 +402,7 @@ provider "aws" {
 data "aws_caller_identity" "current" {}
 
 provider "github" {
-  owner = "BASIC-BIT"
+  owner = "Chronote-gg"
   token = var.GITHUB_TOKEN
 }
 
@@ -465,7 +465,7 @@ EOF
 }
 
 data "github_repository" "repo" {
-  full_name = "BASIC-BIT/meeting-notes-discord-bot"
+  full_name = "Chronote-gg/Chronote"
 }
 
 resource "github_repository_environment" "repo_env" {


### PR DESCRIPTION
## Summary
- point Terraform GitHub provider management at `Chronote-gg/Chronote` so Actions environment variables are written to the live repo
- add docs deploy preflight checks in the production and staging workflows so missing or inaccessible docs targets fail with a clear error before the S3 sync step
- remove the broad `assets/*` exclusion from docs deploy sync and update the PAT rotation instructions for the current org and repository

## Why this is still relevant
- current `master` still has `_infra/main.tf` targeting `BASIC-BIT/meeting-notes-discord-bot`
- current docs deploy workflows still fail late in the `Sync docs to S3` path and still use the older `--exclude assets/*` sync behavior
- the earlier PR branch was based on unrelated feature work, so this clean branch replaces it with only the current fix

## Validation
- `terraform fmt _infra/main.tf`
- `terraform -chdir=_infra init -backend=false`
- `terraform -chdir=_infra validate`
- `npx markdownlint-cli2 README.md`
- `npx prettier --check .github/workflows/deploy.yml .github/workflows/deploy-staging.yml README.md`