### PR TITLE
[AGENT] Add Start meeting app action

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,6 +32,7 @@ This file provides Copilot review context. It mirrors AGENTS.md and adds only hi
 - Entry: `index.ts` -> `setupBot()` and `setupWebServer()`. Independent runtimes: `src/apps/bot/main.ts` and `src/apps/api/main.ts` boot the bot and API separately.
 - Bot interactions: `src/bot.ts`
   - Slash commands: `/startmeeting`, `/autorecord`, `/context`, `/dictionary`.
+  - User context menu app actions: `Start meeting`, `Stop recording`.
   - Buttons: end meeting, generate image, suggest correction.
   - Auto-record on voice join if configured.
 - Web server: `webserver.ts` (health check; optional Discord OAuth scaffolding). API routes are modularized under `src/api/` (billing, guilds, MCP) and share services with bot commands (ask/context/autorecord/billing).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@
 - Entry: `index.ts` -> `setupBot()` and `setupWebServer()`. Independent runtimes: `src/apps/bot/main.ts` and `src/apps/api/main.ts` boot the bot and API separately.
 - Bot interactions: `src/bot.ts`
   - Slash commands: `/startmeeting`, `/autorecord`, `/context`, `/dictionary`.
+  - User context menu app actions: `Start meeting`, `Stop recording`.
   - Buttons: end meeting, generate image, suggest correction.
   - Auto-record on voice join if configured.
 - Web server: `webserver.ts` (health check; optional Discord OAuth scaffolding). API routes are modularized under `src/api/` (billing, guilds, MCP) and share services with bot commands (ask/context/autorecord/billing).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Discord bot that records voice meetings, transcribes them with OpenAI, generat
 
 ## Commands
 
-- `/startmeeting`: Begin recording the meeting (audio + chat logs).
+- `/startmeeting`: Begin recording the meeting (audio + chat logs). You can also right-click Chronote and choose **Apps** -> **Start meeting**.
 - `/autorecord`: Configure auto-recording for a server/channel.
 - `/context`: Manage prompt context.
 - `/dictionary`: Manage dictionary terms used in prompts.

--- a/apps/docs-site/docs/core-concepts/meeting-lifecycle.md
+++ b/apps/docs-site/docs/core-concepts/meeting-lifecycle.md
@@ -9,7 +9,7 @@ Every Chronote recording follows a predictable lifecycle. Understanding these st
 
 A meeting starts in one of two ways:
 
-- **Manual**: A user runs `/startmeeting` while in a voice channel. They can optionally provide a `context` description and `tags`.
+- **Manual**: A user runs `/startmeeting` while in a voice channel, or right-clicks Chronote and selects **Apps** -> **Start meeting**. The slash command can optionally include a `context` description and `tags`.
 - **Auto-record**: A user joins a voice channel that has auto-recording enabled. Chronote starts recording automatically and posts an "Auto-Recording Started" embed.
 
 At this point, Chronote joins the voice channel and begins capturing audio from each participant separately. A meeting embed appears in the text channel with controls.

--- a/apps/docs-site/docs/features/feature-overview.md
+++ b/apps/docs-site/docs/features/feature-overview.md
@@ -9,7 +9,7 @@ This page is a reference for every Chronote command and feature. Each section de
 
 ### `/startmeeting`
 
-Starts a recorded meeting in the voice channel you are currently in.
+Starts a recorded meeting in the voice channel you are currently in. You can also right-click Chronote and select **Apps** -> **Start meeting** to start without context or tags.
 
 | Option    | Required | Description                                |
 | --------- | -------- | ------------------------------------------ |

--- a/apps/docs-site/docs/getting-started/overview.md
+++ b/apps/docs-site/docs/getting-started/overview.md
@@ -33,8 +33,8 @@ The onboarding wizard requires **Manage Server** permission. You can skip it and
 ## Step 3: Start your first meeting
 
 1. Join a voice channel.
-2. Run `/startmeeting` in a text channel.
-3. Optionally add a `context` parameter (e.g., "Weekly standup for backend team") and `tags` (e.g., "standup, backend").
+2. Run `/startmeeting` in a text channel, or right-click Chronote and select **Apps** -> **Start meeting**.
+3. If you use `/startmeeting`, optionally add a `context` parameter (e.g., "Weekly standup for backend team") and `tags` (e.g., "standup, backend").
 
 Chronote joins the voice channel and begins recording. You will see a "Meeting Started" embed with an **End Meeting** button.
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -124,6 +124,11 @@ import {
   dismissAutoRecordCommand,
   handleDismissAutoRecord,
 } from "./commands/dismissAutoRecord";
+import {
+  START_MEETING_CONTEXT_COMMAND_NAME,
+  handleStartMeetingContextCommand,
+  startMeetingContextCommand,
+} from "./commands/startMeetingContextMenu";
 import { claimInteractionReceipt } from "./services/interactionIdempotencyService";
 import { tryReplyToUnacknowledgedInteraction } from "./services/interactionResponseService";
 
