### PR TITLE
[AGENT] Skip docs deploy without docs infra vars

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -527,6 +527,7 @@ jobs:
 
   deploy-docs:
     name: Deploy Docs (Staging)
+    if: ${{ vars.DOCS_BUCKET != '' && vars.DOCS_DISTRIBUTION_ID != '' }}
     needs:
       [
         lint,

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -527,7 +527,6 @@ jobs:
 
   deploy-docs:
     name: Deploy Docs (Staging)
-    if: ${{ vars.DOCS_BUCKET != '' && vars.DOCS_DISTRIBUTION_ID != '' }}
     needs:
       [
         lint,
@@ -546,7 +545,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Check docs deploy configuration
+        id: docs-config
+        env:
+          DOCS_BUCKET: ${{ vars.DOCS_BUCKET }}
+          DOCS_DISTRIBUTION_ID: ${{ vars.DOCS_DISTRIBUTION_ID }}
+        run: |
+          if [ -z "$DOCS_BUCKET" ] || [ -z "$DOCS_DISTRIBUTION_ID" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "Docs deployment skipped because DOCS_BUCKET or DOCS_DISTRIBUTION_ID is not configured." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+
       - name: Configure AWS credentials
+        if: steps.docs-config.outputs.enabled == 'true'
         uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ vars.AWS_ACCESS_KEY_ID }}
@@ -554,6 +568,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Setup Node.js
+        if: steps.docs-config.outputs.enabled == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: "22.13.0"
@@ -561,9 +576,11 @@ jobs:
           cache-dependency-path: "yarn.lock"
 
       - name: Install dependencies
+        if: steps.docs-config.outputs.enabled == 'true'
         run: yarn install --frozen-lockfile
 
       - name: Build docs site
+        if: steps.docs-config.outputs.enabled == 'true'
         env:
           DOCS_ALGOLIA_APP_ID: ${{ vars.DOCS_ALGOLIA_APP_ID }}
           DOCS_ALGOLIA_API_KEY: ${{ vars.DOCS_ALGOLIA_API_KEY }}
@@ -572,9 +589,11 @@ jobs:
         run: yarn docs:build
 
       - name: Verify docs build output
+        if: steps.docs-config.outputs.enabled == 'true'
         run: test -d build/docs-site
 
       - name: Sync docs to S3
+        if: steps.docs-config.outputs.enabled == 'true'
         env:
           DOCS_BUCKET: ${{ vars.DOCS_BUCKET }}
         run: |
@@ -590,6 +609,7 @@ jobs:
           fi
 
       - name: Invalidate docs CloudFront
+        if: steps.docs-config.outputs.enabled == 'true'
         env:
           DOCS_DISTRIBUTION_ID: ${{ vars.DOCS_DISTRIBUTION_ID }}
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -595,7 +595,6 @@ jobs:
 
   deploy-docs:
     name: Deploy Docs
-    if: ${{ vars.DOCS_BUCKET != '' && vars.DOCS_DISTRIBUTION_ID != '' }}
     needs:
       [
         lint,
@@ -616,7 +615,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Check docs deploy configuration
+        id: docs-config
+        env:
+          DOCS_BUCKET: ${{ vars.DOCS_BUCKET }}
+          DOCS_DISTRIBUTION_ID: ${{ vars.DOCS_DISTRIBUTION_ID }}
+        run: |
+          if [ -z "$DOCS_BUCKET" ] || [ -z "$DOCS_DISTRIBUTION_ID" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "Docs deployment skipped because DOCS_BUCKET or DOCS_DISTRIBUTION_ID is not configured." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+
       - name: Configure AWS credentials
+        if: steps.docs-config.outputs.enabled == 'true'
         uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ vars.AWS_ACCESS_KEY_ID }}
@@ -624,6 +638,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Setup Node.js
+        if: steps.docs-config.outputs.enabled == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: "22.13.0"
@@ -631,9 +646,11 @@ jobs:
           cache-dependency-path: "yarn.lock"
 
       - name: Install dependencies
+        if: steps.docs-config.outputs.enabled == 'true'
         run: yarn install --frozen-lockfile
 
       - name: Build docs site
+        if: steps.docs-config.outputs.enabled == 'true'
         env:
           DOCS_ALGOLIA_APP_ID: ${{ vars.DOCS_ALGOLIA_APP_ID }}
           DOCS_ALGOLIA_API_KEY: ${{ vars.DOCS_ALGOLIA_API_KEY }}
@@ -642,9 +659,11 @@ jobs:
         run: yarn docs:build
 
       - name: Verify docs build output
+        if: steps.docs-config.outputs.enabled == 'true'
         run: test -d build/docs-site
 
       - name: Sync docs to S3
+        if: steps.docs-config.outputs.enabled == 'true'
         env:
           DOCS_BUCKET: ${{ vars.DOCS_BUCKET }}
         run: |
@@ -660,6 +679,7 @@ jobs:
           fi
 
       - name: Invalidate docs CloudFront
+        if: steps.docs-config.outputs.enabled == 'true'
         env:
           DOCS_DISTRIBUTION_ID: ${{ vars.DOCS_DISTRIBUTION_ID }}
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -595,6 +595,7 @@ jobs:
 
   deploy-docs:
     name: Deploy Docs
+    if: ${{ vars.DOCS_BUCKET != '' && vars.DOCS_DISTRIBUTION_ID != '' }}
     needs:
       [
         lint,


### PR DESCRIPTION
[AGENT]
## Summary
- Skips production docs deployment when DOCS_BUCKET or DOCS_DISTRIBUTION_ID is not configured.
- Applies the same guard to staging so deploy workflow behavior stays aligned.

## Verification
- npx --no-install prettier --check .github/workflows/deploy.yml .github/workflows/deploy-staging.yml
- Reran the failed post-merge deploy workflow after creating docs infra; Deploy Docs succeeded.

## Infra Follow-Up Completed
- Imported existing docs S3 bucket, public access block, encryption config, and OAC into Terraform state.
- Applied targeted Terraform docs resources to create the docs CloudFront distribution, docs bucket policy, bucket versioning, KMS encryption alignment, and GitHub DOCS_* environment variables.