### PR TITLE
[AGENT] Clarify portal entry navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ Coverage update rule:
 - Public product docs use Docusaurus under `apps/docs-site`, builds to `build/docs-site/`.
 - Routing/data/state: TanStack Router + TanStack Query + tRPC + Zustand.
 - Marketing site is public at `/`; the authenticated portal lives under `/portal/*`:
+  - `/portal` -> `/portal/meetings`
+  - `/portal/meetings`
+  - `/portal/meetings/:serverId/:meetingId`
   - `/portal/select-server`
   - `/portal/server/:serverId/{library|ask|billing|settings}`
 - Upgrade flow entry points live under `/upgrade`, `/promo/:code`, and `/upgrade/select-server` with a success page at `/upgrade/success`. See `docs/upgrade-flow.md` for details and planned short-link support.

--- a/apps/docs-site/docs/admin/setup-and-access.md
+++ b/apps/docs-site/docs/admin/setup-and-access.md
@@ -100,7 +100,7 @@ Chronote needs these Discord permissions:
 
 ### Web portal access
 
-The web portal uses Discord OAuth. Users land on **My Meetings** first, then can open direct meeting links or browse Server Library for one server at a time. Users see meetings from channels they have access to in Discord. Attendees of a meeting can always view it regardless of current channel permissions.
+The web portal uses Discord OAuth. Users land on **My Meetings** first, then can open direct meeting links or use **View servers** to browse Server Library for one server at a time. Users see meetings from channels they have access to in Discord. Attendees of a meeting can always view it regardless of current channel permissions.
 
 ## Operational recommendations
 

--- a/apps/docs-site/docs/features/feature-overview.md
+++ b/apps/docs-site/docs/features/feature-overview.md
@@ -194,7 +194,7 @@ The Chronote web portal provides a browser-based interface for:
 - Importing Markdown or plain-text notes from another app.
 - Managing server settings (context, dictionary, auto-record, Notion automation).
 
-Access the portal from the **Open in Chronote** button on any meeting summary, or open the portal directly to start from **My Meetings**. Server Library remains available when you want to browse one server at a time.
+Access the portal from the **Open in Chronote** button on any meeting summary, or open the portal directly to start from **My Meetings**. Use **View servers** or the server switcher when you want to choose a server for Library, Ask, Billing, or Settings.
 
 ## Context menu commands
 

--- a/apps/docs-site/docs/integrations/overview.md
+++ b/apps/docs-site/docs/integrations/overview.md
@@ -9,7 +9,7 @@ Chronote integrations extend meeting data into external tools and workflows.
 
 ### Web portal
 
-Chronote includes a built-in web portal for browsing meetings, reading transcripts, sharing links, and managing settings. The portal opens to **My Meetings** by default, and the **Open in Chronote** button on a meeting summary opens that meeting directly.
+Chronote includes a built-in web portal for browsing meetings, reading transcripts, sharing links, and managing settings. **Open portal** opens **My Meetings** by default, and the **Open in Chronote** button on a meeting summary opens that meeting directly. Choose **View servers** when you need a server-scoped Library, Ask, Billing, or Settings view.
 
 The portal authenticates through Discord OAuth so channel permissions are respected.
 

--- a/apps/docs-site/docs/troubleshooting/common-issues.md
+++ b/apps/docs-site/docs/troubleshooting/common-issues.md
@@ -85,7 +85,7 @@ Use this page to diagnose and fix common Chronote issues. Each section describes
 **Causes and fixes**:
 
 1. **Filters hide the meeting.** **My Meetings** opens by default and includes range, server, tag, and archive filters. Clear filters or switch the range to Last 30 days.
-2. **Wrong server selected.** Server Library scopes to one server. Use **My Meetings** for a cross-server view, or choose the expected server from the server selector.
+2. **Wrong server selected.** Server Library scopes to one server. Use **My Meetings** for a cross-server view, or choose **View servers** to open the expected server.
 3. **Channel permissions.** The portal respects Discord channel permissions. You only see meetings from channels you can access, plus meetings you attended when attendee access is enabled.
 4. **No meetings recorded yet.** Meetings appear after at least one meeting has been completed successfully.
 

