### PR TITLE
[AGENT] Add manual Terraform plan workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -93,6 +93,7 @@ This file provides Copilot review context. It mirrors AGENTS.md and adds only hi
 
 - Variables (tfvars.example): Discord IDs/tokens, OpenAI keys, OAuth secrets, ENABLE_OAUTH (false by default in example), AWS/GitHub tokens.
 - ECS task environment passes all relevant vars from Terraform; OpenAI org/project optional; OAuth vars included but can be blank if disabled.
+- Terraform plan visibility is manual via `.github/workflows/terraform-plan.yml`; merges do not auto-apply Terraform. The workflow uses environment-scoped AWS credentials and a `TERRAFORM_TFVARS_JSON` secret.
 - Future work suggestion: keep cache and Redis Terraform resources in `_infra/cache.tf`, and add new cache infrastructure there.
 
 ## Known nuances / gotchas

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ vars.AWS_ACCESS_KEY_ID }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
@@ -94,7 +94,9 @@ jobs:
         run: terraform -chdir=_infra init -input=false
 
       - name: Select Terraform workspace
-        run: terraform -chdir=_infra workspace select "${{ inputs.terraform_workspace }}"
+        env:
+          TERRAFORM_WORKSPACE: ${{ inputs.terraform_workspace }}
+        run: terraform -chdir=_infra workspace select "$TERRAFORM_WORKSPACE"
 
       - name: Terraform validate
         run: terraform -chdir=_infra validate -no-color
@@ -122,13 +124,17 @@ jobs:
 
       - name: Write summary
         if: always()