@@ -356,6 +361,10 @@ const handleInteractionCreate = async (interaction: RepliableInteraction) => {
     return;
   }
   if (interaction.isUserContextMenuCommand()) {
+    if (interaction.commandName === START_MEETING_CONTEXT_COMMAND_NAME) {
+      await handleStartMeetingContextCommand(client, interaction);
+      return;
+    }
     if (interaction.commandName === DISMISS_AUTORECORD_COMMAND_NAME) {
       await handleDismissAutoRecord(client, interaction);
       return;
@@ -1130,6 +1139,7 @@ async function setupApplicationCommands() {
           .setDescription("Remove all dictionary entries for this server"),
       ),
     dismissAutoRecordCommand,
+    startMeetingContextCommand,
     new SlashCommandBuilder()
       .setName("feedback")
       .setDescription("Send feedback, report a bug, or suggest a feature"),

--- a/src/commands/startMeeting.ts
+++ b/src/commands/startMeeting.ts
@@ -52,6 +52,10 @@ type StartMeetingInteraction =
   | ChatInputCommandInteraction
   | UserContextMenuCommandInteraction;
 
+type StartMeetingOptions = {
+  ephemeralErrors?: boolean;
+};
+
 const buildLiveMeetingUrl = (guildId: string, meetingId: string) => {
   const base = config.frontend.siteUrl?.replace(/\/$/, "");
   if (!base) {
@@ -100,6 +104,19 @@ const getMeetingRequestOptions = (interaction: StartMeetingInteraction) => {
     meetingContext,
     tags: rawTags ? parseTags(rawTags) : undefined,
   };
+};
+
+const replyStartMeetingError = async (
+  interaction: StartMeetingInteraction,
+  content: string,
+  options?: StartMeetingOptions,
+) => {
+  if (!options?.ephemeralErrors) {
+    await interaction.reply(content);
+    return;
+  }
+
+  await interaction.reply({ content, ephemeral: true });
 };
 
 type GuildChannelResult =
@@ -186,31 +203,36 @@ const resolveMemberVoiceChannel = (member: GuildMember): VoiceChannelResult => {
 
 export async function handleRequestStartMeeting(
   interaction: StartMeetingInteraction,
+  options?: StartMeetingOptions,
 ) {
   const guildId = interaction.guildId!;
   const { meetingContext, tags } = getMeetingRequestOptions(interaction);
   const channelResult = resolveGuildChannels(interaction);
   if (!channelResult.ok) {
-    await interaction.reply(channelResult.error);
+    await replyStartMeetingError(interaction, channelResult.error, options);
     return;
   }
 
   const { guild, guildChannel, textChannel } = channelResult;
   const botMember = resolveBotMember(guild);
   if (!botMember) {
-    await interaction.reply("Bot not found in guild.");
+    await replyStartMeetingError(
+      interaction,
+      "Bot not found in guild.",
+      options,
+    );
     return;
   }
 
   const permissionError = ensureBotCanSend(guildChannel, botMember);
   if (permissionError) {
-    await interaction.reply(permissionError);
+    await replyStartMeetingError(interaction, permissionError, options);
     return;
   }
 
   const meetingConflict = await ensureNoActiveMeeting(guildId);
   if (meetingConflict) {
-    await interaction.reply(meetingConflict);
+    await replyStartMeetingError(interaction, meetingConflict, options);
     return;
   }
 
@@ -219,7 +241,7 @@ export async function handleRequestStartMeeting(
   const member = untypedMember as GuildMember;
   const voiceResult = resolveMemberVoiceChannel(member);
   if (!voiceResult.ok) {
-    await interaction.reply(voiceResult.error);
+    await replyStartMeetingError(interaction, voiceResult.error, options);
     return;
   }
   const { voiceChannel } = voiceResult;
@@ -240,7 +262,11 @@ export async function handleRequestStartMeeting(
   );
 
   if (!permissionCheck.success) {
-    await interaction.reply(permissionCheck.errorMessage!);
+    await replyStartMeetingError(
+      interaction,
+      permissionCheck.errorMessage!,
+      options,
+    );
     return;
   }
 
@@ -265,7 +291,11 @@ export async function handleRequestStartMeeting(
     startTriggeredByUserId: interaction.user.id,
   });
   if (!leaseAcquired) {
-    await interaction.reply("A meeting is already active in this server.");
+    await replyStartMeetingError(
+      interaction,
+      "A meeting is already active in this server.",
+      options,
+    );
     return;
   }
 

--- a/src/commands/startMeeting.ts
+++ b/src/commands/startMeeting.ts
@@ -2,12 +2,13 @@ import {
   ActionRowBuilder,
   ButtonBuilder,
   ButtonStyle,
+  ChatInputCommandInteraction,
   Client,
-  CommandInteraction,
   EmbedBuilder,
   GuildMember,
   PermissionsBitField,
   TextChannel,
+  UserContextMenuCommandInteraction,
   VoiceBasedChannel,
 } from "discord.js";
 import {
@@ -47,6 +48,10 @@ import {
 
 type GuildLimits = Awaited<ReturnType<typeof getGuildLimits>>["limits"];
 
+type StartMeetingInteraction =
+  | ChatInputCommandInteraction
+  | UserContextMenuCommandInteraction;
+
 const buildLiveMeetingUrl = (guildId: string, meetingId: string) => {
   const base = config.frontend.siteUrl?.replace(/\/$/, "");
   if (!base) {
@@ -85,7 +90,7 @@ async function getLimitNotice(
   return buildLimitReachedMessage(nextAvailableAtIso);
 }
 
-const getMeetingRequestOptions = (interaction: CommandInteraction) => {
+const getMeetingRequestOptions = (interaction: StartMeetingInteraction) => {
   if (!interaction.isChatInputCommand()) {
     return { meetingContext: undefined, tags: undefined };
   }
@@ -100,14 +105,14 @@ const getMeetingRequestOptions = (interaction: CommandInteraction) => {
 type GuildChannelResult =
   | {
       ok: true;
-      guild: NonNullable<CommandInteraction["guild"]>;
+      guild: NonNullable<StartMeetingInteraction["guild"]>;
       guildChannel: GuildChannel;
       textChannel: TextChannel;
     }
   | { ok: false; error: string };
 
 const resolveGuildChannels = (
-  interaction: CommandInteraction,
+  interaction: StartMeetingInteraction,
 ): GuildChannelResult => {
   const channel = interaction.channel;
   const guild = interaction.guild;
@@ -125,7 +130,9 @@ const resolveGuildChannels = (
   };
 };
 
-const resolveBotMember = (guild: NonNullable<CommandInteraction["guild"]>) => {
+const resolveBotMember = (
+  guild: NonNullable<StartMeetingInteraction["guild"]>,
+) => {
   const botId = guild.client.user?.id;
   if (!botId) return null;
   return guild.members.cache.get(botId) ?? null;
@@ -178,7 +185,7 @@ const resolveMemberVoiceChannel = (member: GuildMember): VoiceChannelResult => {
 };
 
 export async function handleRequestStartMeeting(
-  interaction: CommandInteraction,
+  interaction: StartMeetingInteraction,
 ) {
   const guildId = interaction.guildId!;
   const { meetingContext, tags } = getMeetingRequestOptions(interaction);

--- a/src/commands/startMeetingContextMenu.ts
+++ b/src/commands/startMeetingContextMenu.ts
@@ -17,13 +17,22 @@ export async function handleStartMeetingContextCommand(
   client: Client,
   interaction: UserContextMenuCommandInteraction,
 ) {
-  if (interaction.targetUser.id !== client.user?.id) {
+  const botUserId = client.user?.id;
+  if (!botUserId) {
     await interaction.reply({
-      content: "Right-click Chronote to start a meeting.",
+      content: "The bot is still starting up. Try again in a moment.",
       ephemeral: true,
     });
     return;
   }
 
-  await handleRequestStartMeeting(interaction);
+  if (interaction.targetUser.id !== botUserId) {
+    await interaction.reply({
+      content: `Right-click <@${botUserId}> to start a meeting.`,
+      ephemeral: true,
+    });
+    return;
+  }
+
+  await handleRequestStartMeeting(interaction, { ephemeralErrors: true });
 }

--- a/src/commands/startMeetingContextMenu.ts
+++ b/src/commands/startMeetingContextMenu.ts
@@ -1,0 +1,29 @@
+import {
+  ApplicationCommandType,
+  ContextMenuCommandBuilder,
+  type Client,
+  type UserContextMenuCommandInteraction,
+} from "discord.js";
+import { handleRequestStartMeeting } from "./startMeeting";
+
+export const START_MEETING_CONTEXT_COMMAND_NAME = "Start meeting";
+
+export const startMeetingContextCommand = new ContextMenuCommandBuilder()
+  .setName(START_MEETING_CONTEXT_COMMAND_NAME)
+  .setType(ApplicationCommandType.User)
+  .setDMPermission(false);
+
+export async function handleStartMeetingContextCommand(
+  client: Client,
+  interaction: UserContextMenuCommandInteraction,
+) {
+  if (interaction.targetUser.id !== client.user?.id) {
+    await interaction.reply({
+      content: "Right-click Chronote to start a meeting.",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  await handleRequestStartMeeting(interaction);
+}

--- a/test/commands/startMeetingContextMenu.test.ts
+++ b/test/commands/startMeetingContextMenu.test.ts
@@ -1,0 +1,64 @@
+import type { Client, UserContextMenuCommandInteraction } from "discord.js";
+import { ApplicationCommandType } from "discord.js";
+import { handleRequestStartMeeting } from "../../src/commands/startMeeting";
+import {
+  START_MEETING_CONTEXT_COMMAND_NAME,
+  handleStartMeetingContextCommand,
+  startMeetingContextCommand,
+} from "../../src/commands/startMeetingContextMenu";
+
+jest.mock("../../src/commands/startMeeting", () => ({
+  handleRequestStartMeeting: jest.fn(),
+}));
+
+const mockedHandleRequestStartMeeting =
+  handleRequestStartMeeting as jest.MockedFunction<
+    typeof handleRequestStartMeeting
+  >;
+
+const makeClient = (botId = "bot-1"): Client =>
+  ({ user: { id: botId } }) as Client;
+
+const makeInteraction = (targetUserId = "bot-1") =>
+  ({
+    targetUser: { id: targetUserId },
+    reply: jest.fn().mockResolvedValue(undefined),
+  }) as unknown as UserContextMenuCommandInteraction;
+
+describe("start meeting context menu", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedHandleRequestStartMeeting.mockResolvedValue(undefined);
+  });
+
+  it("registers a guild-only user context menu command", () => {
+    expect(startMeetingContextCommand.toJSON()).toEqual(
+      expect.objectContaining({
+        name: START_MEETING_CONTEXT_COMMAND_NAME,
+        type: ApplicationCommandType.User,
+        dm_permission: false,
+      }),
+    );
+  });
+
+  it("starts a meeting when invoked on Chronote", async () => {
+    const interaction = makeInteraction("bot-1");
+
+    await handleStartMeetingContextCommand(makeClient("bot-1"), interaction);
+
+    expect(mockedHandleRequestStartMeeting).toHaveBeenCalledWith(interaction);
+    expect(interaction.reply).not.toHaveBeenCalled();
+  });
+
+  it("blocks invocations on users other than Chronote", async () => {
+    const interaction = makeInteraction("user-1");
+
+    await handleStartMeetingContextCommand(makeClient("bot-1"), interaction);
+
+    expect(mockedHandleRequestStartMeeting).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: "Right-click Chronote to start a meeting.",
+      ephemeral: true,
+    });
+  });
+});

--- a/test/commands/startMeetingContextMenu.test.ts
+++ b/test/commands/startMeetingContextMenu.test.ts
@@ -16,8 +16,8 @@ const mockedHandleRequestStartMeeting =
     typeof handleRequestStartMeeting
   >;
 
-const makeClient = (botId = "bot-1"): Client =>
-  ({ user: { id: botId } }) as Client;
+const makeClient = (botId: string | null = "bot-1"): Client =>
+  ({ user: botId ? { id: botId } : null }) as Client;
 
 const makeInteraction = (targetUserId = "bot-1") =>
   ({
@@ -46,7 +46,9 @@ describe("start meeting context menu", () => {
 
     await handleStartMeetingContextCommand(makeClient("bot-1"), interaction);
 
-    expect(mockedHandleRequestStartMeeting).toHaveBeenCalledWith(interaction);
+    expect(mockedHandleRequestStartMeeting).toHaveBeenCalledWith(interaction, {
+      ephemeralErrors: true,
+    });
     expect(interaction.reply).not.toHaveBeenCalled();
   });
 
@@ -57,7 +59,19 @@ describe("start meeting context menu", () => {
 
     expect(mockedHandleRequestStartMeeting).not.toHaveBeenCalled();
     expect(interaction.reply).toHaveBeenCalledWith({
-      content: "Right-click Chronote to start a meeting.",
+      content: "Right-click <@bot-1> to start a meeting.",
+      ephemeral: true,
+    });
+  });
+
+  it("blocks while the bot user is unavailable", async () => {
+    const interaction = makeInteraction("bot-1");
+
+    await handleStartMeetingContextCommand(makeClient(null), interaction);
+
+    expect(mockedHandleRequestStartMeeting).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: "The bot is still starting up. Try again in a moment.",
       ephemeral: true,
     });
   });


### PR DESCRIPTION
[AGENT]
## Summary
- Add a Discord user context menu action named `Start meeting` that reuses the existing manual meeting start flow when invoked on Chronote.
- Guard accidental invocations on other users with an ephemeral hint.
- Update docs and repo guidance to mention the new app action alongside `/startmeeting`.

## Verification
- `yarn test test/commands/startMeetingContextMenu.test.ts --runInBand --coverage=false`
- `yarn test`
- `yarn lint:check`
- `yarn build`
- `yarn build:web`
- `yarn docs:check`
- `yarn prettier:check`
- `yarn markdownlint:check`

Closes #174