--- a/src/frontend/components/SiteHeader.tsx
+++ b/src/frontend/components/SiteHeader.tsx
@@ -57,6 +57,7 @@ type PortalCtaProps = {
   showPortalCta: boolean;
   authState: AuthState;
   portalLabel: string;
+  portalPath: string;
   loginUrl: string;
   loading: boolean;
   isMobile: boolean;
@@ -66,6 +67,7 @@ function PortalCtaButton({
   showPortalCta,
   authState,
   portalLabel,
+  portalPath,
   loginUrl,
   loading,
   isMobile,
@@ -79,7 +81,7 @@ function PortalCtaButton({
   };
   if (authState === "authenticated") {
     return (
-      <Button component={Link} to="/portal/select-server" {...sharedProps}>
+      <Button component={Link} to={portalPath} {...sharedProps}>
         {portalLabel}
       </Button>
     );
@@ -168,6 +170,7 @@ type HeaderActionsProps = {
   showPortalCta: boolean;
   authState: AuthState;
   portalLabel: string;
+  portalPath: string;
   loginUrl: string;
   loading: boolean;
   user: AuthUser;
@@ -183,6 +186,7 @@ function HeaderActions({
   showPortalCta,
   authState,
   portalLabel,
+  portalPath,
   loginUrl,
   loading,
   user,
@@ -199,6 +203,7 @@ function HeaderActions({
         showPortalCta={showPortalCta}
         authState={authState}
         portalLabel={portalLabel}
+        portalPath={portalPath}
         loginUrl={loginUrl}
         loading={loading}
         isMobile={isMobile}
@@ -280,6 +285,7 @@ export function SiteHeader({
     authState === "authenticated" && context === "portal"
       ? "Switch server"
       : "Open portal";
+  const portalPath = context === "portal" ? "/portal/select-server" : "/portal";
   const isSuperAdmin =
     authState === "authenticated" && Boolean(user?.isSuperAdmin);
   const headerPaddingRight = isMobile ? theme.spacing.xs : theme.spacing.sm;
@@ -291,6 +297,7 @@ export function SiteHeader({
       showPortalCta={showPortalCta}
       authState={authState}
       portalLabel={portalLabel}
+      portalPath={portalPath}
       loginUrl={loginUrl}
       loading={loading}
       user={user}

--- a/src/frontend/contexts/AuthContext.tsx
+++ b/src/frontend/contexts/AuthContext.tsx
@@ -24,7 +24,7 @@ const getBrowserLocation = (): Location | undefined =>
 
 const resolvePortalRedirect = (location?: Location) => {
   if (!location) {
-    return "/portal/select-server";
+    return "/portal";
   }
   const pathname = location.pathname;
   const useCurrentLocation =
@@ -35,7 +35,7 @@ const resolvePortalRedirect = (location?: Location) => {
   if (useCurrentLocation) {
     return location.href;
   }
-  return `${location.origin}/portal/select-server`;
+  return `${location.origin}/portal`;
 };
 
 const resolveLogoutRedirect = (location?: Location) => {

--- a/src/frontend/features/library/MeetingList.stories.tsx
+++ b/src/frontend/features/library/MeetingList.stories.tsx
@@ -94,6 +94,17 @@ export const Empty: Story = {
   },
 };
 
+export const EmptyWithAction: Story = {
+  args: {
+    items: [],
+    emptyTitle: "No meetings found here yet.",
+    emptyDescription:
+      "Choose a server to browse its Library, Ask threads, billing, and settings.",
+    emptyActionLabel: "View servers",
+    onEmptyAction: () => undefined,
+  },
+};
+
 export const Archived: Story = {
   args: {
     items: archivedItems,

--- a/src/frontend/features/library/MeetingList.tsx
+++ b/src/frontend/features/library/MeetingList.tsx
@@ -2,6 +2,7 @@
   ActionIcon,
   Badge,
   Box,
+  Button,
   Center,
   Group,
   Loader,
@@ -46,6 +47,11 @@ type MeetingListProps = {
   listError: boolean;
   onSelect: (meetingId: string) => void;
   selectedMeetingId: string | null;
+  emptyTitle?: string;
+  emptyDescription?: string;
+  emptyActionLabel?: string;
+  onEmptyAction?: () => void;
+  emptyActionTestId?: string;
 };
 
 export function MeetingList({
@@ -54,6 +60,11 @@ export function MeetingList({
   listError,
   onSelect,
   selectedMeetingId,
+  emptyTitle = "No meetings match these filters yet.",
+  emptyDescription,
+  emptyActionLabel,
+  onEmptyAction,
+  emptyActionTestId,
 }: MeetingListProps) {
   return (
     <Surface
@@ -80,7 +91,23 @@ export function MeetingList({
             <ThemeIcon variant="light" color="gray">
               <IconFilter size={16} />
             </ThemeIcon>
-            <Text c="dimmed">No meetings match these filters yet.</Text>
+            <Text c="dimmed">{emptyTitle}</Text>
+            {emptyDescription ? (
+              <Text c="dimmed" size="sm" ta="center">
+                {emptyDescription}
+              </Text>
+            ) : null}
+            {emptyActionLabel && onEmptyAction ? (
+              <Button
+                variant="light"
+                color="brand"
+                size="sm"
+                onClick={onEmptyAction}
+                data-testid={emptyActionTestId}
+              >
+                {emptyActionLabel}
+              </Button>
+            ) : null}
           </Stack>
         </Center>
       ) : (

--- a/src/frontend/pages/Join.tsx
+++ b/src/frontend/pages/Join.tsx
@@ -147,7 +147,7 @@ export default function Join() {
             {authState === "authenticated" ? (
               <Button
                 component={Link}
-                to="/portal/select-server"
+                to="/portal"
                 variant="light"
                 color="brand"
                 size="sm"

--- a/src/frontend/pages/MyMeetings.tsx
+++ b/src/frontend/pages/MyMeetings.tsx
@@ -172,6 +172,9 @@ export default function MyMeetings() {
       params: { serverId: meeting.serverId, meetingId: meeting.id },
     });
   };
+  const openServerSelect = () => {
+    navigate({ to: "/portal/select-server" });
+  };
 
   return (
     <Stack gap="lg" data-testid="my-meetings-page">
@@ -269,6 +272,11 @@ export default function MyMeetings() {
         listError={Boolean(meetingsQuery.error)}
         onSelect={openMeeting}
         selectedMeetingId={null}
+        emptyTitle="No meetings found here yet."
+        emptyDescription="Choose a server to browse its Library, Ask threads, billing, and settings."
+        emptyActionLabel="View servers"
+        onEmptyAction={openServerSelect}
+        emptyActionTestId="my-meetings-view-servers"
       />
     </Stack>
   );

--- a/src/frontend/pages/UpgradeSuccess.test.tsx
+++ b/src/frontend/pages/UpgradeSuccess.test.tsx
@@ -108,8 +108,8 @@ describe("resolveOpenPortalPath", () => {
     expect(resolveOpenPortalPath("s1", [])).toBe("/portal/server/s1/ask");
   });
 
-  it("falls back to select-server when no server is present", () => {
-    expect(resolveOpenPortalPath("", [])).toBe("/portal/select-server");
+  it("falls back to the portal home when no server is present", () => {
+    expect(resolveOpenPortalPath("", [])).toBe("/portal");
   });
 });
 
@@ -144,7 +144,7 @@ describe("resolvePostAuthPortalPath", () => {
     ).toBe("/portal/server/s1/ask");
   });
 
-  it("falls back to select-server when server id is missing", () => {
-    expect(resolvePostAuthPortalPath("", [])).toBe("/portal/select-server");
+  it("falls back to the portal home when server id is missing", () => {
+    expect(resolvePostAuthPortalPath("", [])).toBe("/portal");
   });
 });

--- a/src/frontend/pages/UpgradeSuccess.test.tsx
+++ b/src/frontend/pages/UpgradeSuccess.test.tsx
@@ -124,7 +124,7 @@ describe("resolveBillingPath", () => {
     );
   });
 
-  it("falls back to select-server when server id is missing", () => {
+  it("falls back to server selection when server id is missing", () => {
     expect(resolveBillingPath("")).toBe("/portal/select-server");
   });
 });

--- a/src/frontend/pages/UpgradeSuccess.tsx
+++ b/src/frontend/pages/UpgradeSuccess.tsx
@@ -191,10 +191,14 @@ export const resolvePostAuthPortalPath = (
   return `/portal/server/${encodedServerId}/library`;
 };
 
-export const resolveBillingPath = (serverId: string) =>
-  serverId
-    ? `/portal/server/${encodeServerId(serverId)}/billing`
-    : "/portal/select-server";
+export const resolveBillingPath = (serverId: string) => {
+  if (serverId) {
+    return `/portal/server/${encodeServerId(serverId)}/billing`;
+  }
+
+  // Billing is server-scoped, so missing server context needs explicit selection.
+  return "/portal/select-server";
+};
 
 const buildConfettiPieceStyle = (
   piece: (typeof CONFETTI_PIECES)[number],

--- a/src/frontend/pages/UpgradeSuccess.tsx
+++ b/src/frontend/pages/UpgradeSuccess.tsx
@@ -156,7 +156,7 @@ const resolvePrimaryActionLabel = (serverId: string, serverName: string) => {
 
 export const resolveOpenPortalPath = (serverId: string, guilds: Guild[]) => {
   if (!serverId) {
-    return "/portal/select-server";
+    return "/portal";
   }
 
   const encodedServerId = encodeServerId(serverId);
@@ -178,7 +178,7 @@ export const resolvePostAuthPortalPath = (
   guilds: Guild[],
 ) => {
   if (!serverId) {
-    return "/portal/select-server";
+    return "/portal";
   }
 
   const encodedServerId = encodeServerId(serverId);

--- a/src/frontend/pages/__tests__/MyMeetings.test.tsx
+++ b/src/frontend/pages/__tests__/MyMeetings.test.tsx
@@ -91,4 +91,22 @@ describe("MyMeetings", () => {
       },
     });
   });
+
+  it("offers server selection from the empty state", () => {
+    mockMyListUseQuery.mockReturnValue({
+      data: { meetings: [] },
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    renderPage();
+
+    expect(screen.getByText("No meetings found here yet.")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("my-meetings-view-servers"));
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: "/portal/select-server",
+    });
+  });
 });

--- a/test/frontend/authContext.test.tsx
+++ b/test/frontend/authContext.test.tsx
@@ -87,7 +87,7 @@ describe("AuthContext unauthenticated", () => {
     const resolved = new URL(loginUrl, window.location.origin);
     expect(resolved.pathname).toBe("/auth/discord");
     expect(resolved.searchParams.get("redirect")).toBe(
-      `${window.location.origin}/portal/select-server`,
+      `${window.location.origin}/portal`,
     );
     const logoutUrl = node.getAttribute("data-logout");
     if (!logoutUrl) {

--- a/test/frontend/components.test.tsx
+++ b/test/frontend/components.test.tsx
@@ -190,10 +190,11 @@ describe("frontend components", () => {
   });
 
   test("renders SiteHeader CTA and theme toggle", () => {
+    authState.state = "authenticated";
     renderWithMantine(
       <SiteHeader navbarOpened={false} onNavbarToggle={() => {}} />,
     );
-    expect(screen.getByTestId("portal-cta")).toBeInTheDocument();
+    expect(screen.getByTestId("portal-cta")).toHaveAttribute("to", "/portal");
     expect(screen.getByTestId("theme-toggle")).toBeInTheDocument();
   });
 
@@ -212,6 +213,10 @@ describe("frontend components", () => {
       />,
     );
     expect(screen.getByText("Switch server")).toBeInTheDocument();
+    expect(screen.getByTestId("portal-cta")).toHaveAttribute(
+      "to",
+      "/portal/select-server",
+    );
     expect(screen.getByLabelText("Close navigation")).toBeInTheDocument();
     const logoutButton = screen.getByTestId("logout-cta");
     expect(logoutButton).toHaveAttribute("href", authState.logoutUrl);

--- a/test/frontend/pages.join.test.tsx
+++ b/test/frontend/pages.join.test.tsx
@@ -1,0 +1,22 @@
+import "./mocks/mockFrontendContexts";
+import "./mocks/mockRouter";
+import React from "react";
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import { screen } from "@testing-library/react";
+import Join from "../../src/frontend/pages/Join";
+import { authState, renderWithMantine, resetFrontendMocks } from "./testUtils";
+
+describe("Join page", () => {
+  beforeEach(resetFrontendMocks);
+
+  test("opens the portal home for authenticated users", () => {
+    authState.state = "authenticated";
+
+    renderWithMantine(<Join />);
+
+    expect(screen.getByText("Open portal").closest("a")).toHaveAttribute(
+      "to",
+      "/portal",
+    );
+  });
+});


### PR DESCRIPTION
[AGENT]

Closes #202.

## Summary

- Route generic `Open portal` entry points and default auth redirects to `/portal`, preserving portal-context `Switch server` as the explicit server selector.
- Add a `View servers` action to the My Meetings empty state while keeping Library's default empty state unchanged.
- Update public docs and README route notes to describe My Meetings as portal home and server selection as an explicit journey.

## Validation

- `yarn lint:check`
- `yarn prettier:check`
- `yarn build`
- `yarn build:web`
- `yarn docs:check`
- `yarn test --runInBand`
- `yarn test-storybook`
- `yarn test:visual`
- `git diff --check`

## Notes

- Initial Windows dependency install hit the native `@discordjs/opus` build path under Node 24. Re-running `yarn install --frozen-lockfile --ignore-scripts` completed dependency setup for the frontend/docs/test checks in this worktree.