+        env:
+          GITHUB_ENVIRONMENT: ${{ inputs.github_environment }}
+          TERRAFORM_WORKSPACE: ${{ inputs.terraform_workspace }}
+          PLAN_CHANGES: ${{ steps.plan.outputs.changes || 'unknown' }}
         run: |
           {
             echo "## Terraform Plan"
             echo
-            echo "- GitHub environment: \`${{ inputs.github_environment }}\`"
-            echo "- Terraform workspace: \`${{ inputs.terraform_workspace }}\`"
-            echo "- Pending changes: \`${{ steps.plan.outputs.changes || 'unknown' }}\`"
+            echo "- GitHub environment: \`$GITHUB_ENVIRONMENT\`"
+            echo "- Terraform workspace: \`$TERRAFORM_WORKSPACE\`"
+            echo "- Pending changes: \`$PLAN_CHANGES\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Remove generated tfvars

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,136 @@
+name: Terraform Plan
+
+run-name: Terraform Plan ${{ inputs.github_environment }} by ${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      github_environment:
+        description: GitHub environment containing Terraform plan credentials and tfvars
+        required: true
+        type: choice
+        default: sandbox
+        options:
+          - sandbox
+          - staging
+      terraform_workspace:
+        description: Existing Terraform workspace to plan against
+        required: true
+        type: string
+        default: default
+
+permissions:
+  contents: read
+
+concurrency:
+  group: terraform-plan-${{ inputs.github_environment }}-${{ inputs.terraform_workspace }}
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    name: Terraform Plan
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.github_environment }}
+    env:
+      TF_IN_AUTOMATION: "true"
+      TF_INPUT: "false"
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ vars.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Write Terraform variables
+        env:
+          TERRAFORM_TFVARS_JSON: ${{ secrets.TERRAFORM_TFVARS_JSON }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${TERRAFORM_TFVARS_JSON:-}" ]; then
+            echo "ERROR: TERRAFORM_TFVARS_JSON is not configured for this GitHub environment."
+            exit 1
+          fi
+
+          umask 077
+          printf '%s' "$TERRAFORM_TFVARS_JSON" > _infra/terraform.auto.tfvars.json
+
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          path = Path("_infra/terraform.auto.tfvars.json")
+          data = json.loads(path.read_text())
+
+          required = ["GITHUB_TOKEN", "AWS_TOKEN_KEY", "DISCORD_CLIENT_ID"]
+          missing = [name for name in required if not data.get(name)]
+          if missing:
+              raise SystemExit(
+                  "Missing required Terraform variables in TERRAFORM_TFVARS_JSON: "
+                  + ", ".join(missing)
+              )
+
+          if data.get("grafana_api_key"):
+              raise SystemExit(
+                  "grafana_api_key must be empty after Grafana token rotation is active. "
+                  "Use grafana_service_account_id plus the Secrets Manager token instead."
+              )
+
+          if data.get("grafana_url") and not data.get("grafana_service_account_id"):
+              raise SystemExit(
+                  "grafana_service_account_id is required when grafana_url is configured."
+              )
+          PY
+
+      - name: Terraform init
+        run: terraform -chdir=_infra init -input=false
+
+      - name: Select Terraform workspace
+        run: terraform -chdir=_infra workspace select "${{ inputs.terraform_workspace }}"
+
+      - name: Terraform validate
+        run: terraform -chdir=_infra validate -no-color
+
+      - name: Terraform plan
+        id: plan
+        run: |
+          set +e
+          terraform -chdir=_infra plan -no-color -input=false -detailed-exitcode -out=tfplan | tee terraform-plan.txt
+          exit_code=${PIPESTATUS[0]}
+          set -e
+
+          if [ "$exit_code" -eq 1 ]; then
+            echo "Terraform plan failed."
+            exit 1
+          fi
+
+          if [ "$exit_code" -eq 2 ]; then
+            echo "changes=true" >> "$GITHUB_OUTPUT"
+            echo "Terraform plan completed with pending changes."
+          else
+            echo "changes=false" >> "$GITHUB_OUTPUT"
+            echo "Terraform plan completed with no pending changes."
+          fi
+
+      - name: Write summary
+        if: always()
+        run: |
+          {
+            echo "## Terraform Plan"
+            echo
+            echo "- GitHub environment: \`${{ inputs.github_environment }}\`"
+            echo "- Terraform workspace: \`${{ inputs.terraform_workspace }}\`"
+            echo "- Pending changes: \`${{ steps.plan.outputs.changes || 'unknown' }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Remove generated tfvars
+        if: always()
+        run: rm -f _infra/terraform.auto.tfvars.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,7 @@
 
 - Variables (tfvars.example): Discord IDs/tokens, OpenAI keys, OAuth secrets, ENABLE_OAUTH (false by default in example), AWS/GitHub tokens.
 - ECS task environment passes all relevant vars from Terraform; OpenAI org/project optional; OAuth vars included but can be blank if disabled.
+- Terraform plan visibility is manual via `.github/workflows/terraform-plan.yml`; merges do not auto-apply Terraform. The workflow expects environment-scoped AWS credentials and a `TERRAFORM_TFVARS_JSON` secret. Keep `grafana_api_key` empty after Grafana token rotation is active, and use `grafana_service_account_id` plus the rotated Secrets Manager token.
 - Future work suggestion: keep cache and Redis Terraform resources in `_infra/cache.tf`, and add new cache infrastructure there.
 
 ## Known nuances / gotchas

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ These checks run before PR merge and deployment. Use `yarn run check` for the fu
 - Prompt sync (Langfuse) keeps repo prompt files aligned with Langfuse. Command: `yarn prompts:check`.
 - LLM connection sync (Langfuse) keeps LLM connection YAML aligned with Langfuse. Command: `yarn llm-connections:check`.
 - IaC scan (Checkov via uvx) catches Terraform misconfigurations. Command: `yarn checkov`. Docs: https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html and https://docs.astral.sh/uv/concepts/tools/
+- Terraform drift visibility is manual through `.github/workflows/terraform-plan.yml`. It runs `terraform plan` against a selected GitHub environment and workspace, but does not apply changes.
 
 CI runs the same set as `yarn run check:ci` (see `.github/workflows/ci.yml`).
 

--- a/_infra/README.md
+++ b/_infra/README.md
@@ -206,3 +206,26 @@ If you prefer separate variable files, use:
 - Prod: `terraform -chdir=_infra plan -var-file=terraform.tfvars`
 - Staging: copy `terraform.staging.tfvars.example` to `terraform.staging.tfvars`, then run
   `terraform -chdir=_infra plan -var-file=terraform.staging.tfvars`
+
+## Terraform plan workflow
+
+`.github/workflows/terraform-plan.yml` is a manual plan-only workflow. It does
+not run on merge and does not apply changes. Use it before planned infra work or
+when checking drift after deploys.
+
+Each GitHub environment used by the workflow must provide:
+
+- Variable `AWS_ACCESS_KEY_ID`
+- Secret `AWS_SECRET_ACCESS_KEY`
+- Secret `TERRAFORM_TFVARS_JSON`
+
+`TERRAFORM_TFVARS_JSON` is the environment-specific Terraform variable file as
+JSON. Keep it aligned with the private `terraform.tfvars` values used for manual
+plans. The workflow validates that required variables are present and rejects a
+non-empty `grafana_api_key` after Grafana token rotation is active. Use
+`grafana_service_account_id` and the rotated Secrets Manager token instead.
+
+Merges do not reconcile Terraform drift. The deploy workflows update ECS task
+definitions, S3 objects, and CloudFront invalidations directly, while Terraform
+owns the baseline infrastructure. Review plan output before applying, especially
+ECS task definition replacement and provider normalization diffs.

--- a/_infra/README.md
+++ b/_infra/README.md
@@ -215,7 +215,7 @@ when checking drift after deploys.
 
 Each GitHub environment used by the workflow must provide:
 
-- Variable `AWS_ACCESS_KEY_ID`
+- Secret `AWS_ACCESS_KEY_ID`
 - Secret `AWS_SECRET_ACCESS_KEY`
 - Secret `TERRAFORM_TFVARS_JSON`
 


### PR DESCRIPTION
[AGENT]

## Summary
- Add a manual Terraform plan workflow for sandbox and staging GitHub environments.
- Require environment-scoped AWS credentials and a TERRAFORM_TFVARS_JSON secret instead of relying on local-only tfvars.
- Document that merges do not auto-apply Terraform and that Grafana bootstrap tokens must stay empty after rotation is active.

## Validation
- yarn prettier:check .github/workflows/terraform-plan.yml _infra/README.md AGENTS.md .github/copilot-instructions.md README.md
- yarn markdownlint:check AGENTS.md README.md _infra/README.md .github/copilot-instructions.md
- yarn checkov
- Parsed .github/workflows/terraform-plan.yml with the YAML package.

## Docs
- Technical workflow/docs-only change; public product docs exempt.