### PR TITLE
[AGENT] Codify Terraform MCP import fixes

### DIFF
--- a/_infra/api.tf
+++ b/_infra/api.tf
@@ -14,24 +14,19 @@ resource "aws_acm_certificate" "api_cert" {
 }
 
 resource "aws_route53_record" "api_cert_validation" {
-  for_each = length(aws_acm_certificate.api_cert) > 0 ? {
-    for dvo in aws_acm_certificate.api_cert[0].domain_validation_options :
-    dvo.domain_name => {
-      name  = dvo.resource_record_name
-      type  = dvo.resource_record_type
-      value = dvo.resource_record_value
-    }
+  for_each = var.API_DOMAIN != "" && var.HOSTED_ZONE_NAME != "" && var.API_CERT_ARN == "" ? {
+    (var.API_DOMAIN) = one(aws_acm_certificate.api_cert[0].domain_validation_options)
   } : {}
 
-  name    = each.value.name
-  type    = each.value.type
+  name    = each.value.resource_record_name
+  type    = each.value.resource_record_type
   zone_id = data.aws_route53_zone.api_hosted_zone[0].zone_id
-  records = [each.value.value]
+  records = [each.value.resource_record_value]
   ttl     = 300
 }
 
 resource "aws_acm_certificate_validation" "api_cert" {
-  count                   = length(aws_acm_certificate.api_cert)
+  count                   = var.API_DOMAIN != "" && var.HOSTED_ZONE_NAME != "" && var.API_CERT_ARN == "" ? 1 : 0
   certificate_arn         = aws_acm_certificate.api_cert[0].arn
   validation_record_fqdns = [for r in aws_route53_record.api_cert_validation : r.fqdn]
 }
@@ -70,11 +65,11 @@ resource "aws_security_group" "api_alb_sg" {
 resource "aws_lb" "api_alb" {
   #checkov:skip=CKV_AWS_91: Access logs not yet enabled for the API ALB.
   #checkov:skip=CKV2_AWS_28: WAF not enabled yet; revisit before public launch.
-  name               = "${local.name_prefix}-api"
-  internal           = false
-  load_balancer_type = "application"
-  security_groups    = [aws_security_group.api_alb_sg.id]
-  subnets            = [aws_subnet.app_public_subnet_1.id, aws_subnet.app_public_subnet_2.id]
+  name                       = "${local.name_prefix}-api"
+  internal                   = false
+  load_balancer_type         = "application"
+  security_groups            = [aws_security_group.api_alb_sg.id]
+  subnets                    = [aws_subnet.app_public_subnet_1.id, aws_subnet.app_public_subnet_2.id]
   drop_invalid_header_fields = true
   enable_deletion_protection = true
 }

--- a/_infra/certificate.tf
+++ b/_infra/certificate.tf
@@ -33,47 +33,37 @@ resource "aws_acm_certificate" "docs_cert" {
 }
 
 resource "aws_route53_record" "frontend_cert_validation" {
-  for_each = length(aws_acm_certificate.frontend_cert) > 0 ? {
-    for dvo in aws_acm_certificate.frontend_cert[0].domain_validation_options :
-    dvo.domain_name => {
-      name  = dvo.resource_record_name
-      type  = dvo.resource_record_type
-      value = dvo.resource_record_value
-    }
+  for_each = var.FRONTEND_DOMAIN != "" && var.HOSTED_ZONE_NAME != "" && var.FRONTEND_CERT_ARN == "" ? {
+    (var.FRONTEND_DOMAIN) = one(aws_acm_certificate.frontend_cert[0].domain_validation_options)
   } : {}
 
-  name    = each.value.name
-  type    = each.value.type
+  name    = each.value.resource_record_name
+  type    = each.value.resource_record_type
   zone_id = data.aws_route53_zone.frontend_hosted_zone[0].zone_id
-  records = [each.value.value]
+  records = [each.value.resource_record_value]
   ttl     = 300
 }
 
 resource "aws_route53_record" "docs_cert_validation" {
-  for_each = length(aws_acm_certificate.docs_cert) > 0 ? {
-    for dvo in aws_acm_certificate.docs_cert[0].domain_validation_options :
-    dvo.domain_name => {
-      name  = dvo.resource_record_name
-      type  = dvo.resource_record_type
-      value = dvo.resource_record_value
-    }
+  for_each = var.DOCS_DOMAIN != "" && var.HOSTED_ZONE_NAME != "" && var.DOCS_CERT_ARN == "" ? {
+    (var.DOCS_DOMAIN) = one(aws_acm_certificate.docs_cert[0].domain_validation_options)
   } : {}
 
-  name    = each.value.name
-  type    = each.value.type
+  name    = each.value.resource_record_name
+  type    = each.value.resource_record_type
   zone_id = data.aws_route53_zone.docs_hosted_zone[0].zone_id
-  records = [each.value.value]
+  records = [each.value.resource_record_value]
   ttl     = 300
 }
 
 resource "aws_acm_certificate_validation" "frontend_cert" {
-  count                   = length(aws_acm_certificate.frontend_cert)
+  count                   = var.FRONTEND_DOMAIN != "" && var.HOSTED_ZONE_NAME != "" && var.FRONTEND_CERT_ARN == "" ? 1 : 0
   certificate_arn         = aws_acm_certificate.frontend_cert[0].arn
   validation_record_fqdns = [for r in aws_route53_record.frontend_cert_validation : r.fqdn]
 }
 
 resource "aws_acm_certificate_validation" "docs_cert" {
-  count                   = length(aws_acm_certificate.docs_cert)
+  count                   = var.DOCS_DOMAIN != "" && var.HOSTED_ZONE_NAME != "" && var.DOCS_CERT_ARN == "" ? 1 : 0
   certificate_arn         = aws_acm_certificate.docs_cert[0].arn
   validation_record_fqdns = [for r in aws_route53_record.docs_cert_validation : r.fqdn]
 }

--- a/_infra/grafana.tf
+++ b/_infra/grafana.tf
@@ -51,7 +51,8 @@ locals {
   grafana_rotation_enabled = var.grafana_service_account_id != "" && var.grafana_url != "http://localhost"
 
   # Prefer the rotated secret; fall back to the manual tfvar for bootstrapping
-  grafana_token_from_secret = length(data.aws_secretsmanager_secret_version.grafana_token) > 0 ? try(
+  grafana_reads_rotated_token = local.grafana_rotation_enabled && var.grafana_api_key == ""
+  grafana_token_from_secret = local.grafana_reads_rotated_token ? try(
     jsondecode(data.aws_secretsmanager_secret_version.grafana_token[0].secret_string)["token"], ""
   ) : ""
   grafana_resolved_token = local.grafana_token_from_secret != "" ? local.grafana_token_from_secret : var.grafana_api_key

--- a/_infra/main.tf
+++ b/_infra/main.tf
@@ -225,6 +225,12 @@ variable "ENABLE_OAUTH" {
   default   = "false"
 }
 
+variable "ENABLE_MCP" {
+  description = "Enable the remote MCP endpoint when OAuth is also enabled"
+  type        = string
+  default     = "true"
+}
+
 variable "DISCORD_CALLBACK_URL" {
   sensitive = true
   default   = ""
@@ -1464,6 +1470,10 @@ resource "aws_ecs_task_definition" "app_task" {
         {
           name  = "ENABLE_OAUTH"
           value = var.ENABLE_OAUTH
+        },
+        {
+          name  = "ENABLE_MCP"
+          value = var.ENABLE_MCP
         },
         {
           name  = "OPENAI_ORGANIZATION_ID"

--- a/_infra/terraform.staging.tfvars.example
+++ b/_infra/terraform.staging.tfvars.example
@@ -9,6 +9,7 @@ github_environment="staging"
 
 # OAuth / URLs
 ENABLE_OAUTH="true"
+ENABLE_MCP="true"
 API_DOMAIN="api.staging.chronote.gg"
 DISCORD_CALLBACK_URL="https://api.staging.chronote.gg/auth/discord/callback"
 FRONTEND_DOMAIN="staging.chronote.gg"

--- a/_infra/terraform.tfvars.example
+++ b/_infra/terraform.tfvars.example
@@ -8,6 +8,7 @@ github_environment="sandbox"                 # GitHub Actions environment name
 
 # Optional (leave blank to use defaults)
 ENABLE_OAUTH="false"                          # defaults false
+ENABLE_MCP="true"                             # requires ENABLE_OAUTH=true at runtime
 DISCORD_CALLBACK_URL=""                       # required if ENABLE_OAUTH=true
 NODE_ENV="production"                         # recommended for ECS task
 ENABLE_ONBOARDING="false"


### PR DESCRIPTION
[AGENT]
## Summary
- Makes ACM DNS validation resource counts depend on static input variables so imports and plans do not depend on unknown certificate validation options.
- Lets Grafana provider bootstrap and import flows skip reading the rotated token when rotation is disabled by placeholder vars.
- Codifies ENABLE_MCP in the ECS task environment and example tfvars so future task definitions preserve remote MCP.

## Verification
- terraform validate
- terraform fmt -check api.tf certificate.tf grafana.tf main.tf
- terraform plan -target=aws_dynamodb_table.mcp_oauth_table -target=aws_iam_policy.dynamodb_access_policy -target=aws_ecs_task_definition.app_task -detailed-exitcode -no-color

## Notes
- MCP OAuth table meeting-notes-prod-McpOAuthTable was already imported into Terraform state as aws_dynamodb_table.mcp_oauth_table.
- Production was already hotfixed manually; this PR codifies the fix to prevent future Terraform drift.
- The targeted plan returned expected target-mode drift, including unrelated docs resources and a task definition replacement from container definition changes.