### PR TITLE
[AGENT] Make My Meetings the portal home

### DIFF
--- a/apps/docs-site/docs/admin/setup-and-access.md
+++ b/apps/docs-site/docs/admin/setup-and-access.md
@@ -100,7 +100,7 @@ Chronote needs these Discord permissions:
 
 ### Web portal access
 
-The web portal uses Discord OAuth. Users see meetings from channels they have access to in Discord. Attendees of a meeting can always view it regardless of current channel permissions.
+The web portal uses Discord OAuth. Users land on **My Meetings** first, then can open direct meeting links or browse Server Library for one server at a time. Users see meetings from channels they have access to in Discord. Attendees of a meeting can always view it regardless of current channel permissions.
 
 ## Operational recommendations
 

--- a/apps/docs-site/docs/features/feature-overview.md
+++ b/apps/docs-site/docs/features/feature-overview.md
@@ -183,14 +183,14 @@ This feature requires a Basic plan or higher.
 The Chronote web portal provides a browser-based interface for:
 
 - Browsing meeting history with search and filters.
-- Viewing **My Meetings** across every server you can access, with filters for today, the past week, and accessible meetings.
+- Viewing **My Meetings** as your portal home, with direct links to meetings across servers you can access.
 - Reading full transcripts and notes.
 - Sharing meeting links with teammates.
 - Suggesting and applying notes corrections.
 - Importing Markdown or plain-text notes from another app.
 - Managing server settings (context, dictionary, auto-record).
 
-Access the portal from the **Open in Chronote** button on any meeting summary, or visit your server's portal URL directly.
+Access the portal from the **Open in Chronote** button on any meeting summary, or open the portal directly to start from **My Meetings**. Server Library remains available when you want to browse one server at a time.
 
 ## Context menu commands
 

--- a/apps/docs-site/docs/integrations/overview.md
+++ b/apps/docs-site/docs/integrations/overview.md
@@ -9,7 +9,7 @@ Chronote integrations extend meeting data into external tools and workflows.
 
 ### Web portal
 
-Chronote includes a built-in web portal for browsing meetings, reading transcripts, sharing links, and managing settings. The portal is accessible from any meeting summary embed via the **Open in Chronote** button.
+Chronote includes a built-in web portal for browsing meetings, reading transcripts, sharing links, and managing settings. The portal opens to **My Meetings** by default, and the **Open in Chronote** button on a meeting summary opens that meeting directly.
 
 The portal authenticates through Discord OAuth so channel permissions are respected.
 

--- a/apps/docs-site/docs/integrations/remote-mcp.md
+++ b/apps/docs-site/docs/integrations/remote-mcp.md
@@ -69,9 +69,9 @@ When your MCP client connects, it opens a Chronote authorization flow in the bro
 
 ## Access Rules
 
-Chronote only returns meeting data if the authenticated Discord user can access the meeting. Access follows the same model as the Library:
+Chronote only returns meeting data if the authenticated Discord user can access the meeting. Access follows the same model as My Meetings and Server Library:
 
-- Current server members who participated can access their meetings when attendee access is enabled.
+- Users who participated can access their indexed meetings when attendee access is enabled.
 - Other users need access to the voice channel and notes channel history.
 - Transcript access requires explicit transcript scope consent.
 

--- a/apps/docs-site/docs/troubleshooting/common-issues.md
+++ b/apps/docs-site/docs/troubleshooting/common-issues.md
@@ -84,9 +84,10 @@ Use this page to diagnose and fix common Chronote issues. Each section describes
 
 **Causes and fixes**:
 
-1. **Wrong server selected.** The portal scopes to a specific server. Check the server selector.
-2. **Channel permissions.** The portal respects Discord channel permissions. You only see meetings from channels you have access to.
-3. **No meetings recorded yet.** Meetings appear after at least one meeting has been completed successfully.
+1. **Filters hide the meeting.** **My Meetings** opens by default and includes range, server, tag, and archive filters. Clear filters or switch the range to Last 30 days.
+2. **Wrong server selected.** Server Library scopes to one server. Use **My Meetings** for a cross-server view, or choose the expected server from the server selector.
+3. **Channel permissions.** The portal respects Discord channel permissions. You only see meetings from channels you can access, plus meetings you attended when attendee access is enabled.
+4. **No meetings recorded yet.** Meetings appear after at least one meeting has been completed successfully.
 
 ## Billing or plan issues
 

--- a/docs/meeting-access.md
+++ b/docs/meeting-access.md
@@ -7,11 +7,11 @@ Chronote tries to make meeting privacy match Discord as closely as possible.
 - Meeting summaries and notes are posted as normal Discord messages in a text channel.
 - Discord channel permissions control who can read them.
 
-## Web portal (Library + Ask)
+## Web portal (My Meetings + Library + Ask)
 
 The portal can show additional artifacts (transcript text, timeline, audio playback). Access is based on Discord permissions.
 
-By default, a user can view a meeting in the portal if they:
+By default, a user can view a meeting through server-scoped Library or Ask if they:
 
 1. Are still a member of the server.
 2. Can join the meeting's voice channel.
