### PR TITLE
[AGENT] Fall back when MCP attended index fails

### DIFF
--- a/src/api/__tests__/mcp.test.ts
+++ b/src/api/__tests__/mcp.test.ts
@@ -81,6 +81,10 @@ const captureMcpPostHandler = () => {
 };
 
 describe("MCP JSON-RPC handler", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it("returns the Chronote MCP tool list", async () => {
     await expect(
       handleMcpJsonRpcRequest(auth, {
@@ -227,6 +231,38 @@ describe("MCP JSON-RPC handler", () => {
       jsonrpc: "2.0",
       id: 3,
       error: { code: -32602, message: "Invalid params." },
+    });
+  });
+
+  it("logs the tool name for unexpected tool errors", async () => {
+    const error = new Error("DynamoDB query failed");
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    jest.mocked(listMcpMyMeetings).mockRejectedValueOnce(error);
+
+    await expect(
+      handleMcpJsonRpcRequest(auth, {
+        jsonrpc: "2.0",
+        id: "unexpected-tool-error",
+        method: "tools/call",
+        params: {
+          name: "list_my_meetings",
+          arguments: { range: "past_7_days" },
+        },
+      }),
+    ).resolves.toMatchObject({
+      jsonrpc: "2.0",
+      id: "unexpected-tool-error",
+      result: {
+        content: [{ type: "text", text: "Unexpected tool error." }],
+        isError: true,
+      },
+    });
+
+    expect(consoleError).toHaveBeenCalledWith("Unexpected MCP tool error", {
+      toolName: "list_my_meetings",
+      error,
     });
   });
 

--- a/src/api/mcp.ts
+++ b/src/api/mcp.ts
@@ -397,7 +397,10 @@ async function callTool(auth: McpAccessTokenInfo, name: string, args: unknown) {
     return toolError(`Unknown tool: ${name}`);
   } catch (error) {
     if (error instanceof z.ZodError) return toolError("Invalid tool input.");
-    return mapMeetingError(error) ?? toolError("Unexpected tool error.");
+    const meetingError = mapMeetingError(error);
+    if (meetingError) return meetingError;
+    console.error("Unexpected MCP tool error", { toolName: name, error });
+    return toolError("Unexpected tool error.");
   }
 }
 

--- a/src/services/__tests__/mcpMeetingService.test.ts
+++ b/src/services/__tests__/mcpMeetingService.test.ts
@@ -582,6 +582,41 @@ describe("mcpMeetingService", () => {
     });
   });
 
+  it("falls back to server ranges when attended mode index lookup fails", async () => {
+    const fallbackMeeting = createMeeting("fallback", {
+      guildId: "guild-1",
+      timestamp: "2026-01-02T00:00:00.000Z",
+      channelId_timestamp: "channel-1#2026-01-02T00:00:00.000Z",
+      participants: [{ id: "user-1", username: "user1" }],
+    });
+    jest
+      .mocked(listBotGuildsCached)
+      .mockResolvedValue([{ id: "guild-1", name: "Guild 1", icon: null }]);
+    jest
+      .mocked(listMeetingUserIndexForUserInRangeService)
+      .mockRejectedValue(new Error("index unavailable"));
+    jest
+      .mocked(listMeetingsForGuildInRangeService)
+      .mockResolvedValue([fallbackMeeting]);
+    jest.mocked(checkUserMeetingAccess).mockResolvedValue({
+      allowed: true,
+      via: "attendee",
+    });
+
+    await expect(
+      listMcpMyMeetings({
+        userId: "user-1",
+        mode: "attended",
+        startDate: "2026-01-01T00:00:00.000Z",
+        endDate: "2026-01-05T00:00:00.000Z",
+      }),
+    ).resolves.toMatchObject({
+      meetings: [{ meetingId: "fallback", serverName: "Guild 1" }],
+    });
+
+    expect(getMeetingHistoryService).not.toHaveBeenCalled();
+  });
+
   it("skips servers whose My Meetings range fallback fails", async () => {
     const visibleMeeting = createMeeting("visible", {
       guildId: "guild-1",

--- a/src/services/mcpMeetingService.ts
+++ b/src/services/mcpMeetingService.ts
@@ -486,12 +486,23 @@ const listIndexedMeetingsForUser = async (input: {
   endDate: string;
   limit: number;
 }) => {
-  const records = await listMeetingUserIndexForUserInRangeService(
-    input.userId,
-    input.startDate,
-    input.endDate,
-    input.limit,
-  );
+  let records;
+  try {
+    records = await listMeetingUserIndexForUserInRangeService(
+      input.userId,
+      input.startDate,
+      input.endDate,
+      input.limit,
+    );
+  } catch (error) {
+    console.warn("Failed to list MCP indexed meetings", {
+      userId: input.userId,
+      startDate: input.startDate,
+      endDate: input.endDate,
+      error,
+    });
+    return [];
+  }
   const meetings = await runInBatches(
     records,
     MCP_INDEX_HISTORY_BATCH_SIZE,


### PR DESCRIPTION
[AGENT]
## Summary
- Make MCP attended meeting lookup degrade to server range scans when the user index query fails.
- Add server-side logging for unexpected MCP tool errors with the tool name.
- Add regression coverage for attended fallback behavior.

## Testing
- `yarn test src/api/__tests__/mcp.test.ts src/services/__tests__/mcpMeetingService.test.ts --runInBand --coverage=false`
- `yarn prettier:check`
- `yarn build`
- `python -m lizard -W whitelizard.txt -l ts src/services/mcpMeetingService.ts src/api/mcp.ts`

## Docs
- docs-exempt: operational resilience fix for existing MCP behavior; no public contract change.