### PR TITLE
[AGENT] Allow Stop recording to end manual meetings

### DIFF
--- a/apps/docs-site/docs/features/feature-overview.md
+++ b/apps/docs-site/docs/features/feature-overview.md
@@ -174,4 +174,4 @@ Access the portal from the **Open in Chronote** button on any meeting summary, o
 
 Right-click a user in the voice channel to access:
 
-- **Stop recording**: Cancels the current auto-recorded meeting in this channel.
+- **Stop recording**: Ends the current meeting. For short auto-recorded meetings, this can cancel the recording instead of generating notes.

--- a/src/commands/dismissAutoRecord.ts
+++ b/src/commands/dismissAutoRecord.ts
@@ -10,6 +10,7 @@ import { getMeeting } from "../meetings";
 import { resolveConfigEnum } from "../services/unifiedConfigService";
 import { MEETING_END_REASONS } from "../types/meetingLifecycle";
 import type { MeetingData } from "../types/meeting-data";
+import { canUserEndMeeting } from "../utils/meetingPermissions";
 import { handleEndMeetingOther } from "./endMeeting";
 
 export const DISMISS_AUTORECORD_COMMAND_NAME = "Stop recording";
@@ -73,10 +74,17 @@ function resolveStopRecordingPermission(options: {
 type DismissAutoRecordContext = {
   meeting: MeetingData;
   invokerId: string;
-  policy: DismissPolicy;
-  admin: boolean;
-  soloNonBot: boolean;
-};
+} & (
+  | {
+      isAutoRecording: true;
+      policy: DismissPolicy;
+      admin: boolean;
+      soloNonBot: boolean;
+    }
+  | {
+      isAutoRecording: false;
+    }
+);
 
 type DismissAutoRecordCheckResult =
   | { ok: true; context: DismissAutoRecordContext }
@@ -104,18 +112,22 @@ async function resolveDismissAutoRecordContext(
     return { ok: false, message: "No active recording to stop right now." };
   }
 
-  if (!meeting.isAutoRecording) {
-    return {
-      ok: false,
-      message: "This command only applies to auto-recorded meetings.",
-    };
-  }
-
   if (meeting.finishing) {
     return { ok: false, message: "This meeting is already ending." };
   }
 
   const invokerId = interaction.user.id;
+  if (!meeting.isAutoRecording) {
+    return {
+      ok: true,
+      context: {
+        meeting,
+        invokerId,
+        isAutoRecording: false,
+      },
+    };
+  }
+
   const invokerMember = meeting.voiceChannel.members.get(invokerId);
   if (!invokerMember) {
     return {
@@ -144,6 +156,7 @@ async function resolveDismissAutoRecordContext(
     context: {
       meeting,
       invokerId,
+      isAutoRecording: true,
       policy,
       admin,
       soloNonBot,
@@ -167,20 +180,28 @@ export async function handleDismissAutoRecord(
     return;
   }
 
-  const { meeting, invokerId, policy, admin, soloNonBot } =
-    contextResult.context;
+  const { meeting, invokerId } = contextResult.context;
 
-  const permissionDecision = resolveStopRecordingPermission({
-    policy,
-    invokerId,
-    admin,
-    soloNonBot,
-    startTriggeredByUserId: meeting.startTriggeredByUserId,
-  });
+  if (contextResult.context.isAutoRecording) {
+    const { policy, admin, soloNonBot } = contextResult.context;
+    const permissionDecision = resolveStopRecordingPermission({
+      policy,
+      invokerId,
+      admin,
+      soloNonBot,
+      startTriggeredByUserId: meeting.startTriggeredByUserId,
+    });
 
-  if (!permissionDecision.allowed) {
+    if (!permissionDecision.allowed) {
+      await interaction.reply({
+        content: `You do not have permission to stop this auto-record. ${permissionDecision.hint}`,
+        ephemeral: true,
+      });
+      return;
+    }
+  } else if (!canUserEndMeeting(meeting, invokerId)) {
     await interaction.reply({
-      content: `You do not have permission to stop this auto-record. ${permissionDecision.hint}`,
+      content: "You do not have permission to end this meeting.",
       ephemeral: true,
     });
     return;
@@ -188,11 +209,20 @@ export async function handleDismissAutoRecord(
 
   await interaction.deferReply({ ephemeral: true });
 
-  meeting.endReason = MEETING_END_REASONS.DISMISSED;
+  meeting.endReason = contextResult.context.isAutoRecording
+    ? MEETING_END_REASONS.DISMISSED
+    : MEETING_END_REASONS.BUTTON;
   meeting.endTriggeredByUserId = invokerId;
-  meeting.cancelled = true;
-  meeting.cancellationReason = `Stopped by <@${invokerId}>`;
+
+  if (contextResult.context.isAutoRecording) {
+    meeting.cancelled = true;
+    meeting.cancellationReason = `Stopped by <@${invokerId}>`;
+  }
 
   await handleEndMeetingOther(client, meeting);
-  await interaction.editReply("Stopped recording.");
+  await interaction.editReply(
+    contextResult.context.isAutoRecording
+      ? "Stopped recording."
+      : "Ended meeting.",
+  );
 }

--- a/src/utils/meetingPermissions.ts
+++ b/src/utils/meetingPermissions.ts
@@ -17,6 +17,8 @@ export function canUserEndMeeting(
   return member.permissions.any([
     PermissionFlagsBits.ModerateMembers,
     PermissionFlagsBits.Administrator,
+    PermissionFlagsBits.ManageChannels,
+    PermissionFlagsBits.ManageGuild,
     PermissionFlagsBits.ManageMessages,
   ]);
 }

--- a/test/commands/dismissAutoRecord.test.ts
+++ b/test/commands/dismissAutoRecord.test.ts
@@ -140,6 +140,56 @@ describe("handleDismissAutoRecord", () => {
     expect(interaction.editReply).toHaveBeenCalledWith("Stopped recording.");
   });
 
+  it("allows a manual meeting creator to end the meeting", async () => {
+    const client = makeClient();
+    const interaction = makeInteraction();
+    const meeting = makeMeeting({
+      isAutoRecording: false,
+      creator: { id: "user-1" } as MeetingData["creator"],
+      guild: {
+        id: "guild-1",
+        members: { cache: new Collection() },
+      } as unknown as MeetingData["guild"],
+      voiceChannel: makeVoiceChannel(makeMembers([["bot-1", true]])),
+    });
+    mockedGetMeeting.mockReturnValue(meeting);
+
+    await handleDismissAutoRecord(client, interaction);
+
+    expect(mockedResolveConfigEnum).not.toHaveBeenCalled();
+    expect(mockedHandleEndMeetingOther).toHaveBeenCalledWith(client, meeting);
+    expect(meeting.endReason).toBe(MEETING_END_REASONS.BUTTON);
+    expect(meeting.endTriggeredByUserId).toBe("user-1");
+    expect(meeting.cancelled).toBeUndefined();
+    expect(meeting.cancellationReason).toBeUndefined();
+    expect(interaction.deferReply).toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith("Ended meeting.");
+  });
+
+  it("blocks unauthorized users from ending manual meetings", async () => {
+    const client = makeClient();
+    const interaction = makeInteraction();
+    const meeting = makeMeeting({
+      isAutoRecording: false,
+      creator: { id: "user-2" } as MeetingData["creator"],
+      guild: {
+        id: "guild-1",
+        members: { cache: new Collection() },
+      } as unknown as MeetingData["guild"],
+    });
+    mockedGetMeeting.mockReturnValue(meeting);
+
+    await handleDismissAutoRecord(client, interaction);
+
+    expect(mockedResolveConfigEnum).not.toHaveBeenCalled();
+    expect(mockedHandleEndMeetingOther).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "You do not have permission to end this meeting.",
+      }),
+    );
+  });
+
   it("allows the trigger user for trigger_or_admin", async () => {
     const client = makeClient();
     const interaction = makeInteraction();

--- a/test/utils/meetingPermissions.test.ts
+++ b/test/utils/meetingPermissions.test.ts
@@ -1,0 +1,50 @@
+import { PermissionFlagsBits, PermissionsBitField } from "discord.js";
+import type { MeetingData } from "../../src/types/meeting-data";
+import { canUserEndMeeting } from "../../src/utils/meetingPermissions";
+
+function makeMeetingWithMemberPermissions(
+  userId: string,
+  permissions: bigint,
+): MeetingData {
+  return {
+    creator: { id: "creator-1" },
+    guild: {
+      members: {
+        cache: new Map([
+          [
+            userId,
+            {
+              permissions: new PermissionsBitField(permissions),
+            },
+          ],
+        ]),
+      },
+    },
+  } as unknown as MeetingData;
+}
+
+describe("canUserEndMeeting", () => {
+  it.each([
+    ["ModerateMembers", PermissionFlagsBits.ModerateMembers],
+    ["Administrator", PermissionFlagsBits.Administrator],
+    ["ManageChannels", PermissionFlagsBits.ManageChannels],
+    ["ManageGuild", PermissionFlagsBits.ManageGuild],
+    ["ManageMessages", PermissionFlagsBits.ManageMessages],
+  ])("allows users with %s", (_label, permission) => {
+    const meeting = makeMeetingWithMemberPermissions("user-1", permission);
+
+    expect(canUserEndMeeting(meeting, "user-1")).toBe(true);
+  });
+
+  it("allows the meeting creator", () => {
+    const meeting = makeMeetingWithMemberPermissions("user-1", 0n);
+
+    expect(canUserEndMeeting(meeting, "creator-1")).toBe(true);
+  });
+
+  it("blocks users without meeting permissions", () => {
+    const meeting = makeMeetingWithMemberPermissions("user-1", 0n);
+
+    expect(canUserEndMeeting(meeting, "user-1")).toBe(false);
+  });
+});


### PR DESCRIPTION
[AGENT]
## Summary
- Allow the Stop recording context-menu command to end manual meetings instead of rejecting them as non-auto-recorded.
- Preserve auto-record dismissal policy and cancellation behavior for auto-recorded meetings.
- Update public docs and tests for manual meeting creator and unauthorized user paths.

## Verification
- yarn jest test/commands/dismissAutoRecord.test.ts --runInBand --coverage=false
- yarn lint:check
- yarn build
- yarn docs:check
- yarn prettier:check
- yarn test --runInBand