@@ -23,13 +23,13 @@ By default, a user can view a meeting in the portal if they:
 
 If a user participated in the meeting (their Discord user id appears in the meeting's stored participant snapshot), Chronote can allow portal access even if they no longer have access to the voice or notes channel.
 
-This exception is meant to support common workflows like role changes after a meeting. Users still need to be a member of the server.
+This exception is meant to support common workflows like role changes after a meeting. User-centric surfaces such as My Meetings and MCP can list and open indexed attended meetings without requiring current server membership. Server Library remains a server-scoped browsing view.
 
 This behavior is controlled by the server setting `meetings.attendeeAccess.enabled` (default: enabled).
 
 ### Ask uses the same rules
 
-When you use Ask (both in the portal and via `/ask` in Discord), Chronote only searches meetings you can access under the same rules as the Library.
+When you use Ask (both in the portal and via `/ask` in Discord), Chronote only searches meetings you can access under the same rules as the active surface.
 
 ## Notes
 

--- a/src/api/__tests__/mcp.test.ts
+++ b/src/api/__tests__/mcp.test.ts
@@ -179,7 +179,7 @@ describe("MCP JSON-RPC handler", () => {
           transcriptAvailable: false,
           audioAvailable: false,
           archivedAt: undefined,
-          portalUrl: "https://chronote.gg/portal/server/guild-1/library",
+          portalUrl: "https://chronote.gg/portal/meetings/guild-1/meeting-key",
           serverId: "guild-1",
           serverName: "Server 1",
           serverIcon: null,

--- a/src/frontend/components/SiteNavbar.tsx
+++ b/src/frontend/components/SiteNavbar.tsx
@@ -139,7 +139,7 @@ export function SiteNavbar({ onClose, pathname }: SiteNavbarProps) {
           {NAV_ITEMS.map((item) => {
             const Icon = item.icon;
             const isActive = item.to
-              ? pathname === item.to
+              ? pathname === item.to || pathname.startsWith(`${item.to}/`)
               : pathname.includes(`/${item.value}`);
             const disabled =
               (item.requiresAuth && authState !== "authenticated") ||

--- a/src/frontend/features/ask/AskMessageBubble.stories.tsx
+++ b/src/frontend/features/ask/AskMessageBubble.stories.tsx
@@ -47,7 +47,7 @@ export const WithCitations: Story = {
   args: {
     message: {
       ...baseMessage,
-      text: "Decision recap with citations. [1](https://chronote.test/portal/server/server-1/library?meetingId=meeting-1)",
+      text: "Decision recap with citations. [1](https://chronote.test/portal/meetings/server-1/meeting-1)",
     },
   },
 };

--- a/src/frontend/layouts/PortalLayout.tsx
+++ b/src/frontend/layouts/PortalLayout.tsx
@@ -164,7 +164,7 @@ export default function PortalLayout() {
               <Stack gap="sm" align="center">
                 <Text fw={600}>Connect Discord to open your portal.</Text>
                 <Text size="sm" c="dimmed" ta="center">
-                  Sign in to select a server and view meeting history.
+                  Sign in to open My Meetings and view meeting history.
                 </Text>
                 <Button
                   component="a"

--- a/src/frontend/layouts/PortalServerLayout.tsx
+++ b/src/frontend/layouts/PortalServerLayout.tsx
@@ -75,6 +75,14 @@ export default function PortalServerLayout() {
         canManageSelectedGuild={canManageSelectedGuild}
         channelNameMap={channelNameMap}
         invalidateMeetingLists={invalidateMeetingLists}
+        onFullScreenChange={(fullScreen) =>
+          (isAskRoute ? navigateAsk : navigateLibrary)({
+            search: (prev) => ({
+              ...prev,
+              fullScreen: fullScreen ? true : undefined,
+            }),
+          })
+        }
         onClose={() =>
           (isAskRoute ? navigateAsk : navigateLibrary)({
             search: (prev) => ({

--- a/src/frontend/pages/MeetingDetail.tsx
+++ b/src/frontend/pages/MeetingDetail.tsx
@@ -1,0 +1,69 @@
+import { useMemo } from "react";
+import { Stack, Text } from "@mantine/core";
+import { useNavigate, useParams } from "@tanstack/react-router";
+import PageHeader from "../components/PageHeader";
+import Surface from "../components/Surface";
+import { useGuildContext } from "../contexts/GuildContext";
+import { useInvalidateMeetingLists } from "../hooks/useInvalidateMeetingLists";
+import { trpc } from "../services/trpc";
+import MeetingDetailDrawer from "./library/components/MeetingDetailDrawer";
+
+export default function MeetingDetail() {
+  const { serverId, meetingId } = useParams({
+    from: "/portal/meetings/$serverId/$meetingId",
+  });
+  const navigate = useNavigate({
+    from: "/portal/meetings/$serverId/$meetingId",
+  });
+  const { guilds } = useGuildContext();
+  const guild = guilds.find((item) => item.id === serverId) ?? null;
+  const canManageSelectedGuild = guild?.canManage === true;
+
+  const channelsQuery = trpc.servers.channels.useQuery(
+    { serverId },
+    { enabled: canManageSelectedGuild },
+  );
+  const channelNameMap = useMemo(() => {
+    const map = new Map<string, string>();
+    const voiceChannels = channelsQuery.data?.voiceChannels ?? [];
+    const textChannels = channelsQuery.data?.textChannels ?? [];
+    [...voiceChannels, ...textChannels].forEach((channel) => {
+      map.set(channel.id, channel.name);
+    });
+    return map;
+  }, [channelsQuery.data]);
+  const invalidateMeetingLists = useInvalidateMeetingLists(serverId);
+
+  return (
+    <Stack gap="lg" data-testid="meeting-detail-page">
+      <PageHeader
+        title="Meeting details"
+        description="A direct link to one meeting you can access from My Meetings."
+      />
+      <Surface p="lg" tone="soft">
+        <Text size="sm" c="dimmed">
+          {guild?.name
+            ? `This meeting belongs to ${guild.name}.`
+            : "This meeting may belong to a server you no longer browse directly."}
+        </Text>
+      </Surface>
+      <MeetingDetailDrawer
+        opened
+        selectedMeetingId={meetingId}
+        selectedGuildId={serverId}
+        canManageSelectedGuild={canManageSelectedGuild}
+        channelNameMap={channelNameMap}
+        invalidateMeetingLists={invalidateMeetingLists}
+        onFullScreenChange={(fullScreen) =>
+          navigate({
+            search: (prev) => ({
+              ...prev,
+              fullScreen: fullScreen ? true : undefined,
+            }),
+          })
+        }
+        onClose={() => navigate({ to: "/portal/meetings" })}
+      />
+    </Stack>
+  );
+}

--- a/src/frontend/pages/MyMeetings.tsx
+++ b/src/frontend/pages/MyMeetings.tsx
@@ -168,9 +168,8 @@ export default function MyMeetings() {
     const meeting = filteredMeetings.find((item) => item.id === meetingId);
     if (!meeting?.serverId) return;
     navigate({
-      to: "/portal/server/$serverId/library",
-      params: { serverId: meeting.serverId },
-      search: { meetingId: meeting.id },
+      to: "/portal/meetings/$serverId/$meetingId",
+      params: { serverId: meeting.serverId, meetingId: meeting.id },
     });
   };
 

--- a/src/frontend/pages/__tests__/MyMeetings.test.tsx
+++ b/src/frontend/pages/__tests__/MyMeetings.test.tsx
@@ -78,15 +78,17 @@ describe("MyMeetings", () => {
     );
   });
 
-  it("opens the existing server library detail route", () => {
+  it("opens the direct meeting detail route", () => {
     renderPage();
 
     fireEvent.click(screen.getByTestId("library-meeting-row"));
 
     expect(mockNavigate).toHaveBeenCalledWith({
-      to: "/portal/server/$serverId/library",
-      params: { serverId: "guild-1" },
-      search: { meetingId: "channel-1#2026-01-02T00:00:00.000Z" },
+      to: "/portal/meetings/$serverId/$meetingId",
+      params: {
+        serverId: "guild-1",
+        meetingId: "channel-1#2026-01-02T00:00:00.000Z",
+      },
     });
   });
 });

--- a/src/frontend/pages/library/components/MeetingDetailDrawer.tsx
+++ b/src/frontend/pages/library/components/MeetingDetailDrawer.tsx
@@ -128,7 +128,7 @@ export default function MeetingDetailDrawer({
   const scheme = useComputedColorScheme("dark");
   const isDark = scheme === "dark";
   const drawerOffset = theme.spacing.sm;
-  const search = useSearch({ strict: false }) as { fullScreen?: boolean };
+  const search = useSearch({ strict: false });
   const fullScreenFromSearch = search.fullScreen === true;
   const trpcUtils = trpc.useUtils();
 

--- a/src/frontend/pages/library/components/MeetingDetailDrawer.tsx
+++ b/src/frontend/pages/library/components/MeetingDetailDrawer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useNavigate, useRouterState, useSearch } from "@tanstack/react-router";
+import { useSearch } from "@tanstack/react-router";
 import type { HTMLAttributes } from "react";
 import {
   ActionIcon,
@@ -94,6 +94,7 @@ type MeetingDetailDrawerProps = {
   canManageSelectedGuild: boolean;
   channelNameMap: Map<string, string>;
   invalidateMeetingLists: () => Promise<void>;
+  onFullScreenChange?: (fullScreen: boolean) => void;
   onClose: () => void;
 };
 
@@ -120,21 +121,14 @@ export default function MeetingDetailDrawer({
   canManageSelectedGuild,
   channelNameMap,
   invalidateMeetingLists,
+  onFullScreenChange,
   onClose,
 }: MeetingDetailDrawerProps) {
   const theme = useMantineTheme();
   const scheme = useComputedColorScheme("dark");
   const isDark = scheme === "dark";
   const drawerOffset = theme.spacing.sm;
-  const navigateAsk = useNavigate({ from: "/portal/server/$serverId/ask" });
-  const navigateLibrary = useNavigate({
-    from: "/portal/server/$serverId/library",
-  });
-  const activeRouteId = useRouterState({
-    select: (state) => state.matches[state.matches.length - 1]?.routeId,
-  });
-  const isAskRoute = activeRouteId === "/portal/server/$serverId/ask";
-  const search = useSearch({ from: "/portal/server/$serverId" });
+  const search = useSearch({ strict: false }) as { fullScreen?: boolean };
   const fullScreenFromSearch = search.fullScreen === true;
   const trpcUtils = trpc.useUtils();
 
@@ -506,12 +500,7 @@ export default function MeetingDetailDrawer({
   const handleToggleFullScreen = () => {
     const next = !fullScreen;
     setFullScreen(next);
-    (isAskRoute ? navigateAsk : navigateLibrary)({
-      search: (prev) => ({
-        ...prev,
-        fullScreen: next ? true : undefined,
-      }),
-    });
+    onFullScreenChange?.(next);
   };
 
   const preflightEndMeeting = async () => {

--- a/src/frontend/router.tsx
+++ b/src/frontend/router.tsx
@@ -28,6 +28,7 @@ const UpgradeSuccess = lazyRouteComponent(
   () => import("./pages/UpgradeSuccess"),
 );
 const MyMeetings = lazyRouteComponent(() => import("./pages/MyMeetings"));
+const MeetingDetail = lazyRouteComponent(() => import("./pages/MeetingDetail"));
 const Library = lazyRouteComponent(() => import("./pages/Library"));
 const Ask = lazyRouteComponent(() => import("./pages/Ask"));
 const PublicAsk = lazyRouteComponent(() => import("./pages/PublicAsk"));
@@ -41,8 +42,6 @@ const AdminFeedback = lazyRouteComponent(() => import("./pages/AdminFeedback"));
 const ContactFeedback = lazyRouteComponent(
   () => import("./pages/ContactFeedback"),
 );
-import { useGuildContext } from "./contexts/GuildContext";
-import { usePortalStore } from "./stores/portalStore";
 
 function RootLayout() {
   return <Outlet />;
@@ -173,24 +172,7 @@ const portalRoute = new Route({
 });
 
 function PortalIndexRedirect() {
-  const { selectedGuildId, guilds } = useGuildContext();
-  const lastServerId = usePortalStore((state) => state.lastServerId);
-  const targetServerId = selectedGuildId || lastServerId;
-  if (targetServerId) {
-    const canManage =
-      guilds.find((guild) => guild.id === targetServerId)?.canManage ?? false;
-    return (
-      <Navigate
-        to={
-          canManage
-            ? "/portal/server/$serverId/library"
-            : "/portal/server/$serverId/ask"
-        }
-        params={{ serverId: targetServerId }}
-      />
-    );
-  }
-  return <Navigate to="/portal/select-server" />;
+  return <Navigate to="/portal/meetings" />;
 }
 
 const portalIndexRoute = new Route({
@@ -210,6 +192,16 @@ const portalMyMeetingsRoute = new Route({
   getParentRoute: () => portalRoute,
   path: "meetings",
   component: MyMeetings,
+});
+
+const portalMeetingDetailRoute = new Route({
+  getParentRoute: () => portalRoute,
+  path: "meetings/$serverId/$meetingId",
+  component: MeetingDetail,
+  validateSearch: z.object({
+    eventId: optionalStringParam,
+    fullScreen: optionalBooleanParam,
+  }).parse,
 });
 
 const portalServerRoute = new Route({
@@ -342,6 +334,7 @@ const routeTree = rootRoute.addChildren([
     portalIndexRoute,
     portalSelectRoute,
     portalMyMeetingsRoute,
+    portalMeetingDetailRoute,
     portalServerRoute.addChildren([
       portalLibraryRoute,
       portalAskRoute,

--- a/src/frontend/utils/__tests__/portalLinks.test.ts
+++ b/src/frontend/utils/__tests__/portalLinks.test.ts
@@ -7,6 +7,20 @@ import {
 describe("portalLinks", () => {
   test("parses portal meeting links", () => {
     const result = parsePortalMeetingLink(
+      "https://chronote.test/portal/meetings/guild-1/voice-1%232026-01-02T00%3A00%3A00.000Z?eventId=line-9&fullScreen=true",
+      "https://chronote.test",
+    );
+
+    expect(result).toEqual({
+      serverId: "guild-1",
+      meetingId: "voice-1#2026-01-02T00:00:00.000Z",
+      eventId: "line-9",
+      fullScreen: true,
+    });
+  });
+
+  test("parses legacy server library meeting links", () => {
+    const result = parsePortalMeetingLink(
       "https://chronote.test/portal/server/guild-1/library?meetingId=meet-1&eventId=line-9&fullScreen=true",
       "https://chronote.test",
     );

--- a/src/frontend/utils/__tests__/portalLinks.test.ts
+++ b/src/frontend/utils/__tests__/portalLinks.test.ts
@@ -33,6 +33,15 @@ describe("portalLinks", () => {
     });
   });
 
+  test("ignores malformed direct meeting path encoding", () => {
+    const result = parsePortalMeetingLink(
+      "https://chronote.test/portal/meetings/guild-1/%E0%A4%A",
+      "https://chronote.test",
+    );
+
+    expect(result).toBeNull();
+  });
+
   test("ignores links without meetingId", () => {
     const result = parsePortalMeetingLink(
       "https://chronote.test/portal/server/guild-1/library",

--- a/src/frontend/utils/portalLinks.ts
+++ b/src/frontend/utils/portalLinks.ts
@@ -5,7 +5,22 @@ export type PortalMeetingLink = {
   fullScreen?: boolean;
 };
 
-const portalServerPath = /^\/portal\/server\/([^/]+)\//;
+const directMeetingPath = /^\/portal\/meetings\/([^/]+)\/([^/]+)$/;
+const legacyPortalServerPath = /^\/portal\/server\/([^/]+)\//;
+
+const resolveFullScreenParam = (value: string | null) =>
+  value === "true" || value === "1" ? true : undefined;
+
+const resolveDirectMeetingLink = (url: URL): PortalMeetingLink | null => {
+  const match = url.pathname.match(directMeetingPath);
+  if (!match) return null;
+  return {
+    serverId: decodeURIComponent(match[1]),
+    meetingId: decodeURIComponent(match[2]),
+    eventId: url.searchParams.get("eventId") ?? undefined,
+    fullScreen: resolveFullScreenParam(url.searchParams.get("fullScreen")),
+  };
+};
 
 export const parsePortalMeetingLink = (
   href: string,
@@ -17,15 +32,16 @@ export const parsePortalMeetingLink = (
   } catch {
     return null;
   }
+  const direct = resolveDirectMeetingLink(url);
+  if (direct) return direct;
+
   const meetingId = url.searchParams.get("meetingId");
   if (!meetingId) return null;
-  const match = url.pathname.match(portalServerPath);
+  const match = url.pathname.match(legacyPortalServerPath);
   if (!match) return null;
   const serverId = match[1];
   const eventId = url.searchParams.get("eventId") ?? undefined;
-  const fullScreenParam = url.searchParams.get("fullScreen");
-  const fullScreen =
-    fullScreenParam === "true" || fullScreenParam === "1" ? true : undefined;
+  const fullScreen = resolveFullScreenParam(url.searchParams.get("fullScreen"));
   return { serverId, meetingId, eventId, fullScreen };
 };
 

--- a/src/frontend/utils/portalLinks.ts
+++ b/src/frontend/utils/portalLinks.ts
@@ -11,12 +11,23 @@ const legacyPortalServerPath = /^\/portal\/server\/([^/]+)\//;
 const resolveFullScreenParam = (value: string | null) =>
   value === "true" || value === "1" ? true : undefined;
 
+const decodePathSegment = (value: string) => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+};
+
 const resolveDirectMeetingLink = (url: URL): PortalMeetingLink | null => {
   const match = url.pathname.match(directMeetingPath);
   if (!match) return null;
+  const serverId = decodePathSegment(match[1]);
+  const meetingId = decodePathSegment(match[2]);
+  if (!serverId || !meetingId) return null;
   return {
-    serverId: decodeURIComponent(match[1]),
-    meetingId: decodeURIComponent(match[2]),
+    serverId,
+    meetingId,
     eventId: url.searchParams.get("eventId") ?? undefined,
     fullScreen: resolveFullScreenParam(url.searchParams.get("fullScreen")),
   };

--- a/src/services/mcpMeetingService.ts
+++ b/src/services/mcpMeetingService.ts
@@ -25,6 +25,7 @@ import type { Participant } from "../types/participants";
 import type { TranscriptPayload } from "../types/transcript";
 import { replaceDiscordMentionsWithDisplayNames } from "../utils/participants";
 import { isMeetingIndexedForUser } from "../utils/meetingUserIndex";
+import { buildPortalMeetingUrl } from "../utils/portalLinks";
 
 const MIN_TIMESTAMP_ISO = "1970-01-01T00:00:00.000Z";
 const MAX_TIMESTAMP_ISO = "9999-12-31T23:59:59.999Z";
@@ -201,8 +202,11 @@ const assertMcpGuildMembership = async (guildId: string, userId: string) => {
 const resolveMcpMeetingAccessContext = async (
   guildId: string,
   userId: string,
+  options: { requireGuildMembership?: boolean } = {},
 ): Promise<McpMeetingAccessContext> => {
-  await assertMcpGuildMembership(guildId, userId);
+  if (options.requireGuildMembership !== false) {
+    await assertMcpGuildMembership(guildId, userId);
+  }
   return {
     attendeeOverrideEnabled: await resolveAttendeeAccessEnabled(guildId),
   };
@@ -214,9 +218,15 @@ const ensureMcpMeetingAccess = async (options: {
   userId: string;
   accessContext?: McpMeetingAccessContext;
 }) => {
+  const indexedForUser = isMeetingIndexedForUser(
+    options.meeting,
+    options.userId,
+  );
   const accessContext =
     options.accessContext ??
-    (await resolveMcpMeetingAccessContext(options.guildId, options.userId));
+    (await resolveMcpMeetingAccessContext(options.guildId, options.userId, {
+      requireGuildMembership: !indexedForUser,
+    }));
   const decision = await checkUserMeetingAccess({
     guildId: options.guildId,
     meeting: options.meeting,
@@ -250,15 +260,6 @@ const resolveChannelMap = async (guildId: string) => {
   }
 };
 
-const buildPortalMeetingUrl = (guildId: string, meetingId: string) => {
-  const url = new URL(
-    `/portal/server/${guildId}/library`,
-    config.frontend.siteUrl,
-  );
-  url.searchParams.set("meetingId", meetingId);
-  return url.toString();
-};
-
 const summarizeMeeting = (
   meeting: MeetingHistory,
   channelMap: Map<string, string>,
@@ -280,10 +281,11 @@ const summarizeMeeting = (
     transcriptAvailable: Boolean(meeting.transcriptS3Key),
     audioAvailable: Boolean(meeting.audioS3Key),
     archivedAt: meeting.archivedAt,
-    portalUrl: buildPortalMeetingUrl(
-      meeting.guildId,
-      meeting.channelId_timestamp,
-    ),
+    portalUrl: buildPortalMeetingUrl({
+      baseUrl: config.frontend.siteUrl,
+      guildId: meeting.guildId,
+      meetingId: meeting.channelId_timestamp,
+    }),
   };
 };
 
@@ -675,23 +677,25 @@ const collectAccessibleUserMeetings = async (input: {
   const allowedMeetings: MeetingHistory[] = [];
 
   for (const meeting of input.meetings) {
-    if (
-      input.mode === "attended" &&
-      !isMeetingIndexedForUser(meeting, input.userId)
-    ) {
+    const indexedForUser = isMeetingIndexedForUser(meeting, input.userId);
+    if (input.mode === "attended" && !indexedForUser) {
       continue;
     }
     if (!meetingMatchesListFilters(meeting, input, requestedTags)) {
       continue;
     }
     try {
-      let accessContext = accessContexts.get(meeting.guildId);
+      const requireGuildMembership =
+        input.mode !== "attended" || !indexedForUser;
+      const accessContextKey = `${meeting.guildId}:${requireGuildMembership}`;
+      let accessContext = accessContexts.get(accessContextKey);
       if (!accessContext) {
         accessContext = await resolveMcpMeetingAccessContext(
           meeting.guildId,
           input.userId,
+          { requireGuildMembership },
         );
-        accessContexts.set(meeting.guildId, accessContext);
+        accessContexts.set(accessContextKey, accessContext);
       }
       await ensureMcpMeetingAccess({
         guildId: meeting.guildId,
@@ -755,14 +759,10 @@ export async function listMcpMyMeetings(input: ListMcpMyMeetingsInput) {
 
   const mode = input.mode ?? "attended";
   const range = resolveMyMeetingsDateRange(input);
-  const servers = filterMcpServers(
-    await listMcpServersForUser(input.userId),
-    input.serverIds,
-  );
-  if (servers.length === 0) return { meetings: [] };
-
-  const serverMap = new Map(servers.map((server) => [server.id, server]));
   const scanLimit = limit * MCP_MEETING_SCAN_LIMIT_MULTIPLIER;
+  const requestedServerIds = input.serverIds?.length
+    ? new Set(input.serverIds)
+    : null;
   const indexedMeetings =
     mode === "attended"
       ? await listIndexedMeetingsForUser({
@@ -773,11 +773,21 @@ export async function listMcpMyMeetings(input: ListMcpMyMeetingsInput) {
         })
       : [];
   const indexedCandidates = compactUniqueMeetings(
-    indexedMeetings.filter((meeting) => serverMap.has(meeting.guildId)),
+    indexedMeetings.filter(
+      (meeting) =>
+        !requestedServerIds || requestedServerIds.has(meeting.guildId),
+    ),
   );
+  const servers = filterMcpServers(
+    await listMcpServersForUser(input.userId),
+    input.serverIds,
+  );
+
+  const serverMap = new Map(servers.map((server) => [server.id, server]));
   const needsRangeFallback =
-    mode === "accessible" ||
-    countMeetingsMatchingListFilters(indexedCandidates, input) < limit;
+    servers.length > 0 &&
+    (mode === "accessible" ||
+      countMeetingsMatchingListFilters(indexedCandidates, input) < limit);
   const rangeMeetings = needsRangeFallback
     ? await listRangeMeetingsForServers({
         servers,
@@ -788,8 +798,9 @@ export async function listMcpMyMeetings(input: ListMcpMyMeetingsInput) {
       })
     : [];
   const candidateMeetings = compactUniqueMeetings(
-    [...indexedCandidates, ...rangeMeetings].filter((meeting) =>
-      serverMap.has(meeting.guildId),
+    [...indexedCandidates, ...rangeMeetings].filter(
+      (meeting) =>
+        !requestedServerIds || requestedServerIds.has(meeting.guildId),
     ),
   );
   const allowedMeetings = await collectAccessibleUserMeetings({

--- a/src/trpc/routers/meetings.ts
+++ b/src/trpc/routers/meetings.ts
@@ -888,7 +888,7 @@ const myList = authedProcedure
     }
   });
 
-const detail = guildMemberProcedure
+const detail = authedProcedure
   .input(
     z.object({
       serverId: z.string(),

--- a/src/utils/portalLinks.ts
+++ b/src/utils/portalLinks.ts
@@ -6,14 +6,17 @@ export function buildPortalMeetingUrl(options: {
   fullScreen?: boolean;
 }) {
   const { baseUrl, guildId, meetingId, eventId, fullScreen } = options;
-  const params = new URLSearchParams({ meetingId });
+  const params = new URLSearchParams();
   if (eventId) {
     params.set("eventId", eventId);
   }
   if (fullScreen) {
     params.set("fullScreen", "true");
   }
-  const path = `/portal/server/${guildId}/library?${params.toString()}`;
+  const query = params.toString();
+  const path = `/portal/meetings/${encodeURIComponent(
+    guildId,
+  )}/${encodeURIComponent(meetingId)}${query ? `?${query}` : ""}`;
   const trimmed = baseUrl.replace(/\/$/, "");
   return `${trimmed}${path}`;
 }

--- a/test/frontend/mocks/mockRouter.tsx
+++ b/test/frontend/mocks/mockRouter.tsx
@@ -10,6 +10,8 @@ import {
 
 type RouteSearch = {
   meetingId?: string;
+  eventId?: string;
+  fullScreen?: boolean | string;
   list?: string;
   conversationId?: string;
   messageId?: string;
@@ -37,6 +39,12 @@ const buildSearchString = () => {
 };
 
 const resolveRouteId = (pathname: string) => {
+  if (
+    pathname.startsWith("/portal/meetings/") &&
+    pathname !== "/portal/meetings"
+  ) {
+    return "/portal/meetings/$serverId/$meetingId";
+  }
   if (pathname.startsWith("/portal/server/")) {
     if (pathname.endsWith("/ask")) return "/portal/server/$serverId/ask";
     if (pathname.endsWith("/library"))

--- a/test/frontend/mocks/routerState.ts
+++ b/test/frontend/mocks/routerState.ts
@@ -9,11 +9,14 @@ export const routerState = {
 };
 export const routeParams: {
   serverId?: string;
+  meetingId?: string;
   conversationId?: string;
   code?: string;
 } = {};
 let routeSearch: {
   meetingId?: string;
+  eventId?: string;
+  fullScreen?: boolean | string;
   list?: string;
   conversationId?: string;
   messageId?: string;
@@ -45,6 +48,7 @@ export const resetNavigateSpy = () => {
 export const resetRouterState = () => {
   routerState.pathname = "/";
   routeParams.serverId = undefined;
+  routeParams.meetingId = undefined;
   routeParams.conversationId = undefined;
   routeParams.code = undefined;
   routeSearch = {};
@@ -57,16 +61,20 @@ export const setRouterPathname = (pathname: string) => {
 
 export const setRouteParams = (params: {
   serverId?: string;
+  meetingId?: string;
   conversationId?: string;
   code?: string;
 }) => {
   routeParams.serverId = params.serverId;
+  routeParams.meetingId = params.meetingId;
   routeParams.conversationId = params.conversationId;
   routeParams.code = params.code;
 };
 
 export const setRouteSearch = (search: {
   meetingId?: string;
+  eventId?: string;
+  fullScreen?: boolean | string;
   list?: string;
   conversationId?: string;
   messageId?: string;

--- a/test/frontend/pages.meetingDetail.test.tsx
+++ b/test/frontend/pages.meetingDetail.test.tsx
@@ -1,8 +1,13 @@
 import React from "react";
 import { beforeEach, describe, expect, test } from "@jest/globals";
 import { screen, waitFor } from "@testing-library/react";
-import { renderWithMantine, resetFrontendMocks } from "./testUtils";
-import { guildState, setRouteParams, setRouterPathname } from "./testUtils";
+import {
+  guildState,
+  renderWithMantine,
+  resetFrontendMocks,
+  setRouteParams,
+  setRouterPathname,
+} from "./testUtils";
 import { setMeetingsDetailQuery } from "./mocks/trpc";
 import MeetingDetail from "../../src/frontend/pages/MeetingDetail";
 

--- a/test/frontend/pages.meetingDetail.test.tsx
+++ b/test/frontend/pages.meetingDetail.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import { screen, waitFor } from "@testing-library/react";
+import { renderWithMantine, resetFrontendMocks } from "./testUtils";
+import { guildState, setRouteParams, setRouterPathname } from "./testUtils";
+import { setMeetingsDetailQuery } from "./mocks/trpc";
+import MeetingDetail from "../../src/frontend/pages/MeetingDetail";
+
+const meetingId = "voice-1#2026-01-02T00:00:00.000Z";
+
+describe("MeetingDetail page", () => {
+  beforeEach(() => {
+    resetFrontendMocks();
+    setRouteParams({ serverId: "guild-1", meetingId });
+    setRouterPathname(
+      `/portal/meetings/guild-1/${encodeURIComponent(meetingId)}`,
+    );
+  });
+
+  test("renders a direct meeting detail route without a selected server", async () => {
+    guildState.guilds = [];
+    setMeetingsDetailQuery({
+      data: {
+        meeting: {
+          id: meetingId,
+          meetingId: "meeting-1",
+          channelId: "voice-1",
+          channelName: "Private sync",
+          timestamp: "2026-01-02T00:00:00.000Z",
+          duration: 3600,
+          tags: ["planning"],
+          notes: "Summary: private planning sync",
+          summarySentence: "Private planning sync.",
+          summaryLabel: "Private sync",
+          audioUrl: null,
+          attendees: ["User A", "User B"],
+          events: [],
+        },
+      },
+    });
+
+    renderWithMantine(<MeetingDetail />);
+
+    expect(screen.getByTestId("meeting-detail-page")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This meeting may belong to a server you no longer browse directly.",
+      ),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getAllByText("Private sync").length).toBeGreaterThan(0);
+    });
+    expect(screen.getByText("Full transcript")).toBeInTheDocument();
+  });
+
+  test("shows access errors from the meeting detail query", async () => {
+    setMeetingsDetailQuery({
+      data: { meeting: null },
+      error: new Error("Meeting access required."),
+    });
+
+    renderWithMantine(<MeetingDetail />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Meeting access required.")).toBeInTheDocument();
+    });
+  });
+});

--- a/test/frontend/router.test.tsx
+++ b/test/frontend/router.test.tsx
@@ -77,7 +77,7 @@ jest.mock("../../src/frontend/stores/portalStore", () => ({
 import { router } from "../../src/frontend/router";
 
 describe("router", () => {
-  test("portal index redirects to selected guild", () => {
+  test("portal index redirects to My Meetings", () => {
     const portalRoute = router.routeTree.children.find(
       (child) => child.path === "portal",
     );
@@ -96,30 +96,20 @@ describe("router", () => {
     portalState.lastServerId = "g2";
     render(<PortalIndexComponent />);
     const node = screen.getByTestId("navigate");
-    expect(node).toHaveAttribute("data-to", "/portal/server/$serverId/library");
-    expect(node).toHaveAttribute("data-server", "g1");
+    expect(node).toHaveAttribute("data-to", "/portal/meetings");
+    expect(node).toHaveAttribute("data-server", "");
   });
 
-  test("portal index redirects to server select when none chosen", () => {
+  test("portal includes direct meeting detail route", () => {
     const portalRoute = router.routeTree.children.find(
       (child) => child.path === "portal",
     );
     if (!portalRoute) {
       throw new Error("Missing portal route");
     }
-    const portalIndex = portalRoute.children.find(
-      (child) => child.path === "/",
+    const detailRoute = portalRoute.children.find(
+      (child) => child.path === "meetings/$serverId/$meetingId",
     );
-    if (!portalIndex || !portalIndex.component) {
-      throw new Error("Missing portal index route");
-    }
-    const PortalIndexComponent = portalIndex.component;
-    guildState.selectedGuildId = null;
-    guildState.guilds = [];
-    portalState.lastServerId = null;
-    render(<PortalIndexComponent />);
-    const node = screen.getByTestId("navigate");
-    expect(node).toHaveAttribute("data-to", "/portal/select-server");
-    expect(node).toHaveAttribute("data-server", "");
+    expect(detailRoute).toBeDefined();
   });
 });

--- a/test/services/askCitations.test.ts
+++ b/test/services/askCitations.test.ts
@@ -66,7 +66,7 @@ describe("askCitations", () => {
 
     expect(rendered).toContain("Decision [1](");
     expect(rendered).toContain(
-      "https://app.example.com/portal/server/guild-1/library?meetingId=voice-1%232025-01-01T00%3A00%3A00.000Z",
+      "https://app.example.com/portal/meetings/guild-1/voice-1%232025-01-01T00%3A00%3A00.000Z",
     );
   });
 

--- a/test/services/mcpMeetingService.test.ts
+++ b/test/services/mcpMeetingService.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, test, jest } from "@jest/globals";
+import type { MeetingHistory } from "../../src/types/db";
+import {
+  getGuildMemberCached,
+  listBotGuildsCached,
+  listGuildChannelsCached,
+} from "../../src/services/discordCacheService";
+import { getMeetingHistoryService } from "../../src/services/meetingHistoryService";
+import { listMeetingUserIndexForUserInRangeService } from "../../src/services/meetingUserIndexService";
+import { checkUserMeetingAccess } from "../../src/services/meetingAccessService";
+import {
+  getMcpMeetingSummary,
+  listMcpMyMeetings,
+} from "../../src/services/mcpMeetingService";
+
+jest.mock("../../src/services/configService", () => ({
+  config: {
+    frontend: { siteUrl: "https://app.example.com" },
+    cache: {
+      enabled: false,
+      keyPrefix: "test",
+      redisUrl: "",
+      referencesTtlSeconds: 60,
+      memorySize: 100,
+      invalidationEnabled: false,
+      defaultTtlSeconds: 60,
+      discord: { membersTtlSeconds: 60 },
+    },
+  },
+}));
+
+jest.mock("../../src/services/discordService", () => ({
+  isDiscordApiError: jest.fn(() => false),
+}));
+
+jest.mock("../../src/services/discordCacheService", () => ({
+  getGuildMemberCached: jest.fn(),
+  listBotGuildsCached: jest.fn(),
+  listGuildChannelsCached: jest.fn(),
+}));
+
+jest.mock("../../src/services/meetingHistoryService", () => ({
+  getMeetingHistoryService: jest.fn(),
+  listMeetingsForGuildInRangeService: jest.fn(),
+  listRecentMeetingsForGuildService: jest.fn(),
+}));
+
+jest.mock("../../src/services/meetingUserIndexService", () => ({
+  listMeetingUserIndexForUserInRangeService: jest.fn(),
+}));
+
+jest.mock("../../src/services/meetingAccessService", () => ({
+  checkUserMeetingAccess: jest.fn(),
+}));
+
+jest.mock("../../src/services/storageService", () => ({
+  fetchJsonFromS3: jest.fn(),
+}));
+
+jest.mock("../../src/services/unifiedConfigService", () => ({
+  resolveConfigSnapshot: jest.fn(async () => ({})),
+  getSnapshotBoolean: jest.fn(() => true),
+}));
+
+const meeting: MeetingHistory = {
+  guildId: "guild-old",
+  channelId_timestamp: "voice-1#2026-01-02T00:00:00.000Z",
+  meetingId: "meeting-1",
+  channelId: "voice-1",
+  timestamp: "2026-01-02T00:00:00.000Z",
+  participants: [{ id: "user-1", username: "Tester" }],
+  duration: 1800,
+  transcribeMeeting: true,
+  generateNotes: true,
+  notes: "Summary: private sync",
+};
+
+describe("mcpMeetingService", () => {
+  const mockedGetGuildMember = jest.mocked(getGuildMemberCached);
+  const mockedListBotGuilds = jest.mocked(listBotGuildsCached);
+  const mockedListGuildChannels = jest.mocked(listGuildChannelsCached);
+  const mockedGetMeetingHistory = jest.mocked(getMeetingHistoryService);
+  const mockedListMeetingUserIndex = jest.mocked(
+    listMeetingUserIndexForUserInRangeService,
+  );
+  const mockedCheckMeetingAccess = jest.mocked(checkUserMeetingAccess);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockedGetGuildMember.mockRejectedValue(new Error("not a member"));
+    mockedListBotGuilds.mockResolvedValue([]);
+    mockedListGuildChannels.mockResolvedValue([]);
+    mockedGetMeetingHistory.mockResolvedValue(meeting);
+    mockedListMeetingUserIndex.mockResolvedValue([
+      {
+        userId: "user-1",
+        userTimestamp: `2026-01-02T00:00:00.000Z#${meeting.guildId}#${meeting.channelId_timestamp}`,
+        guildId: meeting.guildId,
+        channelId_timestamp: meeting.channelId_timestamp,
+        meetingId: meeting.meetingId,
+        timestamp: meeting.timestamp,
+      },
+    ]);
+    mockedCheckMeetingAccess.mockResolvedValue({
+      allowed: true,
+      via: "attendee",
+    });
+  });
+
+  test("lists attended indexed meetings without current server membership", async () => {
+    const result = await listMcpMyMeetings({
+      userId: "user-1",
+      range: "custom",
+      startDate: "2026-01-01T00:00:00.000Z",
+      endDate: "2026-01-03T00:00:00.000Z",
+    });
+
+    expect(result.meetings).toHaveLength(1);
+    expect(result.meetings[0]).toMatchObject({
+      id: meeting.channelId_timestamp,
+      serverId: meeting.guildId,
+      serverName: meeting.guildId,
+      portalUrl:
+        "https://app.example.com/portal/meetings/guild-old/voice-1%232026-01-02T00%3A00%3A00.000Z",
+    });
+    expect(mockedGetGuildMember).not.toHaveBeenCalled();
+  });
+
+  test("fetches an indexed meeting summary without current server membership", async () => {
+    const result = await getMcpMeetingSummary({
+      userId: "user-1",
+      guildId: meeting.guildId,
+      id: meeting.channelId_timestamp,
+    });
+
+    expect(result.meeting.id).toBe(meeting.channelId_timestamp);
+    expect(mockedGetGuildMember).not.toHaveBeenCalled();
+    expect(mockedCheckMeetingAccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        guildId: meeting.guildId,
+        meeting,
+        userId: "user-1",
+      }),
+    );
+  });
+});

--- a/test/trpc/meetingsRouter.test.ts
+++ b/test/trpc/meetingsRouter.test.ts
@@ -218,6 +218,66 @@ describe("meetings router detail", () => {
       }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
+
+  test("uses meeting access checks without requiring current guild membership", async () => {
+    const meetingId = "channel-1#2025-01-01T00:00:00.000Z";
+    const history: MeetingHistory = {
+      guildId: "guild-1",
+      channelId_timestamp: meetingId,
+      meetingId: "meeting-1",
+      channelId: "channel-1",
+      timestamp: "2025-01-01T00:00:00.000Z",
+      participants: [{ id: getMockUser().id, username: "Tester" }],
+      duration: 1800,
+      transcribeMeeting: true,
+      generateNotes: true,
+      notes: "Summary: private sync",
+    };
+    mockedEnsureUserInGuild.mockResolvedValue(false);
+    mockedGetMeetingHistory.mockResolvedValue(history);
+
+    const result = await buildCaller().meetings.detail({
+      serverId: "guild-1",
+      meetingId,
+    });
+
+    expect(result.meeting.id).toBe(meetingId);
+    expect(mockedEnsureUserInGuild).not.toHaveBeenCalled();
+    expect(mockedCheckMeetingAccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        guildId: "guild-1",
+        meeting: history,
+        userId: getMockUser().id,
+      }),
+    );
+  });
+
+  test("throws FORBIDDEN when meeting access denies the direct detail request", async () => {
+    const meetingId = "channel-1#2025-01-01T00:00:00.000Z";
+    mockedGetMeetingHistory.mockResolvedValue({
+      guildId: "guild-1",
+      channelId_timestamp: meetingId,
+      meetingId: "meeting-1",
+      channelId: "channel-1",
+      timestamp: "2025-01-01T00:00:00.000Z",
+      participants: [],
+      duration: 1800,
+      transcribeMeeting: true,
+      generateNotes: true,
+      notes: "Summary: private sync",
+    });
+    mockedCheckMeetingAccess.mockResolvedValueOnce({
+      allowed: false,
+      missing: ["voice_connect"],
+    });
+
+    await expect(
+      buildCaller().meetings.detail({
+        serverId: "guild-1",
+        meetingId,
+      }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
 });
 
 describe("meetings notes correction mutations", () => {

--- a/test/utils/portalLinks.test.ts
+++ b/test/utils/portalLinks.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "@jest/globals";
+import { buildPortalMeetingUrl } from "../../src/utils/portalLinks";
+
+describe("portalLinks", () => {
+  test("builds direct meeting detail URLs", () => {
+    const url = buildPortalMeetingUrl({
+      baseUrl: "https://app.example.com/",
+      guildId: "guild-1",
+      meetingId: "voice-1#2026-01-02T00:00:00.000Z",
+      eventId: "line-9",
+      fullScreen: true,
+    });
+
+    expect(url).toBe(
+      "https://app.example.com/portal/meetings/guild-1/voice-1%232026-01-02T00%3A00%3A00.000Z?eventId=line-9&fullScreen=true",
+    );
+  });
+});


### PR DESCRIPTION
[AGENT] Closes #199.

## Summary
- Route authenticated portal entry to My Meetings.
- Add direct meeting detail URLs for authorized participant access without server browsing context.
- Update MCP, citations, docs, and tests to use the user-centric meeting route.

## Testing
- `yarn test --runInBand`
- `yarn build`
- `yarn build:web`
- `yarn lint:check`
- `yarn docs:check`
- `yarn prettier:check`
- `yarn test-storybook`

## Risk Notes
- Meeting detail access now relies on meeting access checks rather than route-level current guild membership.
- Legacy server Library meeting links remain parseable in the frontend.