### PR TITLE
[AGENT] Add Remote MCP live controls

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Copilot Review Instructions
 
-This file provides Copilot review context. It mirrors AGENTS.md and adds only high level prompt guidance to avoid drift.
+This file provides Copilot review context. AGENTS.md remains the source of truth; keep this file high level to avoid drift.
 
 ## AGENTS.md (source of truth)
 
@@ -17,7 +17,7 @@ This file provides Copilot review context. It mirrors AGENTS.md and adds only hi
 - Discord: discord.js v14, discord-api-types, @discordjs/voice for audio capture, @discordjs/opus, prism-media.
 - AI: openai SDK; gpt-4o-transcribe for transcription; gpt-5.1 for cleanup/notes/corrections; gpt-5-mini for live gate; DALL-E 3 for images.
 - Observability and prompt management: Langfuse for tracing, prompt versioning, and prompt sync scripts.
-- Storage: AWS DynamoDB (tables: GuildSubscription, PaymentTransaction, StripeWebhookEvent, InteractionReceipt, ActiveMeeting, AccessLogs, RecordingTranscript, AutoRecordSettings, SessionTable, Installer, OnboardingState, AskConversation, Feedback, ServerContext, ChannelContext, DictionaryTable, UserSpeechSettings, MeetingHistory, MeetingUserIndex, MeetingShare, McpOAuthTable), S3 for transcripts/audio.
+- Storage: AWS DynamoDB (tables: GuildSubscription, PaymentTransaction, StripeWebhookEvent, InteractionReceipt, ActiveMeeting, MeetingControlCommand, AccessLogs, RecordingTranscript, AutoRecordSettings, ServerContext, ChannelContext, DictionaryTable, MeetingHistory, MeetingUserIndex, SessionTable, McpOAuthTable, NotionIntegrationTable), S3 for transcripts/audio.
 - Infra: Terraform -> AWS ECS Fargate, ECR, CloudWatch logs; static frontend on S3 + CloudFront with OAC; local Dynamo via docker-compose.
 - IaC scanning: Checkov runs in `.github/workflows/ci.yml` on PRs and main pushes. Local: `npm run checkov` (uses `uvx --from checkov checkov`; install uv first: https://docs.astral.sh/uv/).
 - Known/suppressed infra choices:
@@ -36,6 +36,7 @@ This file provides Copilot review context. It mirrors AGENTS.md and adds only hi
   - Buttons: end meeting, generate image, suggest correction.
   - Auto-record on voice join if configured.
 - Web server: `webserver.ts` (health check; optional Discord OAuth scaffolding). API routes are modularized under `src/api/` (billing, guilds, MCP) and share services with bot commands (ask/context/autorecord/billing).
+- Remote MCP live controls enqueue meeting control commands in DynamoDB so API-only and bot runtimes can be split. Bot workers claim start/stop/live-status/live-transcript commands from `MeetingControlCommandTable`; live meeting owner-specific commands target the active lease owner instance.
 - Frontend: `src/frontend/` (Vite + React 19), builds to `build/frontend/`, deployed to S3/CloudFront. Express only handles API/health; static assets served via CDN.
 - Public docs site: `apps/docs-site/` (Docusaurus), builds to `build/docs-site/`, deployed to S3/CloudFront at `docs.chronote.gg`.
 - Dev/QA commands: `yarn start` (bot via nodemon+ts-node), `yarn dev` (starts local Dynamo + init + bot), `yarn frontend:dev`, `yarn docs:dev`, `yarn build`, `yarn build:web`, `yarn build:all`, `yarn docs:build`, `yarn docs:check`, `yarn test`, `yarn lint`, `yarn prettier`, `yarn terraform:init|plan|apply`, `yarn prompts:push`, `yarn prompts:pull`, `yarn prompts:check`.
@@ -50,8 +51,8 @@ This file provides Copilot review context. It mirrors AGENTS.md and adds only hi
 - Dictionary management: `commands/dictionary.ts`, `services/dictionaryService.ts`
   - Terms are injected into transcription and context prompts, definitions are used outside transcription to reduce prompt bloat.
 - Notes correction flow: `commands/notesCorrections.ts`
-  - â€œSuggest correctionâ€ button â†’ modal (single textarea).
-  - Fetches saved notes + transcript from DB, calls GPT-4o with a â€œminimal edits, do not copy transcriptâ€ prompt, shows a compact line diff, requires approval (meeting creator or ManageChannels if auto-record), updates embed + MeetingHistory and bumps version/last editor.
+  - "Suggest correction" button -> modal (single textarea).
+  - Fetches saved notes + transcript from DB, calls GPT-4o with a "minimal edits, do not copy transcript" prompt, shows a compact line diff, requires approval (meeting creator or ManageChannels if auto-record), updates embed + MeetingHistory and bumps version/last editor.
 - Context management: `commands/context.ts` writes/reads ServerContext and ChannelContext.
 - Meeting history persistence: `commands/saveMeetingHistory.ts`, `db.ts` helpers.
 - Web server: `webserver.ts` (health check, optional Discord OAuth scaffolding).
@@ -80,6 +81,7 @@ This file provides Copilot review context. It mirrors AGENTS.md and adds only hi
 - ServerContext / ChannelContext store prompt context.
 - AutoRecordSettings enable record-all or per-channel auto-start.
 - McpOAuthTable stores hashed remote MCP OAuth clients, authorization codes, tokens, and user consents.
+- MeetingControlCommand stores short-lived queued MCP meeting control requests and results for bot workers.
 
 ## Frontend
 
@@ -100,7 +102,7 @@ This file provides Copilot review context. It mirrors AGENTS.md and adds only hi
 
 ## Known nuances / gotchas
 
-- Token leaks: donâ€™t reintroduce secret re-exports in `constants.ts`; use `configService`.
+- Token leaks: don't reintroduce secret re-exports in `constants.ts`; use `configService`.
 - Discord interaction timing: modal/button handlers must reply within 3s; correction flow already uses direct replies.
 - Diff output is intentionally minimal (line diff, capped length); LLM output is stripped of code fences to avoid code-block embeds.
 - Meeting duration capped at 2h (`MAXIMUM_MEETING_DURATION`).
@@ -118,7 +120,7 @@ This file provides Copilot review context. It mirrors AGENTS.md and adds only hi
 - Avoid hedging and speculative fallbacks. Follow YAGNI and KISS, do not add code for hypothetical cases unless explicitly required.
 - Config constraints: when numeric settings depend on caps, use minKey/maxKey to reference other config entries, clamp inputs in the UI, and enforce bounds in API validation.
 - Playwright mock mode: ensure only the mock API (port 3001) and frontend dev server (port 5173) are running. If ports are occupied, stop them first (`Get-NetTCPConnection -LocalPort 3001,5173 | Select-Object -ExpandProperty OwningProcess -Unique | ForEach-Object { Stop-Process -Id $_ }`). Clear `VITE_API_BASE_URL` (for example via `.env.local`) so the frontend uses the mock server.
-- Comment hygiene: donâ€™t leave transient or change-log style comments (e.g., â€œSDK v3 exposes transformToStringâ€). Use comments only to clarify non-obvious logic, constraints, or intent.
+- Comment hygiene: don't leave transient or change-log style comments (e.g., "SDK v3 exposes transformToString"). Use comments only to clarify non-obvious logic, constraints, or intent.
 - Writing style: do not use em dashes in copy/docs/comments; prefer commas, parentheses, or hyphens.
 - **User data in public outputs (CRITICAL):** This is a public repository. NEVER include real user data (Discord usernames, IDs, meeting content, server names, etc.) in PR descriptions, commit messages, issues, comments, or any publicly visible content. Use generic placeholders (e.g., "User A", "Server X") to preserve meaning while stripping all PII.
 - Documentation accuracy: after changes that affect behavior, config, prompts, infra, or user flows, review and update `AGENTS.md`, `.github/copilot-instructions.md`, `README.md`, and any related `docs/` or prompt files to keep them accurate and high signal. Keep the copilot instructions high level to reduce drift.
@@ -128,7 +130,7 @@ This file provides Copilot review context. It mirrors AGENTS.md and adds only hi
 - Backwards compatibility update (January 6, 2026): prioritize DynamoDB data compatibility; URLs and UI flows can change without preserving prior behavior.
 - Workflow sync: when changing GitHub Actions env or steps, review `.github/workflows/ci.yml`, `.github/workflows/deploy.yml`, and `.github/workflows/deploy-staging.yml` to keep them aligned.
 - ADRs: use the existing ADR format (see `docs/adr-20260106-voice-receiver-resubscribe.md`). New ADRs must live in `docs/` with filename `adr-YYYYMMDD-<slug>.md` and include Status, Date, Owners, Context, Decision, Consequences, Alternatives Considered, and Notes. Keep ADRs short and factual. Update or add ADRs when a design decision changes behavior or data contracts.
-- â€œRemember that â€¦â€ shorthand: when the user says â€œremember that <rule>â€, add it to AGENTS.md under the relevant section as a standing rule.
+- "Remember that ..." shorthand: when the user says "remember that <rule>", add it to AGENTS.md under the relevant section as a standing rule.
 - Do not suppress runtime warnings by monkey-patching globals (e.g., overriding console.error). Fix the underlying issue or accept the warning; never silence it via code hacks.
 - Stripe webhook parsing: keep a single `express.raw({ type: "application/json" })` at app-level in `webserver.ts`; do not add per-route raw parsers elsewhere.
 - React tests: when a test triggers state updates (e.g., data-fetching effects), wrap renders/updates in `act` (from `react`/RTL helpers) to avoid act warnings instead of silencing console errors.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 - Discord: discord.js v14, discord-api-types, @discordjs/voice for audio capture, @discordjs/opus, prism-media.
 - AI: openai SDK; gpt-4o-transcribe for transcription; gpt-5.1 for cleanup/notes/corrections; gpt-5-mini for live gate; DALL-E 3 for images.
 - Observability and prompt management: Langfuse for tracing, prompt versioning, and prompt sync scripts. AMG (Grafana) service account token is auto-rotated via EventBridge + Lambda (see `_infra/grafana.tf` and `_infra/README.md`). Critical alerts (ECS down, ALB 5xx, unhealthy hosts, rotation failures) are sent via SNS email and optionally to a Discord channel via a separate Node.js Lambda (see `_infra/notifications.tf` and `_infra/README.md`).
-- Storage: AWS DynamoDB (tables: GuildSubscription, PaymentTransaction, StripeWebhookEvent, InteractionReceipt, ActiveMeeting, AccessLogs, RecordingTranscript, AutoRecordSettings, ServerContext, ChannelContext, DictionaryTable, MeetingHistory, MeetingUserIndex, SessionTable, McpOAuthTable, NotionIntegrationTable), S3 for transcripts/audio.
+- Storage: AWS DynamoDB (tables: GuildSubscription, PaymentTransaction, StripeWebhookEvent, InteractionReceipt, ActiveMeeting, MeetingControlCommand, AccessLogs, RecordingTranscript, AutoRecordSettings, ServerContext, ChannelContext, DictionaryTable, MeetingHistory, MeetingUserIndex, SessionTable, McpOAuthTable, NotionIntegrationTable), S3 for transcripts/audio.
 - Infra: Terraform -> AWS ECS Fargate, ECR, CloudWatch logs; static frontend on S3 + CloudFront with OAC; local Dynamo via docker-compose.
 - IaC scanning: Checkov runs in `.github/workflows/ci.yml` on PRs and main pushes. Local: `npm run checkov` (uses `uvx --from checkov checkov`; install uv first: https://docs.astral.sh/uv/).
 - Known/suppressed infra choices:
@@ -30,6 +30,7 @@
   - Buttons: end meeting, generate image, suggest correction.
   - Auto-record on voice join if configured.
 - Web server: `webserver.ts` (health check; optional Discord OAuth scaffolding). API routes are modularized under `src/api/` (billing, guilds, MCP) and share services with bot commands (ask/context/autorecord/billing).
+- Remote MCP live controls enqueue meeting control commands in DynamoDB so API-only and bot runtimes can be split. Bot workers claim start/stop/live-status/live-transcript commands from `MeetingControlCommandTable`; live meeting owner-specific commands target the active lease owner instance.
 - Frontend: `src/frontend/` (Vite + React 19), builds to `build/frontend/`, deployed to S3/CloudFront. Express only handles API/health; static assets served via CDN.
 - Public docs site: `apps/docs-site/` (Docusaurus), builds to `build/docs-site/`, deployed to S3/CloudFront at `docs.chronote.gg`.
 - Dev/QA commands: `yarn start` (bot via nodemon+ts-node), `yarn dev` (starts local Dynamo + init + bot), `yarn frontend:dev`, `yarn docs:dev`, `yarn build`, `yarn build:web`, `yarn build:all`, `yarn docs:build`, `yarn docs:check`, `yarn test`, `yarn lint`, `yarn prettier`, `yarn terraform:init|plan|apply`, `yarn prompts:push`, `yarn prompts:pull`, `yarn prompts:check`.
@@ -76,6 +77,7 @@
 - ServerContext / ChannelContext store prompt context.
 - AutoRecordSettings enable record-all or per-channel auto-start.
 - McpOAuthTable stores hashed MCP OAuth clients, authorization codes, tokens, and user consents. Access tokens are resource-bound to the configured MCP endpoint and scopes are enforced per tool.
+- MeetingControlCommand stores short-lived queued MCP meeting control requests and results. Pending commands are claimed by bot workers via `StatusCreatedAtIndex`; commands targeting an active meeting owner include `targetOwnerInstanceId`.
 - NotionIntegrationTable stores per-user Notion connection metadata and per-user meeting export mappings, plus server-scoped automation config/export/reservation records keyed under `GUILD#guildId`. Notion access and refresh tokens are encrypted before persistence.
 
 ## Frontend

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A Discord bot that records voice meetings, transcribes them with OpenAI, generat
 
 - Discord summary/notes messages follow Discord channel permissions.
 - Portal Library, My Meetings, and Ask also follow Discord channel permissions (voice connect + notes channel history), with an attendee exception.
-- Remote MCP uses Discord OAuth and the same meeting access checks before returning meeting data to agents.
+- Remote MCP uses Discord OAuth and scoped consent for meeting data, live meeting start/stop controls, and live transcript access.
 - Details: `docs/meeting-access.md`
 
 ## Run locally

--- a/_infra/main.tf
+++ b/_infra/main.tf
@@ -1340,6 +1340,8 @@ resource "aws_iam_policy" "dynamodb_access_policy" {
           aws_dynamodb_table.stripe_webhook_event_table.arn,
           aws_dynamodb_table.interaction_receipt_table.arn,
           aws_dynamodb_table.active_meeting_table.arn,
+          aws_dynamodb_table.meeting_control_command_table.arn,
+          "${aws_dynamodb_table.meeting_control_command_table.arn}/index/*",
           aws_dynamodb_table.access_logs_table.arn,
           aws_dynamodb_table.recording_transcript_table.arn,
           aws_dynamodb_table.auto_record_settings_table.arn,
@@ -1948,6 +1950,52 @@ resource "aws_dynamodb_table" "active_meeting_table" {
 
   tags = {
     Name = "ActiveMeetingTable"
+  }
+}
+
+resource "aws_dynamodb_table" "meeting_control_command_table" {
+  name         = "${local.name_prefix}-MeetingControlCommandTable"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "requestId"
+
+  attribute {
+    name = "requestId"
+    type = "S"
+  }
+
+  attribute {
+    name = "queueStatus"
+    type = "S"
+  }
+
+  attribute {
+    name = "createdAt"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name            = "StatusCreatedAtIndex"
+    hash_key        = "queueStatus"
+    range_key       = "createdAt"
+    projection_type = "ALL"
+  }
+
+  ttl {
+    attribute_name = "expiresAt"
+    enabled        = true
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_key.app_general.arn
+  }
+
+  tags = {
+    Name = "MeetingControlCommandTable"
   }
 }
 

--- a/apps/docs-site/docs/integrations/remote-mcp.md
+++ b/apps/docs-site/docs/integrations/remote-mcp.md
@@ -29,7 +29,7 @@ Remote MCP requires Discord OAuth and `OAUTH_SECRET` to be configured. Set `MCP_
 - `start_meeting`: Starts a Chronote recording from the authenticated user's current Discord voice channel. Optionally pass `serverId`, `voiceChannelId`, `textChannelId`, `context`, and `tags`.
 - `stop_meeting`: Stops the active Chronote meeting, either by `serverId` or by inferring the server from the authenticated user's current voice channel. Pass `meetingId` to guard against stopping the wrong meeting.
 - `get_live_meeting_status`: Returns status for an active meeting.
-- `get_live_meeting_transcript`: Returns currently available live transcript events. Use `afterEventId` to page from the last event you saw.
+- `get_live_meeting_transcript`: Returns currently available live transcript events. Pass `serverId` so the request reaches the bot runtime that owns the meeting, and use `afterEventId` to page from the last event you saw.
 - `get_meeting_control_request`: Checks a queued start, stop, or live meeting request by `requestId`.
 
 For follow-up fetch tools, use the list item's `id` field. Do not pass the UUID-style `meetingId` field.

--- a/apps/docs-site/docs/integrations/remote-mcp.md
+++ b/apps/docs-site/docs/integrations/remote-mcp.md
@@ -3,9 +3,9 @@ title: Remote MCP
 slug: /integrations/remote-mcp
 ---
 
-Chronote exposes a remote MCP (Model Context Protocol) endpoint for AI assistants and agents that need meeting context.
+Chronote exposes a remote MCP (Model Context Protocol) endpoint for AI assistants and agents that need meeting context or want to control live recordings.
 
-The endpoint is read-only today and uses OAuth with Discord sign-in. Chronote checks the same meeting access rules used by the web portal before returning data.
+The endpoint uses OAuth with Discord sign-in. Chronote checks the same meeting access rules used by the web portal before returning data, and write tools require separate consent scopes.
 
 ## Endpoint
 
@@ -26,19 +26,32 @@ Remote MCP requires Discord OAuth and `OAUTH_SECRET` to be configured. Set `MCP_
 - `list_my_meetings`: Lists meetings across servers for the authenticated user. It defaults to meetings the user attended in the past 7 days and can also list meetings the user can access. Use `all`, `today`, or `past_7_days` without `startDate` or `endDate`. Use `range: "custom"` when you need explicit date bounds. If the response includes `nextCursor`, pass it as `cursor` to fetch the next page.
 - `get_meeting_summary`: Returns notes and metadata for one accessible meeting.
 - `get_meeting_transcript`: Returns transcript text for one accessible meeting. Use `offset` and `maxChars` to page through long transcripts.
+- `start_meeting`: Starts a Chronote recording from the authenticated user's current Discord voice channel. Optionally pass `serverId`, `voiceChannelId`, `textChannelId`, `context`, and `tags`.
+- `stop_meeting`: Stops the active Chronote meeting, either by `serverId` or by inferring the server from the authenticated user's current voice channel. Pass `meetingId` to guard against stopping the wrong meeting.
+- `get_live_meeting_status`: Returns status for an active meeting.
+- `get_live_meeting_transcript`: Returns currently available live transcript events. Use `afterEventId` to page from the last event you saw.
+- `get_meeting_control_request`: Checks a queued start, stop, or live meeting request by `requestId`.
 
 For follow-up fetch tools, use the list item's `id` field. Do not pass the UUID-style `meetingId` field.
 
 Example flow:
 
 1. Call `list_meetings` or `list_my_meetings`.
-2. Take the returned `id` value, for example `123456789012345678#2026-05-08T01:06:47.307Z`.
+2. Take the returned `id` value, for example `<server-id>#2026-05-08T01:06:47.307Z`.
 3. Pass that `id` into `get_meeting_summary` or `get_meeting_transcript`.
 
 For long transcripts, request a window at a time:
 
 1. Call `get_meeting_transcript` with `id`, optionally adding `maxChars`.
 2. If the response includes `truncated: true`, call it again with `offset` set to `nextOffset`.
+
+## Live Control Tips
+
+- Join the Discord voice channel before calling `start_meeting` without explicit IDs.
+- If you are connected in multiple servers, pass `serverId`.
+- If the server does not have a default notes channel, pass `textChannelId`.
+- Write and live tools may return `requestStatus: "pending"` with a `requestId` while a bot worker completes the command. Call `get_meeting_control_request` with that `requestId` to check the result.
+- `stop_meeting` can be used by the meeting creator or members with meeting-management permissions.
 
 ## Date Range Tips
 
@@ -50,6 +63,9 @@ For long transcripts, request a window at a time:
 
 - `meetings:read`: Required for server lists, meeting lists, and meeting summaries.
 - `transcripts:read`: Required in addition to `meetings:read` for transcript text.
+- `meetings:start`: Required to start recordings through MCP.
+- `meetings:stop`: Required to stop recordings through MCP.
+- `get_meeting_control_request` requires a valid MCP token and only returns requests created by the authenticated user.
 
 ## OpenCode Example
 
@@ -74,5 +90,5 @@ Chronote only returns meeting data if the authenticated Discord user can access 
 - Users who participated can access their indexed meetings when attendee access is enabled.
 - Other users need access to the voice channel and notes channel history.
 - Transcript access requires explicit transcript scope consent.
-
-Future write tools will use narrower scopes and separate consent.
+- Starting a live meeting requires the authenticated Discord user to already be in the target voice channel.
+- Stopping a meeting requires creator or meeting-management permissions.

--- a/apps/docs-site/docs/whats-new/index.md
+++ b/apps/docs-site/docs/whats-new/index.md
@@ -7,6 +7,12 @@ Notable product changes for Chronote users. For the full changelog, see the [Git
 
 ## 2026
 
+### Remote MCP live controls
+
+- AI assistants can now start Chronote recordings from your current Discord voice channel through Remote MCP.
+- Remote MCP can stop active meetings, check live meeting status, and fetch available live transcript events using existing meeting/transcript scopes plus separate start/stop OAuth consent scopes.
+- Meeting control requests are queued so Chronote can route work to the bot runtime that owns the live recording.
+
 ### Transcription reliability guardrails
 
 - Low-confidence transcription retries now reject punctuation-only outputs before they can replace a real transcript.

--- a/docs/adr-20260524-mcp-meeting-control-queue.md
+++ b/docs/adr-20260524-mcp-meeting-control-queue.md
@@ -1,0 +1,57 @@
+# ADR-20260524: Queue Remote MCP Meeting Control Commands
+
+Status: Accepted
+Date: 2026-05-24
+Owners: Backend and bot runtime
+
+## Context
+
+Remote MCP originally exposed read-only meeting history tools. Live meeting
+control needs bot gateway state, voice channel objects, permissions, and the
+in-memory meeting owner runtime. The API and bot can run in one process today,
+but the project also supports separate API-only and bot-only runtimes. Scaling
+recording and transcription work will eventually require multiple bot workers.
+
+## Decision
+
+Add a DynamoDB-backed `MeetingControlCommandTable` for short-lived MCP control
+requests:
+
+1. API/MCP tools enqueue start, stop, live-status, and live-transcript commands.
+2. Bot workers poll pending commands through `StatusCreatedAtIndex` and claim
+   work before execution.
+3. Commands that must run on the active meeting owner include
+   `targetOwnerInstanceId` from the active meeting lease.
+4. The MCP tool returns completed results when available, otherwise a `requestId`
+   that can be checked with `get_meeting_control_request`.
+
+## Consequences
+
+Positive:
+
+- API-only and bot-only runtimes can process MCP control without shared memory.
+- Future multi-bot scaling can route live meeting commands to the worker that
+  owns the voice connection.
+- MCP write scopes stay narrow (`meetings:start`, `meetings:stop`).
+
+Costs and risks:
+
+- Meeting control now depends on a DynamoDB queue table and bot worker polling.
+- MCP clients must handle occasional pending responses.
+- Start commands without a target owner can be claimed by any bot worker, so
+  workers must still enforce active meeting leases before joining voice.
+
+## Alternatives Considered
+
+1. Use same-process `getDiscordClient()` from the API. This is simpler but fails
+   when API and bot runtimes are split.
+2. Add direct API-to-bot HTTP callbacks. This adds service discovery and network
+   security concerns before they are needed.
+3. Keep Remote MCP read-only. This avoids write risk but does not support the
+   desired assistant-driven live meeting workflow.
+
+## Notes
+
+The queue is not a durable audit log. Records expire via DynamoDB TTL, deletion
+is eventual, and backup/recovery windows may retain prior versions. Queue records
+store only command metadata, results, and errors needed by the MCP client.

--- a/opencode.json
+++ b/opencode.json
@@ -4,7 +4,7 @@
     "langfuse": {
       "type": "remote",
       "url": "https://us.cloud.langfuse.com/api/public/mcp",
-      "enabled": true,
+      "enabled": false,
       "oauth": false,
       "headers": {
         "Authorization": "{file:.opencode/langfuse.mcp.auth}"
@@ -21,7 +21,7 @@
         "--tools",
         "traces,observations"
       ],
-      "enabled": true,
+      "enabled": false,
       "environment": {
         "LANGFUSE_PUBLIC_KEY": "{file:.opencode/langfuse.public}",
         "LANGFUSE_SECRET_KEY": "{file:.opencode/langfuse.secret}",
@@ -32,6 +32,33 @@
       "type": "remote",
       "url": "https://langfuse.com/api/mcp",
       "enabled": true
+    },
+    "google-developer-knowledge": {
+      "enabled": false
+    },
+    "vrchat-mcp": {
+      "enabled": false
+    },
+    "blender-mcp": {
+      "enabled": false
+    },
+    "unity-mcp": {
+      "enabled": false
+    },
+    "godaddy-dns": {
+      "enabled": false
+    },
+    "irc-admin": {
+      "enabled": false
+    },
+    "ableton-mcp": {
+      "enabled": false
+    },
+    "faceless-server-discord-mcp": {
+      "enabled": false
+    },
+    "faceless-trello": {
+      "enabled": false
     }
   }
 }

--- a/opencode.json
+++ b/opencode.json
@@ -4,7 +4,7 @@
     "langfuse": {
       "type": "remote",
       "url": "https://us.cloud.langfuse.com/api/public/mcp",
-      "enabled": false,
+      "enabled": true,
       "oauth": false,
       "headers": {
         "Authorization": "{file:.opencode/langfuse.mcp.auth}"
@@ -21,7 +21,7 @@
         "--tools",
         "traces,observations"
       ],
-      "enabled": false,
+      "enabled": true,
       "environment": {
         "LANGFUSE_PUBLIC_KEY": "{file:.opencode/langfuse.public}",
         "LANGFUSE_SECRET_KEY": "{file:.opencode/langfuse.secret}",
@@ -32,33 +32,6 @@
       "type": "remote",
       "url": "https://langfuse.com/api/mcp",
       "enabled": true
-    },
-    "google-developer-knowledge": {
-      "enabled": false
-    },
-    "vrchat-mcp": {
-      "enabled": false
-    },
-    "blender-mcp": {
-      "enabled": false
-    },
-    "unity-mcp": {
-      "enabled": false
-    },
-    "godaddy-dns": {
-      "enabled": false
-    },
-    "irc-admin": {
-      "enabled": false
-    },
-    "ableton-mcp": {
-      "enabled": false
-    },
-    "faceless-server-discord-mcp": {
-      "enabled": false
-    },
-    "faceless-trello": {
-      "enabled": false
     }
   }
 }

--- a/scripts/init-dynamodb.js
+++ b/scripts/init-dynamodb.js
@@ -2,7 +2,9 @@ const {
   DynamoDBClient,
   CreateTableCommand,
   DescribeTableCommand,
+  DescribeTimeToLiveCommand,
   UpdateTableCommand,
+  UpdateTimeToLiveCommand,
 } = require("@aws-sdk/client-dynamodb");
 
 require("dotenv").config();
@@ -55,6 +57,26 @@ const tables = [
     TableName: "ActiveMeetingTable",
     KeySchema: [{ AttributeName: "guildId", KeyType: "HASH" }],
     AttributeDefinitions: [{ AttributeName: "guildId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  },
+  {
+    TableName: "MeetingControlCommandTable",
+    KeySchema: [{ AttributeName: "requestId", KeyType: "HASH" }],
+    AttributeDefinitions: [
+      { AttributeName: "requestId", AttributeType: "S" },
+      { AttributeName: "queueStatus", AttributeType: "S" },
+      { AttributeName: "createdAt", AttributeType: "S" },
+    ],
+    GlobalSecondaryIndexes: [
+      {
+        IndexName: "StatusCreatedAtIndex",
+        KeySchema: [
+          { AttributeName: "queueStatus", KeyType: "HASH" },
+          { AttributeName: "createdAt", KeyType: "RANGE" },
+        ],
+        Projection: { ProjectionType: "ALL" },
+      },
+    ],
     BillingMode: "PAY_PER_REQUEST",
   },
   {
@@ -370,8 +392,52 @@ async function createTables() {
     await ensureFeedbackIndexExists();
   }
 
+  await ensureMeetingControlCommandTtlEnabled();
+
   console.log("\nDynamoDB initialization complete!");
   console.log("You can view your tables at http://localhost:8001");
+}
+
+async function ensureMeetingControlCommandTtlEnabled() {
+  const commandTableName = tableName("MeetingControlCommandTable");
+
+  try {
+    const result = await client.send(
+      new DescribeTimeToLiveCommand({ TableName: commandTableName }),
+    );
+    if (
+      ["ENABLED", "ENABLING"].includes(
+        result.TimeToLiveDescription?.TimeToLiveStatus,
+      )
+    ) {
+      console.log(`TTL already enabled on ${commandTableName}`);
+      return;
+    }
+  } catch (error) {
+    if (error.name === "ResourceNotFoundException") {
+      return;
+    }
+    console.error(
+      `Error describing TTL on ${commandTableName}:`,
+      error.message,
+    );
+    return;
+  }
+
+  try {
+    await client.send(
+      new UpdateTimeToLiveCommand({
+        TableName: commandTableName,
+        TimeToLiveSpecification: {
+          AttributeName: "expiresAt",
+          Enabled: true,
+        },
+      }),
+    );
+    console.log(`Enabled TTL on ${commandTableName}`);
+  } catch (error) {
+    console.error(`Error enabling TTL on ${commandTableName}:`, error.message);
+  }
 }
 
 async function ensureFeedbackIndexExists() {

--- a/server.json
+++ b/server.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "gg.chronote/chronote",
+  "title": "Chronote",
+  "description": "Discord meeting recording, live meeting control, notes, and transcript access for Chronote servers.",
+  "version": "1.0.0",
+  "repository": {
+    "url": "https://github.com/Chronote-gg/Chronote",
+    "source": "github"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://api.chronote.gg/mcp"
+    }
+  ]
+}

--- a/src/api/__tests__/mcp.test.ts
+++ b/src/api/__tests__/mcp.test.ts
@@ -389,6 +389,37 @@ describe("MCP JSON-RPC handler", () => {
     });
   });
 
+  it("requires serverId for live meeting transcript routing", async () => {
+    await expect(
+      handleMcpJsonRpcRequest(
+        { ...auth, scopes: ["meetings:read", "transcripts:read"] },
+        {
+          jsonrpc: "2.0",
+          id: "live-transcript-missing-server",
+          method: "tools/call",
+          params: {
+            name: "get_live_meeting_transcript",
+            arguments: { afterEventId: "event-0" },
+          },
+        },
+      ),
+    ).resolves.toMatchObject({
+      jsonrpc: "2.0",
+      id: "live-transcript-missing-server",
+      result: {
+        content: [
+          {
+            type: "text",
+            text: expect.stringContaining("serverId"),
+          },
+        ],
+        isError: true,
+      },
+    });
+
+    expect(getMcpLiveMeetingTranscript).not.toHaveBeenCalled();
+  });
+
   it("calls the list_servers tool with the authenticated user id", async () => {
     jest
       .mocked(listMcpServersForUser)

--- a/src/api/__tests__/mcp.test.ts
+++ b/src/api/__tests__/mcp.test.ts
@@ -7,6 +7,13 @@ import {
   listMcpMyMeetings,
   listMcpServersForUser,
 } from "../../services/mcpMeetingService";
+import {
+  getMcpLiveMeetingStatus,
+  getMcpLiveMeetingTranscript,
+  getMcpMeetingControlRequest,
+  startMcpMeetingControl,
+  stopMcpMeetingControl,
+} from "../../services/mcpMeetingControlService";
 import { validateMcpAccessToken } from "../../services/mcpOAuthService";
 import type { McpAccessTokenInfo } from "../../types/mcpOAuth";
 
@@ -35,6 +42,22 @@ jest.mock("../../services/mcpOAuthService", () => ({
     required.every((scope) => granted.includes(scope)),
   ),
   validateMcpAccessToken: jest.fn(),
+}));
+
+jest.mock("../../services/mcpMeetingControlService", () => ({
+  McpMeetingControlError: class McpMeetingControlError extends Error {
+    constructor(
+      readonly code: string,
+      message: string,
+    ) {
+      super(message);
+    }
+  },
+  getMcpLiveMeetingStatus: jest.fn(),
+  getMcpLiveMeetingTranscript: jest.fn(),
+  getMcpMeetingControlRequest: jest.fn(),
+  startMcpMeetingControl: jest.fn(),
+  stopMcpMeetingControl: jest.fn(),
 }));
 
 const auth: McpAccessTokenInfo = {
@@ -80,6 +103,19 @@ const captureMcpPostHandler = () => {
   return postHandler;
 };
 
+const captureMcpGetHandler = () => {
+  let getHandler: RequestHandler | undefined;
+  const app = {
+    get: jest.fn((_path: string, handler: RequestHandler) => {
+      getHandler = handler;
+    }),
+    post: jest.fn(),
+  };
+  registerMcpRoutes(app as unknown as Express);
+  if (!getHandler) throw new Error("MCP GET route was not registered.");
+  return getHandler;
+};
+
 describe("MCP JSON-RPC handler", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -104,8 +140,252 @@ describe("MCP JSON-RPC handler", () => {
           expect.objectContaining({ name: "list_servers" }),
           expect.objectContaining({ name: "list_my_meetings" }),
           expect.objectContaining({ name: "get_meeting_summary" }),
+          expect.objectContaining({ name: "start_meeting" }),
+          expect.objectContaining({ name: "stop_meeting" }),
+          expect.objectContaining({ name: "get_live_meeting_status" }),
         ]),
       },
+    });
+  });
+
+  it("rejects start meeting without meetings:start", async () => {
+    await expect(
+      handleMcpJsonRpcRequest(auth, {
+        jsonrpc: "2.0",
+        id: "start-scope",
+        method: "tools/call",
+        params: {
+          name: "start_meeting",
+          arguments: {},
+        },
+      }),
+    ).resolves.toMatchObject({
+      jsonrpc: "2.0",
+      id: "start-scope",
+      error: { code: -32001, message: "Insufficient OAuth scope." },
+    });
+  });
+
+  it("calls start_meeting with queued command result", async () => {
+    jest.mocked(startMcpMeetingControl).mockResolvedValue({
+      requestId: "request-1",
+      queueStatus: "completed",
+      commandType: "start_meeting",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:01.000Z",
+      result: {
+        status: "started",
+        serverId: "guild-1",
+        meetingId: "meeting-1",
+        voiceChannelId: "voice-1",
+        textChannelId: "text-1",
+        startedAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+
+    await expect(
+      handleMcpJsonRpcRequest(
+        { ...auth, scopes: ["meetings:read", "meetings:start"] },
+        {
+          jsonrpc: "2.0",
+          id: "start-call",
+          method: "tools/call",
+          params: {
+            name: "start_meeting",
+            arguments: {
+              serverId: "guild-1",
+              textChannelId: "text-1",
+              tags: ["planning"],
+            },
+          },
+        },
+      ),
+    ).resolves.toMatchObject({
+      jsonrpc: "2.0",
+      id: "start-call",
+      result: {
+        structuredContent: {
+          requestId: "request-1",
+          requestStatus: "completed",
+          status: "started",
+          meetingId: "meeting-1",
+        },
+        isError: false,
+      },
+    });
+
+    expect(startMcpMeetingControl).toHaveBeenCalledWith({
+      userId: "user-1",
+      request: {
+        serverId: "guild-1",
+        textChannelId: "text-1",
+        tags: ["planning"],
+      },
+    });
+  });
+
+  it("returns queued pending meeting control requests", async () => {
+    jest.mocked(stopMcpMeetingControl).mockResolvedValue({
+      requestId: "request-2",
+      queueStatus: "pending",
+      commandType: "stop_meeting",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    await expect(
+      handleMcpJsonRpcRequest(
+        { ...auth, scopes: ["meetings:read", "meetings:stop"] },
+        {
+          jsonrpc: "2.0",
+          id: "stop-call",
+          method: "tools/call",
+          params: {
+            name: "stop_meeting",
+            arguments: { serverId: "guild-1" },
+          },
+        },
+      ),
+    ).resolves.toMatchObject({
+      jsonrpc: "2.0",
+      id: "stop-call",
+      result: {
+        structuredContent: {
+          requestId: "request-2",
+          requestStatus: "pending",
+          commandType: "stop_meeting",
+        },
+        isError: false,
+      },
+    });
+  });
+
+  it("returns failed meeting control requests as tool errors", async () => {
+    jest.mocked(getMcpMeetingControlRequest).mockResolvedValue({
+      requestId: "request-3",
+      queueStatus: "failed",
+      commandType: "start_meeting",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:01.000Z",
+      error: "Join a Discord voice channel first, then retry.",
+    });
+
+    await expect(
+      handleMcpJsonRpcRequest(
+        { ...auth, scopes: ["meetings:start"] },
+        {
+          jsonrpc: "2.0",
+          id: "request-status",
+          method: "tools/call",
+          params: {
+            name: "get_meeting_control_request",
+            arguments: { requestId: "request-3" },
+          },
+        },
+      ),
+    ).resolves.toMatchObject({
+      jsonrpc: "2.0",
+      id: "request-status",
+      result: {
+        content: [
+          {
+            type: "text",
+            text: "Join a Discord voice channel first, then retry.",
+          },
+        ],
+        isError: true,
+      },
+    });
+  });
+
+  it("calls live meeting status with authenticated user id", async () => {
+    jest.mocked(getMcpLiveMeetingStatus).mockResolvedValue({
+      requestId: "request-4",
+      queueStatus: "completed",
+      commandType: "get_live_meeting_status",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:01.000Z",
+      result: {
+        status: "in_progress",
+        serverId: "guild-1",
+        meetingId: "meeting-1",
+        voiceChannelId: "voice-1",
+      },
+    });
+
+    await expect(
+      handleMcpJsonRpcRequest(auth, {
+        jsonrpc: "2.0",
+        id: "live-status",
+        method: "tools/call",
+        params: {
+          name: "get_live_meeting_status",
+          arguments: { serverId: "guild-1", meetingId: "meeting-1" },
+        },
+      }),
+    ).resolves.toMatchObject({
+      jsonrpc: "2.0",
+      id: "live-status",
+      result: {
+        structuredContent: {
+          requestId: "request-4",
+          requestStatus: "completed",
+          status: "in_progress",
+        },
+        isError: false,
+      },
+    });
+
+    expect(getMcpLiveMeetingStatus).toHaveBeenCalledWith({
+      userId: "user-1",
+      request: { serverId: "guild-1", meetingId: "meeting-1" },
+    });
+  });
+
+  it("calls live meeting transcript with transcript scope", async () => {
+    jest.mocked(getMcpLiveMeetingTranscript).mockResolvedValue({
+      requestId: "request-5",
+      queueStatus: "completed",
+      commandType: "get_live_meeting_transcript",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:01.000Z",
+      result: {
+        serverId: "guild-1",
+        meetingId: "meeting-1",
+        events: [{ id: "event-1", type: "voice", time: "0:01", text: "Hi" }],
+        hasMore: false,
+      },
+    });
+
+    await expect(
+      handleMcpJsonRpcRequest(
+        { ...auth, scopes: ["meetings:read", "transcripts:read"] },
+        {
+          jsonrpc: "2.0",
+          id: "live-transcript",
+          method: "tools/call",
+          params: {
+            name: "get_live_meeting_transcript",
+            arguments: { serverId: "guild-1", afterEventId: "event-0" },
+          },
+        },
+      ),
+    ).resolves.toMatchObject({
+      jsonrpc: "2.0",
+      id: "live-transcript",
+      result: {
+        structuredContent: {
+          requestId: "request-5",
+          requestStatus: "completed",
+          events: [{ id: "event-1", text: "Hi" }],
+        },
+        isError: false,
+      },
+    });
+
+    expect(getMcpLiveMeetingTranscript).toHaveBeenCalledWith({
+      userId: "user-1",
+      request: { serverId: "guild-1", afterEventId: "event-0" },
     });
   });
 
@@ -462,5 +742,19 @@ describe("MCP JSON-RPC handler", () => {
       id: null,
       error: { code: -32600, message: "Invalid JSON-RPC request." },
     });
+  });
+
+  it("returns OAuth discovery challenge before origin rejection", async () => {
+    const getHandler = captureMcpGetHandler();
+    const response = createResponse();
+
+    await getHandler(
+      { headers: { origin: "https://mcp-client.example" } } as never,
+      response as never,
+      jest.fn(),
+    );
+
+    expect(response.statusCode).toBe(401);
+    expect(response.headers.get("WWW-Authenticate")).toBe("Bearer");
   });
 });

--- a/src/api/mcp.ts
+++ b/src/api/mcp.ts
@@ -17,7 +17,16 @@ import {
   MAX_MCP_TRANSCRIPT_MAX_CHARS,
   McpMeetingAccessError,
 } from "../services/mcpMeetingService";
+import {
+  getMcpLiveMeetingStatus,
+  getMcpLiveMeetingTranscript,
+  getMcpMeetingControlRequest,
+  McpMeetingControlError,
+  startMcpMeetingControl,
+  stopMcpMeetingControl,
+} from "../services/mcpMeetingControlService";
 import type { McpAccessTokenInfo, McpScope } from "../types/mcpOAuth";
+import type { MeetingControlCommandSnapshot } from "../services/meetingControlQueueService";
 
 const MCP_PROTOCOL_VERSION = "2025-11-25";
 const JSON_RPC_VERSION = "2.0";
@@ -48,6 +57,18 @@ const toolAnnotations = {
   readOnlyHint: true,
   destructiveHint: false,
   idempotentHint: true,
+  openWorldHint: true,
+};
+const startMeetingToolAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: false,
+  openWorldHint: true,
+};
+const stopMeetingToolAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: true,
+  idempotentHint: false,
   openWorldHint: true,
 };
 
@@ -111,6 +132,30 @@ const meetingTranscriptLookupSchema = z.object({
     .min(1)
     .max(MAX_MCP_TRANSCRIPT_MAX_CHARS)
     .optional(),
+});
+
+const startMeetingControlSchema = z.object({
+  serverId: z.string().min(1).optional(),
+  voiceChannelId: z.string().min(1).optional(),
+  textChannelId: z.string().min(1).optional(),
+  context: z.string().max(4000).optional(),
+  tags: z.array(z.string().min(1).max(50)).max(20).optional(),
+});
+
+const stopMeetingControlSchema = z.object({
+  serverId: z.string().min(1).optional(),
+  meetingId: z.string().min(1).optional(),
+});
+
+const liveMeetingControlSchema = z.object({
+  serverId: z.string().min(1).optional(),
+  meetingId: z.string().min(1).optional(),
+  afterEventId: z.string().min(1).optional(),
+  limit: z.number().int().min(1).max(200).optional(),
+});
+
+const meetingControlRequestSchema = z.object({
+  requestId: z.string().min(1),
 });
 
 const toolDefinitions: McpToolDefinition[] = [
@@ -261,6 +306,112 @@ const toolDefinitions: McpToolDefinition[] = [
     },
     annotations: toolAnnotations,
   },
+  {
+    name: "start_meeting",
+    title: "Start Chronote Meeting",
+    description:
+      "Start a Chronote recording in the authenticated user's current Discord voice channel. Optionally pass serverId, voiceChannelId, textChannelId, context, and tags. Requires meetings:start.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        serverId: {
+          type: "string",
+          description:
+            "Optional Discord server ID. Required if the user is in voice in multiple servers.",
+        },
+        voiceChannelId: {
+          type: "string",
+          description:
+            "Optional voice channel ID. The authenticated user must already be connected to it.",
+        },
+        textChannelId: {
+          type: "string",
+          description:
+            "Optional text channel for meeting start and notes messages. Defaults to the server notes channel.",
+        },
+        context: { type: "string", maxLength: 4000 },
+        tags: {
+          type: "array",
+          items: { type: "string", minLength: 1, maxLength: 50 },
+          maxItems: 20,
+        },
+      },
+      additionalProperties: false,
+    },
+    annotations: startMeetingToolAnnotations,
+  },
+  {
+    name: "stop_meeting",
+    title: "Stop Chronote Meeting",
+    description:
+      "Stop the active Chronote meeting in a server, or infer the server from the authenticated user's current voice channel. Requires meetings:stop.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        serverId: {
+          type: "string",
+          description: "Optional Discord server ID.",
+        },
+        meetingId: {
+          type: "string",
+          description:
+            "Optional live meeting UUID to guard against ending the wrong meeting.",
+        },
+      },
+      additionalProperties: false,
+    },
+    annotations: stopMeetingToolAnnotations,
+  },
+  {
+    name: "get_live_meeting_status",
+    title: "Get Live Chronote Meeting Status",
+    description:
+      "Get status for an active Chronote meeting. Pass serverId/meetingId or let Chronote infer the server from the authenticated user's current voice channel.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        serverId: { type: "string" },
+        meetingId: { type: "string" },
+      },
+      additionalProperties: false,
+    },
+    annotations: toolAnnotations,
+  },
+  {
+    name: "get_live_meeting_transcript",
+    title: "Get Live Chronote Meeting Transcript",
+    description:
+      "Fetch transcript events currently available for an active Chronote meeting. Requires transcripts:read.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        serverId: { type: "string" },
+        meetingId: { type: "string" },
+        afterEventId: {
+          type: "string",
+          description: "Optional event id cursor from a previous response.",
+        },
+        limit: { type: "integer", minimum: 1, maximum: 200 },
+      },
+      additionalProperties: false,
+    },
+    annotations: toolAnnotations,
+  },
+  {
+    name: "get_meeting_control_request",
+    title: "Get Chronote Meeting Control Request",
+    description:
+      "Check a queued meeting control request returned by start_meeting, stop_meeting, or live meeting tools.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        requestId: { type: "string" },
+      },
+      required: ["requestId"],
+      additionalProperties: false,
+    },
+    annotations: toolAnnotations,
+  },
 ];
 
 const toolScopes = new Map<string, McpScope[]>([
@@ -269,6 +420,11 @@ const toolScopes = new Map<string, McpScope[]>([
   ["list_my_meetings", ["meetings:read"]],
   ["get_meeting_summary", ["meetings:read"]],
   ["get_meeting_transcript", ["meetings:read", "transcripts:read"]],
+  ["start_meeting", ["meetings:start"]],
+  ["stop_meeting", ["meetings:stop"]],
+  ["get_live_meeting_status", ["meetings:read"]],
+  ["get_live_meeting_transcript", ["meetings:read", "transcripts:read"]],
+  ["get_meeting_control_request", []],
 ]);
 
 const isJsonRpcRequest = (value: unknown): value is JsonRpcRequest => {
@@ -339,6 +495,32 @@ const mapMeetingError = (error: unknown) => {
   return toolError(error.message);
 };
 
+const mapMeetingControlError = (error: unknown) => {
+  if (!(error instanceof McpMeetingControlError)) return undefined;
+  if (error.code === "not_found") return toolError("Request not found.");
+  return toolError(error.message);
+};
+
+const meetingControlToolResult = (snapshot: MeetingControlCommandSnapshot) => {
+  if (snapshot.queueStatus === "failed") {
+    return toolError(snapshot.error ?? "Meeting control request failed.");
+  }
+  if (snapshot.queueStatus === "completed" && snapshot.result) {
+    return toolResult({
+      requestId: snapshot.requestId,
+      requestStatus: snapshot.queueStatus,
+      ...snapshot.result,
+    });
+  }
+  return toolResult({
+    requestId: snapshot.requestId,
+    requestStatus: snapshot.queueStatus,
+    commandType: snapshot.commandType,
+    createdAt: snapshot.createdAt,
+    updatedAt: snapshot.updatedAt,
+  });
+};
+
 const formatZodToolError = (error: z.ZodError) => {
   const message = error.issues[0]?.message;
   return message ? `Invalid tool input: ${message}` : "Invalid tool input.";
@@ -366,6 +548,30 @@ const resolveSingleRequestRequiredScopes = (
     callRequest?.params as { name?: string } | undefined
   )?.name;
   return requestedToolName ? toolScopes.get(requestedToolName) : undefined;
+};
+
+const urlOrigin = (value: string) => new URL(value).origin;
+
+const resolveAllowedMcpOrigins = () =>
+  new Set(
+    [
+      config.frontend.siteUrl,
+      config.mcp.publicBaseUrl,
+      ...config.frontend.allowedOrigins,
+    ].map(urlOrigin),
+  );
+
+const hasInvalidOrigin = (req: Request) => {
+  const origin = req.headers.origin;
+  if (!origin) return false;
+  return !resolveAllowedMcpOrigins().has(origin);
+};
+
+const rejectInvalidOrigin = (req: Request, res: Response) => {
+  if (!hasInvalidOrigin(req)) return false;
+  if (!getBearerToken(req)) return false;
+  res.status(403).json({ error: "invalid_origin" });
+  return true;
 };
 
 async function callTool(auth: McpAccessTokenInfo, name: string, args: unknown) {
@@ -430,12 +636,50 @@ async function callTool(auth: McpAccessTokenInfo, name: string, args: unknown) {
         }),
       );
     }
+    if (name === "start_meeting") {
+      const input = startMeetingControlSchema.parse(args);
+      return meetingControlToolResult(
+        await startMcpMeetingControl({ userId: auth.userId, request: input }),
+      );
+    }
+    if (name === "stop_meeting") {
+      const input = stopMeetingControlSchema.parse(args);
+      return meetingControlToolResult(
+        await stopMcpMeetingControl({ userId: auth.userId, request: input }),
+      );
+    }
+    if (name === "get_live_meeting_status") {
+      const input = liveMeetingControlSchema.parse(args);
+      return meetingControlToolResult(
+        await getMcpLiveMeetingStatus({ userId: auth.userId, request: input }),
+      );
+    }
+    if (name === "get_live_meeting_transcript") {
+      const input = liveMeetingControlSchema.parse(args);
+      return meetingControlToolResult(
+        await getMcpLiveMeetingTranscript({
+          userId: auth.userId,
+          request: input,
+        }),
+      );
+    }
+    if (name === "get_meeting_control_request") {
+      const input = meetingControlRequestSchema.parse(args);
+      return meetingControlToolResult(
+        await getMcpMeetingControlRequest({
+          userId: auth.userId,
+          requestId: input.requestId,
+        }),
+      );
+    }
     return toolError(`Unknown tool: ${name}`);
   } catch (error) {
     if (error instanceof z.ZodError)
       return toolError(formatZodToolError(error));
     const meetingError = mapMeetingError(error);
     if (meetingError) return meetingError;
+    const controlError = mapMeetingControlError(error);
+    if (controlError) return controlError;
     console.error("Unexpected MCP tool error", { toolName: name, error });
     return toolError("Unexpected tool error.");
   }
@@ -489,8 +733,27 @@ export async function handleMcpJsonRpcRequest(
   }
 }
 
+export const getMcpServerCard = () => ({
+  serverInfo: {
+    name: "chronote",
+    version: config.server.npmPackageVersion,
+  },
+  authentication: {
+    required: true,
+    schemes: ["oauth2"],
+  },
+  tools: toolDefinitions.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+  })),
+  resources: [],
+  prompts: [],
+});
+
 export function registerMcpRoutes(app: Express) {
   app.get(config.mcp.endpointPath, (req, res) => {
+    if (rejectInvalidOrigin(req, res)) return;
     if (!getBearerToken(req)) {
       sendUnauthorized(res);
       return;
@@ -500,6 +763,7 @@ export function registerMcpRoutes(app: Express) {
   });
 
   app.post(config.mcp.endpointPath, async (req, res) => {
+    if (rejectInvalidOrigin(req, res)) return;
     const rawToken = getBearerToken(req);
     if (!rawToken) {
       sendUnauthorized(res);

--- a/src/api/mcp.ts
+++ b/src/api/mcp.ts
@@ -154,6 +154,18 @@ const liveMeetingControlSchema = z.object({
   limit: z.number().int().min(1).max(200).optional(),
 });
 
+const liveMeetingTranscriptControlSchema = liveMeetingControlSchema.superRefine(
+  (input, ctx) => {
+    if (!input.serverId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "serverId is required for live transcript requests.",
+        path: ["serverId"],
+      });
+    }
+  },
+);
+
 const meetingControlRequestSchema = z.object({
   requestId: z.string().min(1),
 });
@@ -381,7 +393,7 @@ const toolDefinitions: McpToolDefinition[] = [
     name: "get_live_meeting_transcript",
     title: "Get Live Chronote Meeting Transcript",
     description:
-      "Fetch transcript events currently available for an active Chronote meeting. Requires transcripts:read.",
+      "Fetch transcript events currently available for an active Chronote meeting. Requires serverId and transcripts:read.",
     inputSchema: {
       type: "object",
       properties: {
@@ -393,6 +405,7 @@ const toolDefinitions: McpToolDefinition[] = [
         },
         limit: { type: "integer", minimum: 1, maximum: 200 },
       },
+      required: ["serverId"],
       additionalProperties: false,
     },
     annotations: toolAnnotations,
@@ -424,6 +437,7 @@ const toolScopes = new Map<string, McpScope[]>([
   ["stop_meeting", ["meetings:stop"]],
   ["get_live_meeting_status", ["meetings:read"]],
   ["get_live_meeting_transcript", ["meetings:read", "transcripts:read"]],
+  // The repository owner-checks requestId, so polling only needs a valid token.
   ["get_meeting_control_request", []],
 ]);
 
@@ -655,7 +669,7 @@ async function callTool(auth: McpAccessTokenInfo, name: string, args: unknown) {
       );
     }
     if (name === "get_live_meeting_transcript") {
-      const input = liveMeetingControlSchema.parse(args);
+      const input = liveMeetingTranscriptControlSchema.parse(args);
       return meetingControlToolResult(
         await getMcpLiveMeetingTranscript({
           userId: auth.userId,

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -112,6 +112,7 @@ import {
 } from "./commands/onboard";
 import { fetchGuildInstaller } from "./services/guildInstallerService";
 import { setDiscordClient } from "./services/discordClientAccessor";
+import { startMeetingControlCommandWorker } from "./services/meetingControlWorkerService";
 import { autoRecordJoinSuppressionService } from "./services/autoRecordJoinSuppressionService";
 import {
   MEETING_END_REASONS,
@@ -438,6 +439,7 @@ export async function setupBot() {
   client.once(Events.ClientReady, () => {
     console.log(`Logged in as ${client.user?.tag}!`);
     setDiscordClient(client);
+    startMeetingControlCommandWorker(client);
 
     client.on("voiceStateUpdate", handleVoiceStateUpdate);
   });

--- a/src/commands/endMeeting.ts
+++ b/src/commands/endMeeting.ts
@@ -444,6 +444,7 @@ function maybeSuppressAutoRecordRejoin(
   if (
     endReason !== MEETING_END_REASONS.BUTTON &&
     endReason !== MEETING_END_REASONS.WEB_UI &&
+    endReason !== MEETING_END_REASONS.MCP &&
     endReason !== MEETING_END_REASONS.LIVE_VOICE &&
     endReason !== MEETING_END_REASONS.DISMISSED
   ) {

--- a/src/commands/startMeeting.ts
+++ b/src/commands/startMeeting.ts
@@ -5,9 +5,11 @@ import {
   ChatInputCommandInteraction,
   Client,
   EmbedBuilder,
+  Guild,
   GuildMember,
   PermissionsBitField,
   TextChannel,
+  User,
   UserContextMenuCommandInteraction,
   VoiceBasedChannel,
 } from "discord.js";
@@ -37,6 +39,7 @@ import {
   type AutoRecordRule,
   type MeetingStartReason,
 } from "../types/meetingLifecycle";
+import type { MeetingData } from "../types/meeting-data";
 import {
   getActiveMeetingLeaseForGuild,
   getCurrentMeetingLeaseOwnerInstanceId,
@@ -55,6 +58,22 @@ type StartMeetingInteraction =
 type StartMeetingOptions = {
   ephemeralErrors?: boolean;
 };
+
+type StartManualMeetingFromChannelsOptions = {
+  client: Client;
+  guild: Guild;
+  voiceChannel: VoiceBasedChannel;
+  textChannel: TextChannel;
+  creator: User;
+  meetingContext?: string;
+  tags?: string[];
+  startReason?: MeetingStartReason;
+  startTriggeredByUserId: string;
+};
+
+type StartManualMeetingFromChannelsResult =
+  | { ok: true; meeting: MeetingData; liveMeetingUrl: string | null }
+  | { ok: false; error: string; upgradePrompt?: boolean };
 
 const buildLiveMeetingUrl = (guildId: string, meetingId: string) => {
   const base = config.frontend.siteUrl?.replace(/\/$/, "");
@@ -201,6 +220,171 @@ const resolveMemberVoiceChannel = (member: GuildMember): VoiceChannelResult => {
   return { ok: true, voiceChannel };
 };
 
+export async function startManualMeetingFromChannels({
+  client,
+  guild,
+  voiceChannel,
+  textChannel,
+  creator,
+  meetingContext,
+  tags,
+  startReason = MEETING_START_REASONS.MANUAL_COMMAND,
+  startTriggeredByUserId,
+}: StartManualMeetingFromChannelsOptions): Promise<StartManualMeetingFromChannelsResult> {
+  const guildId = guild.id;
+  const meetingConflict = await ensureNoActiveMeeting(guildId);
+  if (meetingConflict) {
+    return { ok: false, error: meetingConflict };
+  }
+
+  const { limits, subscription } = await getGuildLimits(guildId);
+  const limitNotice = await getLimitNotice(guildId, limits);
+  if (limitNotice) {
+    return { ok: false, error: limitNotice, upgradePrompt: true };
+  }
+
+  const botMember = resolveBotMember(guild);
+  if (!botMember) {
+    return { ok: false, error: "Bot not found in guild." };
+  }
+
+  const permissionCheck = checkBotPermissions(
+    voiceChannel,
+    textChannel,
+    botMember,
+  );
+  if (!permissionCheck.success) {
+    return {
+      ok: false,
+      error: permissionCheck.errorMessage ?? "Missing bot permissions.",
+    };
+  }
+
+  const {
+    liveVoiceEnabled,
+    liveVoiceCommandsEnabled,
+    chatTtsEnabled,
+    chatTtsVoice,
+    liveVoiceTtsVoice,
+  } = await resolveMeetingVoiceSettings(guildId, voiceChannel.id, limits);
+
+  const meetingId = randomUUID();
+  const leaseOwnerInstanceId = getCurrentMeetingLeaseOwnerInstanceId();
+  const leaseAcquired = await tryAcquireMeetingLease({
+    guildId,
+    meetingId,
+    voiceChannelId: voiceChannel.id,
+    voiceChannelName: voiceChannel.name,
+    textChannelId: textChannel.id,
+    isAutoRecording: false,
+    startReason,
+    startTriggeredByUserId,
+  });
+  if (!leaseAcquired) {
+    return { ok: false, error: "A meeting is already active in this server." };
+  }
+
+  let meeting;
+  try {
+    meeting = await initializeMeeting({
+      meetingId,
+      leaseOwnerInstanceId,
+      voiceChannel,
+      textChannel,
+      guild,
+      creator,
+      transcribeMeeting: true,
+      generateNotes: true,
+      meetingContext,
+      initialInteraction: undefined,
+      isAutoRecording: false,
+      startReason,
+      startTriggeredByUserId,
+      tags,
+      onTimeout: (meeting) => handleEndMeetingOther(client, meeting),
+      onEndMeeting: (meeting) => handleEndMeetingOther(client, meeting),
+      liveVoiceEnabled,
+      liveVoiceCommandsEnabled,
+      liveVoiceTtsVoice,
+      chatTtsEnabled,
+      chatTtsVoice,
+      maxMeetingDurationMs: limits.maxMeetingDurationMs,
+      maxMeetingDurationPretty: limits.maxMeetingDurationPretty,
+      subscriptionTier: subscription.tier,
+    });
+  } catch (error) {
+    await releaseMeetingLeaseByIdentifiers(
+      guildId,
+      meetingId,
+      leaseOwnerInstanceId,
+    );
+    throw error;
+  }
+  startMeetingLeaseHeartbeat(meeting);
+  void saveMeetingStartToDatabase(meeting);
+
+  return {
+    ok: true,
+    meeting,
+    liveMeetingUrl: buildLiveMeetingUrl(meeting.guildId, meeting.meetingId),
+  };
+}
+
+export function buildManualMeetingStartedMessage(
+  meeting: MeetingData,
+  liveMeetingUrl: string | null,
+) {
+  const embed = new EmbedBuilder()
+    .setTitle("Meeting Started")
+    .setDescription(
+      `The meeting has started in **${meeting.voiceChannel.name}**.`,
+    )
+    .addFields({
+      name: "Start Time",
+      value: `<t:${Math.floor(meeting.startTime.getTime() / 1000)}:F>`,
+    })
+    .addFields({
+      name: "Tip",
+      value:
+        'Right click the bot in voice and choose "Disconnect" to end the meeting.',
+    })
+    .setColor(0x00ae86)
+    .setTimestamp();
+
+  if (meeting.meetingContext) {
+    embed.addFields({
+      name: "Meeting Context",
+      value: meeting.meetingContext,
+    });
+  }
+
+  const endButton = new ButtonBuilder()
+    .setCustomId("end_meeting")
+    .setLabel("End Meeting")
+    .setStyle(ButtonStyle.Danger);
+
+  const editTagsButton = new ButtonBuilder()
+    .setCustomId("edit_tags")
+    .setLabel("Edit Tags")
+    .setStyle(ButtonStyle.Secondary);
+
+  const liveMeetingButton = liveMeetingUrl
+    ? new ButtonBuilder()
+        .setLabel("Live transcript")
+        .setStyle(ButtonStyle.Link)
+        .setURL(liveMeetingUrl)
+    : null;
+  const components = [endButton, editTagsButton];
+  if (liveMeetingButton) {
+    components.push(liveMeetingButton);
+  }
+  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    ...components,
+  );
+
+  return { embeds: [embed], components: [row] };
+}
+
 export async function handleRequestStartMeeting(
   interaction: StartMeetingInteraction,
   options?: StartMeetingOptions,
@@ -246,154 +430,29 @@ export async function handleRequestStartMeeting(
   }
   const { voiceChannel } = voiceResult;
 
-  // Tier and limits
-  const { limits, subscription } = await getGuildLimits(guildId);
-  const limitNotice = await getLimitNotice(guildId, limits);
-  if (limitNotice) {
-    await interaction.reply(buildUpgradePrompt(limitNotice));
-    return;
-  }
-
-  // Check bot permissions
-  const permissionCheck = checkBotPermissions(
+  const startResult = await startManualMeetingFromChannels({
+    client: interaction.client,
+    guild,
     voiceChannel,
     textChannel,
-    botMember,
-  );
-
-  if (!permissionCheck.success) {
-    await replyStartMeetingError(
-      interaction,
-      permissionCheck.errorMessage!,
-      options,
-    );
-    return;
-  }
-
-  const {
-    liveVoiceEnabled,
-    liveVoiceCommandsEnabled,
-    chatTtsEnabled,
-    chatTtsVoice,
-    liveVoiceTtsVoice,
-  } = await resolveMeetingVoiceSettings(guildId, voiceChannel.id, limits);
-
-  const meetingId = randomUUID();
-  const leaseOwnerInstanceId = getCurrentMeetingLeaseOwnerInstanceId();
-  const leaseAcquired = await tryAcquireMeetingLease({
-    guildId,
-    meetingId,
-    voiceChannelId: voiceChannel.id,
-    voiceChannelName: voiceChannel.name,
-    textChannelId: textChannel.id,
-    isAutoRecording: false,
-    startReason: MEETING_START_REASONS.MANUAL_COMMAND,
+    creator: interaction.user,
+    meetingContext,
+    tags,
     startTriggeredByUserId: interaction.user.id,
   });
-  if (!leaseAcquired) {
-    await replyStartMeetingError(
-      interaction,
-      "A meeting is already active in this server.",
-      options,
-    );
+  if (!startResult.ok) {
+    if (startResult.upgradePrompt) {
+      await interaction.reply(buildUpgradePrompt(startResult.error));
+      return;
+    }
+    await replyStartMeetingError(interaction, startResult.error, options);
     return;
   }
 
-  // Initialize the meeting using the core function
-  let meeting;
-  try {
-    meeting = await initializeMeeting({
-      meetingId,
-      leaseOwnerInstanceId,
-      voiceChannel,
-      textChannel,
-      guild,
-      creator: interaction.user,
-      transcribeMeeting: true,
-      generateNotes: true,
-      meetingContext,
-      initialInteraction: undefined,
-      isAutoRecording: false,
-      startReason: MEETING_START_REASONS.MANUAL_COMMAND,
-      startTriggeredByUserId: interaction.user.id,
-      tags,
-      onTimeout: (meeting) =>
-        handleEndMeetingOther(interaction.client, meeting),
-      onEndMeeting: (meeting) =>
-        handleEndMeetingOther(interaction.client, meeting),
-      liveVoiceEnabled,
-      liveVoiceCommandsEnabled,
-      liveVoiceTtsVoice,
-      chatTtsEnabled,
-      chatTtsVoice,
-      maxMeetingDurationMs: limits.maxMeetingDurationMs,
-      maxMeetingDurationPretty: limits.maxMeetingDurationPretty,
-      subscriptionTier: subscription.tier,
-    });
-  } catch (error) {
-    await releaseMeetingLeaseByIdentifiers(
-      guildId,
-      meetingId,
-      leaseOwnerInstanceId,
-    );
-    throw error;
-  }
-  startMeetingLeaseHeartbeat(meeting);
-  void saveMeetingStartToDatabase(meeting);
-
-  const embed = new EmbedBuilder()
-    .setTitle("Meeting Started")
-    .setDescription(`The meeting has started in **${voiceChannel.name}**.`)
-    .addFields({
-      name: "Start Time",
-      value: `<t:${Math.floor(meeting.startTime.getTime() / 1000)}:F>`,
-    })
-    .addFields({
-      name: "Tip",
-      value:
-        'Right click the bot in voice and choose "Disconnect" to end the meeting.',
-    })
-    .setColor(0x00ae86)
-    .setTimestamp();
-
-  if (meetingContext) {
-    embed.addFields({
-      name: "Meeting Context",
-      value: meetingContext,
-    });
-  }
-
-  const endButton = new ButtonBuilder()
-    .setCustomId("end_meeting")
-    .setLabel("End Meeting")
-    .setStyle(ButtonStyle.Danger);
-
-  const editTagsButton = new ButtonBuilder()
-    .setCustomId("edit_tags")
-    .setLabel("Edit Tags")
-    .setStyle(ButtonStyle.Secondary);
-
-  const liveMeetingUrl = buildLiveMeetingUrl(
-    meeting.guildId,
-    meeting.meetingId,
-  );
-  const liveMeetingButton = liveMeetingUrl
-    ? new ButtonBuilder()
-        .setLabel("Live transcript")
-        .setStyle(ButtonStyle.Link)
-        .setURL(liveMeetingUrl)
-    : null;
-  const components = [endButton, editTagsButton];
-  if (liveMeetingButton) {
-    components.push(liveMeetingButton);
-  }
-  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
-    ...components,
-  );
+  const { meeting, liveMeetingUrl } = startResult;
 
   const reply = await interaction.reply({
-    embeds: [embed],
-    components: [row],
+    ...buildManualMeetingStartedMessage(meeting, liveMeetingUrl),
     fetchReply: true,
   });
   meeting.startMessageId = reply.id;

--- a/src/db.ts
+++ b/src/db.ts
@@ -328,25 +328,39 @@ export async function requestActiveMeetingEnd(
   meetingId: string,
   requestedByUserId: string,
   requestedAt: string,
+  endReason?: ActiveMeetingLease["endReason"],
 ): Promise<boolean> {
+  const updateParts = [
+    "#endRequestedAt = if_not_exists(#endRequestedAt, :endRequestedAt)",
+    "#endRequestedByUserId = if_not_exists(#endRequestedByUserId, :endRequestedByUserId)",
+    "#updatedAt = :updatedAt",
+  ];
+  const expressionAttributeNames: Record<string, string> = {
+    "#endRequestedAt": "endRequestedAt",
+    "#endRequestedByUserId": "endRequestedByUserId",
+    "#updatedAt": "updatedAt",
+    "#meetingId": "meetingId",
+  };
+  const expressionAttributeValues: Record<string, unknown> = {
+    ":endRequestedAt": requestedAt,
+    ":endRequestedByUserId": requestedByUserId,
+    ":updatedAt": requestedAt,
+    ":meetingId": meetingId,
+  };
+  if (endReason) {
+    updateParts.push("#endReason = if_not_exists(#endReason, :endReason)");
+    expressionAttributeNames["#endReason"] = "endReason";
+    expressionAttributeValues[":endReason"] = endReason;
+  }
   const params: UpdateItemCommand["input"] = {
     TableName: tableName("ActiveMeetingTable"),
     Key: marshall({ guildId }),
-    UpdateExpression:
-      "SET #endRequestedAt = if_not_exists(#endRequestedAt, :endRequestedAt), #endRequestedByUserId = if_not_exists(#endRequestedByUserId, :endRequestedByUserId), #updatedAt = :updatedAt",
+    UpdateExpression: `SET ${updateParts.join(", ")}`,
     ConditionExpression:
       "#meetingId = :meetingId AND (attribute_not_exists(#endRequestedAt) OR #endRequestedByUserId = :endRequestedByUserId)",
-    ExpressionAttributeNames: {
-      "#endRequestedAt": "endRequestedAt",
-      "#endRequestedByUserId": "endRequestedByUserId",
-      "#updatedAt": "updatedAt",
-      "#meetingId": "meetingId",
-    },
-    ExpressionAttributeValues: marshall({
-      ":endRequestedAt": requestedAt,
-      ":endRequestedByUserId": requestedByUserId,
-      ":updatedAt": requestedAt,
-      ":meetingId": meetingId,
+    ExpressionAttributeNames: expressionAttributeNames,
+    ExpressionAttributeValues: marshall(expressionAttributeValues, {
+      removeUndefinedValues: true,
     }),
   };
   const command = new UpdateItemCommand(params);

--- a/src/repositories/meetingControlCommandRepository.ts
+++ b/src/repositories/meetingControlCommandRepository.ts
@@ -1,0 +1,330 @@
+import {
+  GetItemCommand,
+  PutItemCommand,
+  QueryCommand,
+  UpdateItemCommand,
+  DynamoDBClient,
+} from "@aws-sdk/client-dynamodb";
+import type { AttributeValue } from "@aws-sdk/client-dynamodb";
+import { marshall, unmarshall } from "@aws-sdk/util-dynamodb";
+import { config } from "../services/configService";
+import type {
+  MeetingControlCommand,
+  MeetingControlCommandResult,
+} from "../types/meetingControl";
+
+const PENDING_STATUS = "pending";
+const STATUS_CREATED_AT_INDEX = "StatusCreatedAtIndex";
+
+export type ClaimMeetingControlCommandInput = {
+  requestId: string;
+  instanceId: string;
+  nowEpochSeconds: number;
+  claimExpiresAt: number;
+  updatedAt: string;
+};
+
+export type CompleteMeetingControlCommandInput = {
+  requestId: string;
+  instanceId: string;
+  updatedAt: string;
+  result: MeetingControlCommandResult;
+};
+
+export type FailMeetingControlCommandInput = {
+  requestId: string;
+  instanceId: string;
+  updatedAt: string;
+  error: string;
+};
+
+export type MeetingControlCommandRepository = {
+  writeCommand: (command: MeetingControlCommand) => Promise<void>;
+  getCommand: (requestId: string) => Promise<MeetingControlCommand | undefined>;
+  listClaimablePendingCommands: (options: {
+    instanceId: string;
+    nowEpochSeconds: number;
+    limit: number;
+  }) => Promise<MeetingControlCommand[]>;
+  claimCommand: (
+    input: ClaimMeetingControlCommandInput,
+  ) => Promise<MeetingControlCommand | undefined>;
+  completeCommand: (
+    input: CompleteMeetingControlCommandInput,
+  ) => Promise<boolean>;
+  failCommand: (input: FailMeetingControlCommandInput) => Promise<boolean>;
+};
+
+const tableName = `${config.database.tablePrefix ?? ""}MeetingControlCommandTable`;
+
+const dynamoDbClient = new DynamoDBClient(
+  config.database.useLocalDynamoDB
+    ? {
+        endpoint: "http://localhost:8000",
+        region: "local",
+        credentials: {
+          accessKeyId: "dummy",
+          secretAccessKey: "dummy",
+        },
+      }
+    : { region: config.storage.awsRegion },
+);
+
+const commandKey = (requestId: string) => ({ requestId });
+
+const isConditionalFailure = (error: unknown) =>
+  error instanceof Error && error.name === "ConditionalCheckFailedException";
+
+const realRepository: MeetingControlCommandRepository = {
+  async writeCommand(command) {
+    await dynamoDbClient.send(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: marshall(command, { removeUndefinedValues: true }),
+        ConditionExpression: "attribute_not_exists(#requestId)",
+        ExpressionAttributeNames: { "#requestId": "requestId" },
+      }),
+    );
+  },
+  async getCommand(requestId) {
+    const result = await dynamoDbClient.send(
+      new GetItemCommand({
+        TableName: tableName,
+        Key: marshall(commandKey(requestId)),
+        ConsistentRead: true,
+      }),
+    );
+    return result.Item
+      ? (unmarshall(result.Item) as MeetingControlCommand)
+      : undefined;
+  },
+  async listClaimablePendingCommands({ instanceId, nowEpochSeconds, limit }) {
+    const commands: MeetingControlCommand[] = [];
+    let exclusiveStartKey: Record<string, AttributeValue> | undefined;
+
+    do {
+      const result = await dynamoDbClient.send(
+        new QueryCommand({
+          TableName: tableName,
+          IndexName: STATUS_CREATED_AT_INDEX,
+          KeyConditionExpression: "#queueStatus = :pending",
+          FilterExpression:
+            "(attribute_not_exists(#targetOwnerInstanceId) OR #targetOwnerInstanceId = :instanceId) AND (attribute_not_exists(#claimExpiresAt) OR #claimExpiresAt < :nowEpochSeconds OR #claimedByInstanceId = :instanceId)",
+          ExpressionAttributeNames: {
+            "#queueStatus": "queueStatus",
+            "#targetOwnerInstanceId": "targetOwnerInstanceId",
+            "#claimExpiresAt": "claimExpiresAt",
+            "#claimedByInstanceId": "claimedByInstanceId",
+          },
+          ExpressionAttributeValues: marshall({
+            ":pending": PENDING_STATUS,
+            ":instanceId": instanceId,
+            ":nowEpochSeconds": nowEpochSeconds,
+          }),
+          ScanIndexForward: true,
+          Limit: limit,
+          ExclusiveStartKey: exclusiveStartKey,
+        }),
+      );
+
+      commands.push(
+        ...(result.Items ?? []).map(
+          (item) => unmarshall(item) as MeetingControlCommand,
+        ),
+      );
+      exclusiveStartKey = result.LastEvaluatedKey;
+    } while (commands.length < limit && exclusiveStartKey);
+
+    return commands.slice(0, limit);
+  },
+  async claimCommand(input) {
+    const result = await dynamoDbClient
+      .send(
+        new UpdateItemCommand({
+          TableName: tableName,
+          Key: marshall(commandKey(input.requestId)),
+          UpdateExpression:
+            "SET #claimedByInstanceId = :instanceId, #claimExpiresAt = :claimExpiresAt, #updatedAt = :updatedAt",
+          ConditionExpression:
+            "#queueStatus = :pending AND (attribute_not_exists(#targetOwnerInstanceId) OR #targetOwnerInstanceId = :instanceId) AND (attribute_not_exists(#claimExpiresAt) OR #claimExpiresAt < :nowEpochSeconds OR #claimedByInstanceId = :instanceId)",
+          ExpressionAttributeNames: {
+            "#queueStatus": "queueStatus",
+            "#targetOwnerInstanceId": "targetOwnerInstanceId",
+            "#claimedByInstanceId": "claimedByInstanceId",
+            "#claimExpiresAt": "claimExpiresAt",
+            "#updatedAt": "updatedAt",
+          },
+          ExpressionAttributeValues: marshall({
+            ":pending": PENDING_STATUS,
+            ":instanceId": input.instanceId,
+            ":claimExpiresAt": input.claimExpiresAt,
+            ":nowEpochSeconds": input.nowEpochSeconds,
+            ":updatedAt": input.updatedAt,
+          }),
+          ReturnValues: "ALL_NEW",
+        }),
+      )
+      .catch((error: unknown) => {
+        if (isConditionalFailure(error)) return undefined;
+        throw error;
+      });
+    return result?.Attributes
+      ? (unmarshall(result.Attributes) as MeetingControlCommand)
+      : undefined;
+  },
+  async completeCommand(input) {
+    try {
+      await dynamoDbClient.send(
+        new UpdateItemCommand({
+          TableName: tableName,
+          Key: marshall(commandKey(input.requestId)),
+          UpdateExpression:
+            "SET #queueStatus = :completed, #result = :result, #updatedAt = :updatedAt REMOVE #error",
+          ConditionExpression:
+            "#queueStatus = :pending AND #claimedByInstanceId = :instanceId",
+          ExpressionAttributeNames: {
+            "#queueStatus": "queueStatus",
+            "#result": "result",
+            "#updatedAt": "updatedAt",
+            "#error": "error",
+            "#claimedByInstanceId": "claimedByInstanceId",
+          },
+          ExpressionAttributeValues: marshall({
+            ":pending": PENDING_STATUS,
+            ":completed": "completed",
+            ":result": input.result,
+            ":updatedAt": input.updatedAt,
+            ":instanceId": input.instanceId,
+          }),
+        }),
+      );
+      return true;
+    } catch (error) {
+      if (isConditionalFailure(error)) return false;
+      throw error;
+    }
+  },
+  async failCommand(input) {
+    try {
+      await dynamoDbClient.send(
+        new UpdateItemCommand({
+          TableName: tableName,
+          Key: marshall(commandKey(input.requestId)),
+          UpdateExpression:
+            "SET #queueStatus = :failed, #error = :error, #updatedAt = :updatedAt REMOVE #result",
+          ConditionExpression:
+            "#queueStatus = :pending AND #claimedByInstanceId = :instanceId",
+          ExpressionAttributeNames: {
+            "#queueStatus": "queueStatus",
+            "#error": "error",
+            "#updatedAt": "updatedAt",
+            "#result": "result",
+            "#claimedByInstanceId": "claimedByInstanceId",
+          },
+          ExpressionAttributeValues: marshall({
+            ":pending": PENDING_STATUS,
+            ":failed": "failed",
+            ":error": input.error,
+            ":updatedAt": input.updatedAt,
+            ":instanceId": input.instanceId,
+          }),
+        }),
+      );
+      return true;
+    } catch (error) {
+      if (isConditionalFailure(error)) return false;
+      throw error;
+    }
+  },
+};
+
+const memoryCommands = new Map<string, MeetingControlCommand>();
+
+const cloneCommand = (command: MeetingControlCommand): MeetingControlCommand =>
+  JSON.parse(JSON.stringify(command)) as MeetingControlCommand;
+
+const memoryRepository: MeetingControlCommandRepository = {
+  async writeCommand(command) {
+    if (memoryCommands.has(command.requestId)) {
+      throw new Error("Meeting control command already exists.");
+    }
+    memoryCommands.set(command.requestId, cloneCommand(command));
+  },
+  async getCommand(requestId) {
+    const command = memoryCommands.get(requestId);
+    return command ? cloneCommand(command) : undefined;
+  },
+  async listClaimablePendingCommands({ instanceId, nowEpochSeconds, limit }) {
+    return Array.from(memoryCommands.values())
+      .filter((command) => command.queueStatus === PENDING_STATUS)
+      .filter(
+        (command) =>
+          !command.targetOwnerInstanceId ||
+          command.targetOwnerInstanceId === instanceId,
+      )
+      .filter(
+        (command) =>
+          !command.claimExpiresAt ||
+          command.claimExpiresAt < nowEpochSeconds ||
+          command.claimedByInstanceId === instanceId,
+      )
+      .sort((left, right) => left.createdAt.localeCompare(right.createdAt))
+      .slice(0, limit)
+      .map(cloneCommand);
+  },
+  async claimCommand(input) {
+    const command = memoryCommands.get(input.requestId);
+    if (!command || command.queueStatus !== PENDING_STATUS) return undefined;
+    if (
+      command.targetOwnerInstanceId &&
+      command.targetOwnerInstanceId !== input.instanceId
+    ) {
+      return undefined;
+    }
+    const claimExpired =
+      !command.claimExpiresAt || command.claimExpiresAt < input.nowEpochSeconds;
+    const ownClaim = command.claimedByInstanceId === input.instanceId;
+    if (!claimExpired && !ownClaim) return undefined;
+    command.claimedByInstanceId = input.instanceId;
+    command.claimExpiresAt = input.claimExpiresAt;
+    command.updatedAt = input.updatedAt;
+    return cloneCommand(command);
+  },
+  async completeCommand(input) {
+    const command = memoryCommands.get(input.requestId);
+    if (
+      !command ||
+      command.queueStatus !== PENDING_STATUS ||
+      command.claimedByInstanceId !== input.instanceId
+    ) {
+      return false;
+    }
+    command.queueStatus = "completed";
+    command.result = input.result;
+    command.error = undefined;
+    command.updatedAt = input.updatedAt;
+    return true;
+  },
+  async failCommand(input) {
+    const command = memoryCommands.get(input.requestId);
+    if (
+      !command ||
+      command.queueStatus !== PENDING_STATUS ||
+      command.claimedByInstanceId !== input.instanceId
+    ) {
+      return false;
+    }
+    command.queueStatus = "failed";
+    command.error = input.error;
+    command.result = undefined;
+    command.updatedAt = input.updatedAt;
+    return true;
+  },
+};
+
+export const getMeetingControlCommandRepository = () =>
+  config.mock.enabled ? memoryRepository : realRepository;
+
+export const resetMeetingControlCommandMemoryRepository = () => {
+  memoryCommands.clear();
+};

--- a/src/repositories/meetingControlCommandRepository.ts
+++ b/src/repositories/meetingControlCommandRepository.ts
@@ -109,9 +109,10 @@ const realRepository: MeetingControlCommandRepository = {
           IndexName: STATUS_CREATED_AT_INDEX,
           KeyConditionExpression: "#queueStatus = :pending",
           FilterExpression:
-            "(attribute_not_exists(#targetOwnerInstanceId) OR #targetOwnerInstanceId = :instanceId) AND (attribute_not_exists(#claimExpiresAt) OR #claimExpiresAt < :nowEpochSeconds OR #claimedByInstanceId = :instanceId)",
+            "#expiresAt > :nowEpochSeconds AND (attribute_not_exists(#targetOwnerInstanceId) OR #targetOwnerInstanceId = :instanceId) AND (attribute_not_exists(#claimExpiresAt) OR #claimExpiresAt < :nowEpochSeconds OR #claimedByInstanceId = :instanceId)",
           ExpressionAttributeNames: {
             "#queueStatus": "queueStatus",
+            "#expiresAt": "expiresAt",
             "#targetOwnerInstanceId": "targetOwnerInstanceId",
             "#claimExpiresAt": "claimExpiresAt",
             "#claimedByInstanceId": "claimedByInstanceId",
@@ -146,9 +147,10 @@ const realRepository: MeetingControlCommandRepository = {
           UpdateExpression:
             "SET #claimedByInstanceId = :instanceId, #claimExpiresAt = :claimExpiresAt, #updatedAt = :updatedAt",
           ConditionExpression:
-            "#queueStatus = :pending AND (attribute_not_exists(#targetOwnerInstanceId) OR #targetOwnerInstanceId = :instanceId) AND (attribute_not_exists(#claimExpiresAt) OR #claimExpiresAt < :nowEpochSeconds OR #claimedByInstanceId = :instanceId)",
+            "#queueStatus = :pending AND #expiresAt > :nowEpochSeconds AND (attribute_not_exists(#targetOwnerInstanceId) OR #targetOwnerInstanceId = :instanceId) AND (attribute_not_exists(#claimExpiresAt) OR #claimExpiresAt < :nowEpochSeconds OR #claimedByInstanceId = :instanceId)",
           ExpressionAttributeNames: {
             "#queueStatus": "queueStatus",
+            "#expiresAt": "expiresAt",
             "#targetOwnerInstanceId": "targetOwnerInstanceId",
             "#claimedByInstanceId": "claimedByInstanceId",
             "#claimExpiresAt": "claimExpiresAt",
@@ -257,6 +259,7 @@ const memoryRepository: MeetingControlCommandRepository = {
   async listClaimablePendingCommands({ instanceId, nowEpochSeconds, limit }) {
     return Array.from(memoryCommands.values())
       .filter((command) => command.queueStatus === PENDING_STATUS)
+      .filter((command) => command.expiresAt > nowEpochSeconds)
       .filter(
         (command) =>
           !command.targetOwnerInstanceId ||
@@ -275,6 +278,7 @@ const memoryRepository: MeetingControlCommandRepository = {
   async claimCommand(input) {
     const command = memoryCommands.get(input.requestId);
     if (!command || command.queueStatus !== PENDING_STATUS) return undefined;
+    if (command.expiresAt <= input.nowEpochSeconds) return undefined;
     if (
       command.targetOwnerInstanceId &&
       command.targetOwnerInstanceId !== input.instanceId

--- a/src/services/activeMeetingLeaseService.ts
+++ b/src/services/activeMeetingLeaseService.ts
@@ -170,12 +170,14 @@ export async function requestMeetingEndViaLease(
   guildId: string,
   meetingId: string,
   requestedByUserId: string,
+  endReason: ActiveMeetingLease["endReason"] = MEETING_END_REASONS.WEB_UI,
 ): Promise<boolean> {
   return requestActiveMeetingEnd(
     guildId,
     meetingId,
     requestedByUserId,
     new Date().toISOString(),
+    endReason,
   );
 }
 
@@ -258,7 +260,7 @@ async function processRemoteEndRequest(
     requestedBy: lease.endRequestedByUserId,
   });
   stopMeetingLeaseHeartbeat(meeting);
-  meeting.endReason = MEETING_END_REASONS.WEB_UI;
+  meeting.endReason = lease.endReason ?? MEETING_END_REASONS.WEB_UI;
   meeting.endTriggeredByUserId = lease.endRequestedByUserId;
   await onEndMeeting(meeting);
   return true;

--- a/src/services/mcpMeetingControlService.ts
+++ b/src/services/mcpMeetingControlService.ts
@@ -1,0 +1,94 @@
+import {
+  getMeetingControlCommandForUser,
+  queueMeetingControlCommand,
+  resolveTargetOwnerForGuild,
+  type MeetingControlCommandSnapshot,
+} from "./meetingControlQueueService";
+import {
+  MEETING_CONTROL_COMMAND_TYPES,
+  type LiveMeetingCommandInput,
+  type StartMeetingCommandInput,
+  type StopMeetingCommandInput,
+} from "../types/meetingControl";
+
+export class McpMeetingControlError extends Error {
+  constructor(
+    readonly code: "not_found" | "failed",
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+const queueForGuildOwner = async (
+  userId: string,
+  commandType: (typeof MEETING_CONTROL_COMMAND_TYPES)[keyof typeof MEETING_CONTROL_COMMAND_TYPES],
+  input:
+    | StartMeetingCommandInput
+    | StopMeetingCommandInput
+    | LiveMeetingCommandInput,
+) =>
+  queueMeetingControlCommand({
+    commandType,
+    userId,
+    input,
+    targetOwnerInstanceId: await resolveTargetOwnerForGuild(input.serverId),
+  });
+
+export async function startMcpMeetingControl(input: {
+  userId: string;
+  request: StartMeetingCommandInput;
+}) {
+  return queueMeetingControlCommand({
+    commandType: MEETING_CONTROL_COMMAND_TYPES.START_MEETING,
+    userId: input.userId,
+    input: input.request,
+  });
+}
+
+export async function stopMcpMeetingControl(input: {
+  userId: string;
+  request: StopMeetingCommandInput;
+}) {
+  return queueForGuildOwner(
+    input.userId,
+    MEETING_CONTROL_COMMAND_TYPES.STOP_MEETING,
+    input.request,
+  );
+}
+
+export async function getMcpLiveMeetingStatus(input: {
+  userId: string;
+  request: LiveMeetingCommandInput;
+}) {
+  return queueForGuildOwner(
+    input.userId,
+    MEETING_CONTROL_COMMAND_TYPES.GET_LIVE_STATUS,
+    input.request,
+  );
+}
+
+export async function getMcpLiveMeetingTranscript(input: {
+  userId: string;
+  request: LiveMeetingCommandInput;
+}) {
+  return queueForGuildOwner(
+    input.userId,
+    MEETING_CONTROL_COMMAND_TYPES.GET_LIVE_TRANSCRIPT,
+    input.request,
+  );
+}
+
+export async function getMcpMeetingControlRequest(input: {
+  userId: string;
+  requestId: string;
+}): Promise<MeetingControlCommandSnapshot> {
+  const snapshot = await getMeetingControlCommandForUser(
+    input.requestId,
+    input.userId,
+  );
+  if (!snapshot) {
+    throw new McpMeetingControlError("not_found", "Request not found.");
+  }
+  return snapshot;
+}

--- a/src/services/mcpMeetingControlService.ts
+++ b/src/services/mcpMeetingControlService.ts
@@ -72,6 +72,12 @@ export async function getMcpLiveMeetingTranscript(input: {
   userId: string;
   request: LiveMeetingCommandInput;
 }) {
+  if (!input.request.serverId) {
+    throw new McpMeetingControlError(
+      "failed",
+      "serverId is required for live transcript requests.",
+    );
+  }
   return queueForGuildOwner(
     input.userId,
     MEETING_CONTROL_COMMAND_TYPES.GET_LIVE_TRANSCRIPT,

--- a/src/services/meetingControlBotService.ts
+++ b/src/services/meetingControlBotService.ts
@@ -274,51 +274,47 @@ const canMemberEndLease = (
   startTriggeredByUserId?: string,
 ) => startTriggeredByUserId === userId || canGuildMemberEndMeeting(member);
 
-const executeStopMeeting = async (
-  client: Client,
+const executeStopLocalMeeting = async (
+  guild: Guild,
+  guildId: string,
+  userId: string,
+  input: StopMeetingCommandInput,
+  meeting: MeetingData,
+): Promise<MeetingControlCommandResult> => {
+  if (input.meetingId && meeting.meetingId !== input.meetingId) {
+    throw new MeetingControlExecutionError("Meeting not found.");
+  }
+  const member = await fetchMember(guild, userId);
+  if (
+    meeting.creator.id !== userId &&
+    !canMemberEndLease(member, userId, meeting.startTriggeredByUserId)
+  ) {
+    throw new MeetingControlExecutionError(
+      "You do not have permission to end this meeting.",
+    );
+  }
+  if (meeting.finishing || meeting.finished) {
+    return {
+      status: "stopping",
+      serverId: guildId,
+      meetingId: meeting.meetingId,
+    };
+  }
+  meeting.endReason = MEETING_END_REASONS.MCP;
+  meeting.endTriggeredByUserId = userId;
+  if (!meeting.onEndMeeting) {
+    throw new MeetingControlExecutionError("End meeting handler unavailable.");
+  }
+  await meeting.onEndMeeting(meeting);
+  return { status: "ended", serverId: guildId, meetingId: meeting.meetingId };
+};
+
+const executeStopLeasedMeeting = async (
+  guild: Guild,
+  guildId: string,
   userId: string,
   input: StopMeetingCommandInput,
 ): Promise<MeetingControlCommandResult> => {
-  const state = input.serverId
-    ? undefined
-    : await resolveUserVoiceState(client, userId, input);
-  const guildId = input.serverId ?? state?.guild.id;
-  if (!guildId) {
-    throw new MeetingControlExecutionError("serverId is required.");
-  }
-  const guild = await getGuildOrThrow(client, guildId);
-  const meeting = getMeeting(guildId);
-  if (meeting) {
-    if (input.meetingId && meeting.meetingId !== input.meetingId) {
-      throw new MeetingControlExecutionError("Meeting not found.");
-    }
-    const member = await fetchMember(guild, userId);
-    if (
-      meeting.creator.id !== userId &&
-      !canMemberEndLease(member, userId, meeting.startTriggeredByUserId)
-    ) {
-      throw new MeetingControlExecutionError(
-        "You do not have permission to end this meeting.",
-      );
-    }
-    if (meeting.finishing || meeting.finished) {
-      return {
-        status: "stopping",
-        serverId: guildId,
-        meetingId: meeting.meetingId,
-      };
-    }
-    meeting.endReason = MEETING_END_REASONS.MCP;
-    meeting.endTriggeredByUserId = userId;
-    if (!meeting.onEndMeeting) {
-      throw new MeetingControlExecutionError(
-        "End meeting handler unavailable.",
-      );
-    }
-    await meeting.onEndMeeting(meeting);
-    return { status: "ended", serverId: guildId, meetingId: meeting.meetingId };
-  }
-
   const lease = await getActiveMeetingLeaseForGuild(guildId);
   if (!lease || !isLeaseActive(lease)) {
     throw new MeetingControlExecutionError("Meeting not found.");
@@ -342,6 +338,26 @@ const executeStopMeeting = async (
     throw new MeetingControlExecutionError("Meeting end request was rejected.");
   }
   return { status: "stopping", serverId: guildId, meetingId: lease.meetingId };
+};
+
+const executeStopMeeting = async (
+  client: Client,
+  userId: string,
+  input: StopMeetingCommandInput,
+): Promise<MeetingControlCommandResult> => {
+  const state = input.serverId
+    ? undefined
+    : await resolveUserVoiceState(client, userId, input);
+  const guildId = input.serverId ?? state?.guild.id;
+  if (!guildId) {
+    throw new MeetingControlExecutionError("serverId is required.");
+  }
+  const guild = await getGuildOrThrow(client, guildId);
+  const meeting = getMeeting(guildId);
+  if (meeting) {
+    return executeStopLocalMeeting(guild, guildId, userId, input, meeting);
+  }
+  return executeStopLeasedMeeting(guild, guildId, userId, input);
 };
 
 const resolveLiveMeeting = async (

--- a/src/services/meetingControlBotService.ts
+++ b/src/services/meetingControlBotService.ts
@@ -1,0 +1,497 @@
+import {
+  PermissionFlagsBits,
+  type Client,
+  type Guild,
+  type GuildMember,
+  type TextChannel,
+  type VoiceBasedChannel,
+  type VoiceState,
+} from "discord.js";
+import { getMeeting } from "../meetings";
+import {
+  buildManualMeetingStartedMessage,
+  startManualMeetingFromChannels,
+} from "../commands/startMeeting";
+import {
+  getActiveMeetingLeaseForGuild,
+  isLeaseActive,
+  requestMeetingEndViaLease,
+} from "./activeMeetingLeaseService";
+import { getGuildLimits } from "./subscriptionService";
+import {
+  getSnapshotString,
+  resolveConfigSnapshot,
+} from "./unifiedConfigService";
+import { CONFIG_KEYS } from "../config/keys";
+import { buildLiveMeetingTimelineEvents } from "./meetingTimelineService";
+import {
+  MEETING_CONTROL_COMMAND_TYPES,
+  type LiveMeetingCommandInput,
+  type MeetingControlCommand,
+  type MeetingControlCommandResult,
+  type StartMeetingCommandInput,
+  type StopMeetingCommandInput,
+} from "../types/meetingControl";
+import {
+  MEETING_END_REASONS,
+  MEETING_START_REASONS,
+  MEETING_STATUS,
+  resolveMeetingStatus,
+} from "../types/meetingLifecycle";
+import { canGuildMemberEndMeeting } from "../utils/meetingPermissions";
+import type { ActiveMeetingLease } from "../types/db";
+import type { MeetingData } from "../types/meeting-data";
+
+const DEFAULT_TRANSCRIPT_EVENT_LIMIT = 50;
+const MAX_TRANSCRIPT_EVENT_LIMIT = 200;
+
+class MeetingControlExecutionError extends Error {}
+
+type ResolvedLiveMeeting =
+  | { guildId: string; meeting: MeetingData }
+  | { guildId: string; lease: ActiveMeetingLease };
+
+const getGuildOrThrow = async (client: Client, guildId: string) => {
+  const guild =
+    client.guilds.cache.get(guildId) ??
+    (await client.guilds.fetch(guildId).catch(() => null));
+  if (!guild) {
+    throw new MeetingControlExecutionError("Chronote is not in that server.");
+  }
+  return guild;
+};
+
+const fetchVoiceState = async (guild: Guild, userId: string) => {
+  const cached = guild.voiceStates.cache.get(userId);
+  if (cached?.channelId) return cached;
+  return guild.voiceStates.fetch(userId).catch(() => null);
+};
+
+const findUserVoiceStates = async (
+  client: Client,
+  userId: string,
+  guildId?: string,
+): Promise<VoiceState[]> => {
+  if (guildId) {
+    const guild = await getGuildOrThrow(client, guildId);
+    const state = await fetchVoiceState(guild, userId);
+    return state?.channelId ? [state] : [];
+  }
+
+  const cachedStates = client.guilds.cache
+    .map((guild) => guild.voiceStates.cache.get(userId))
+    .filter((state): state is VoiceState => Boolean(state?.channelId));
+  if (cachedStates.length > 0) return cachedStates;
+
+  const fetchedStates = await Promise.all(
+    client.guilds.cache.map((guild) => fetchVoiceState(guild, userId)),
+  );
+  return fetchedStates.filter((state): state is VoiceState =>
+    Boolean(state?.channelId),
+  );
+};
+
+const resolveUserVoiceState = async (
+  client: Client,
+  userId: string,
+  input:
+    | StartMeetingCommandInput
+    | StopMeetingCommandInput
+    | LiveMeetingCommandInput,
+) => {
+  const states = await findUserVoiceStates(client, userId, input.serverId);
+  if (states.length === 0) {
+    throw new MeetingControlExecutionError(
+      "Join a Discord voice channel first, then retry.",
+    );
+  }
+  if (states.length > 1) {
+    throw new MeetingControlExecutionError(
+      "You are connected to multiple voice channels. Provide serverId.",
+    );
+  }
+  return states[0];
+};
+
+const fetchVoiceChannel = async (guild: Guild, voiceChannelId: string) => {
+  const channel = await guild.channels.fetch(voiceChannelId).catch(() => null);
+  if (!channel?.isVoiceBased()) {
+    throw new MeetingControlExecutionError("Voice channel not found.");
+  }
+  return channel as VoiceBasedChannel;
+};
+
+const fetchTextChannel = async (guild: Guild, textChannelId: string) => {
+  const channel = await guild.channels.fetch(textChannelId).catch(() => null);
+  if (!channel?.isTextBased()) {
+    throw new MeetingControlExecutionError("Text channel not found.");
+  }
+  return channel as TextChannel;
+};
+
+const resolveDefaultTextChannelId = async (guild: Guild) => {
+  const { subscription } = await getGuildLimits(guild.id);
+  const snapshot = await resolveConfigSnapshot({
+    guildId: guild.id,
+    tier: subscription.tier,
+  });
+  return getSnapshotString(snapshot, CONFIG_KEYS.notes.channelId, {
+    trim: true,
+  });
+};
+
+const resolveTextChannel = async (
+  guild: Guild,
+  input: StartMeetingCommandInput,
+) => {
+  const textChannelId =
+    input.textChannelId ?? (await resolveDefaultTextChannelId(guild));
+  if (!textChannelId) {
+    throw new MeetingControlExecutionError(
+      "Set a default notes channel or pass textChannelId.",
+    );
+  }
+  return fetchTextChannel(guild, textChannelId);
+};
+
+const fetchMember = async (guild: Guild, userId: string) =>
+  guild.members.cache.get(userId) ??
+  (await guild.members.fetch(userId).catch(() => null));
+
+const assertGuildMember: (
+  member: GuildMember | null,
+) => asserts member is GuildMember = (member) => {
+  if (!member) {
+    throw new MeetingControlExecutionError("Meeting access required.");
+  }
+};
+
+const assertMemberCanUseTextChannel = (
+  member: GuildMember | null,
+  textChannel: TextChannel,
+) => {
+  assertGuildMember(member);
+  const permissions = textChannel.permissionsFor(member);
+  if (
+    !permissions ||
+    !permissions.has(PermissionFlagsBits.ViewChannel) ||
+    !permissions.has(PermissionFlagsBits.SendMessages)
+  ) {
+    throw new MeetingControlExecutionError(
+      "You do not have permission to use the requested text channel.",
+    );
+  }
+};
+
+const assertMemberCanAccessLiveChannels = (
+  member: GuildMember | null,
+  voiceChannel: VoiceBasedChannel,
+  textChannel: TextChannel,
+) => {
+  assertGuildMember(member);
+  const voicePermissions = voiceChannel.permissionsFor(member);
+  const textPermissions = textChannel.permissionsFor(member);
+  if (
+    !voicePermissions ||
+    !voicePermissions.has(PermissionFlagsBits.ViewChannel) ||
+    !voicePermissions.has(PermissionFlagsBits.Connect) ||
+    !textPermissions ||
+    !textPermissions.has(PermissionFlagsBits.ViewChannel) ||
+    !textPermissions.has(PermissionFlagsBits.ReadMessageHistory)
+  ) {
+    throw new MeetingControlExecutionError("Meeting access required.");
+  }
+};
+
+const assertSameVoiceChannel = (
+  state: VoiceState,
+  voiceChannel: VoiceBasedChannel,
+) => {
+  if (state.channelId !== voiceChannel.id) {
+    throw new MeetingControlExecutionError(
+      "Join the requested voice channel before starting a meeting.",
+    );
+  }
+};
+
+const executeStartMeeting = async (
+  client: Client,
+  userId: string,
+  input: StartMeetingCommandInput,
+): Promise<MeetingControlCommandResult> => {
+  const state = await resolveUserVoiceState(client, userId, input);
+  const guild = state.guild;
+  const voiceChannel = input.voiceChannelId
+    ? await fetchVoiceChannel(guild, input.voiceChannelId)
+    : state.channel;
+  if (!voiceChannel) {
+    throw new MeetingControlExecutionError("Voice channel not found.");
+  }
+  assertSameVoiceChannel(state, voiceChannel);
+
+  const textChannel = await resolveTextChannel(guild, input);
+  const member = await fetchMember(guild, userId);
+  assertMemberCanUseTextChannel(member, textChannel);
+  const creator = await client.users.fetch(userId);
+  const startResult = await startManualMeetingFromChannels({
+    client,
+    guild,
+    voiceChannel,
+    textChannel,
+    creator,
+    meetingContext: input.context,
+    tags: input.tags,
+    startReason: MEETING_START_REASONS.MCP,
+    startTriggeredByUserId: userId,
+  });
+  if (!startResult.ok) {
+    throw new MeetingControlExecutionError(startResult.error);
+  }
+
+  const message = await textChannel.send(
+    buildManualMeetingStartedMessage(
+      startResult.meeting,
+      startResult.liveMeetingUrl,
+    ),
+  );
+  startResult.meeting.startMessageId = message.id;
+
+  return {
+    status: "started",
+    serverId: guild.id,
+    meetingId: startResult.meeting.meetingId,
+    voiceChannelId: voiceChannel.id,
+    voiceChannelName: voiceChannel.name,
+    textChannelId: textChannel.id,
+    startedAt: startResult.meeting.startTime.toISOString(),
+    liveUrl: startResult.liveMeetingUrl ?? undefined,
+  };
+};
+
+const canMemberEndLease = (
+  member: GuildMember | null,
+  userId: string,
+  startTriggeredByUserId?: string,
+) => startTriggeredByUserId === userId || canGuildMemberEndMeeting(member);
+
+const executeStopMeeting = async (
+  client: Client,
+  userId: string,
+  input: StopMeetingCommandInput,
+): Promise<MeetingControlCommandResult> => {
+  const state = input.serverId
+    ? undefined
+    : await resolveUserVoiceState(client, userId, input);
+  const guildId = input.serverId ?? state?.guild.id;
+  if (!guildId) {
+    throw new MeetingControlExecutionError("serverId is required.");
+  }
+  const guild = await getGuildOrThrow(client, guildId);
+  const meeting = getMeeting(guildId);
+  if (meeting) {
+    if (input.meetingId && meeting.meetingId !== input.meetingId) {
+      throw new MeetingControlExecutionError("Meeting not found.");
+    }
+    const member = await fetchMember(guild, userId);
+    if (
+      meeting.creator.id !== userId &&
+      !canMemberEndLease(member, userId, meeting.startTriggeredByUserId)
+    ) {
+      throw new MeetingControlExecutionError(
+        "You do not have permission to end this meeting.",
+      );
+    }
+    if (meeting.finishing || meeting.finished) {
+      return {
+        status: "stopping",
+        serverId: guildId,
+        meetingId: meeting.meetingId,
+      };
+    }
+    meeting.endReason = MEETING_END_REASONS.MCP;
+    meeting.endTriggeredByUserId = userId;
+    if (!meeting.onEndMeeting) {
+      throw new MeetingControlExecutionError(
+        "End meeting handler unavailable.",
+      );
+    }
+    await meeting.onEndMeeting(meeting);
+    return { status: "ended", serverId: guildId, meetingId: meeting.meetingId };
+  }
+
+  const lease = await getActiveMeetingLeaseForGuild(guildId);
+  if (!lease || !isLeaseActive(lease)) {
+    throw new MeetingControlExecutionError("Meeting not found.");
+  }
+  if (input.meetingId && lease.meetingId !== input.meetingId) {
+    throw new MeetingControlExecutionError("Meeting not found.");
+  }
+  const member = await fetchMember(guild, userId);
+  if (!canMemberEndLease(member, userId, lease.startTriggeredByUserId)) {
+    throw new MeetingControlExecutionError(
+      "You do not have permission to end this meeting.",
+    );
+  }
+  const queued = await requestMeetingEndViaLease(
+    guildId,
+    lease.meetingId,
+    userId,
+    MEETING_END_REASONS.MCP,
+  );
+  if (!queued) {
+    throw new MeetingControlExecutionError("Meeting end request was rejected.");
+  }
+  return { status: "stopping", serverId: guildId, meetingId: lease.meetingId };
+};
+
+const resolveLiveMeeting = async (
+  client: Client,
+  userId: string,
+  input: LiveMeetingCommandInput,
+): Promise<ResolvedLiveMeeting> => {
+  const state = input.serverId
+    ? undefined
+    : await resolveUserVoiceState(client, userId, input);
+  const guildId = input.serverId ?? state?.guild.id;
+  if (!guildId) {
+    throw new MeetingControlExecutionError("serverId is required.");
+  }
+  const guild = state?.guild ?? (await getGuildOrThrow(client, guildId));
+  const member = await fetchMember(guild, userId);
+  const meeting = getMeeting(guildId);
+  if (meeting && (!input.meetingId || meeting.meetingId === input.meetingId)) {
+    assertMemberCanAccessLiveChannels(
+      member,
+      meeting.voiceChannel,
+      meeting.textChannel,
+    );
+    return { guildId, meeting };
+  }
+  const lease = await getActiveMeetingLeaseForGuild(guildId);
+  if (
+    !lease ||
+    !isLeaseActive(lease) ||
+    (input.meetingId && lease.meetingId !== input.meetingId)
+  ) {
+    throw new MeetingControlExecutionError("Meeting not found.");
+  }
+  const voiceChannel = await fetchVoiceChannel(guild, lease.voiceChannelId);
+  const textChannel = await fetchTextChannel(guild, lease.textChannelId);
+  assertMemberCanAccessLiveChannels(member, voiceChannel, textChannel);
+  return { guildId, lease };
+};
+
+const executeGetLiveStatus = async (
+  client: Client,
+  userId: string,
+  input: LiveMeetingCommandInput,
+): Promise<MeetingControlCommandResult> => {
+  const live = await resolveLiveMeeting(client, userId, input);
+  if ("meeting" in live) {
+    const meetingStatus = resolveMeetingStatus({
+      cancelled: live.meeting.cancelled,
+      finished: live.meeting.finished,
+      finishing: live.meeting.finishing,
+    });
+    return {
+      status: meetingStatus,
+      serverId: live.guildId,
+      meetingId: live.meeting.meetingId,
+      voiceChannelId: live.meeting.voiceChannel.id,
+      voiceChannelName: live.meeting.voiceChannel.name,
+      textChannelId: live.meeting.textChannel.id,
+      startedAt: live.meeting.startTime.toISOString(),
+      endedAt: live.meeting.endTime?.toISOString(),
+      isAutoRecording: live.meeting.isAutoRecording,
+    };
+  }
+  return {
+    status: isLeaseActive(live.lease)
+      ? (live.lease.status ?? MEETING_STATUS.IN_PROGRESS)
+      : MEETING_STATUS.COMPLETE,
+    serverId: live.guildId,
+    meetingId: live.lease.meetingId,
+    voiceChannelId: live.lease.voiceChannelId,
+    voiceChannelName: live.lease.voiceChannelName,
+    textChannelId: live.lease.textChannelId,
+    startedAt: live.lease.createdAt,
+    endedAt: live.lease.endedAt,
+    isAutoRecording: live.lease.isAutoRecording,
+  };
+};
+
+const executeGetLiveTranscript = async (
+  client: Client,
+  userId: string,
+  input: LiveMeetingCommandInput,
+): Promise<MeetingControlCommandResult> => {
+  const live = await resolveLiveMeeting(client, userId, input);
+  if (!("meeting" in live)) {
+    throw new MeetingControlExecutionError(
+      "Live transcript is only available on the meeting owner runtime.",
+    );
+  }
+  const allEvents = buildLiveMeetingTimelineEvents(live.meeting).filter(
+    (event) =>
+      (event.type === "voice" ||
+        event.type === "tts" ||
+        event.type === "bot") &&
+      event.text.trim().length > 0,
+  );
+  const startIndex = input.afterEventId
+    ? allEvents.findIndex((event) => event.id === input.afterEventId) + 1
+    : 0;
+  const safeStartIndex = Math.max(0, startIndex);
+  const limit = Math.min(
+    MAX_TRANSCRIPT_EVENT_LIMIT,
+    Math.max(1, input.limit ?? DEFAULT_TRANSCRIPT_EVENT_LIMIT),
+  );
+  const events = allEvents.slice(safeStartIndex, safeStartIndex + limit);
+  const nextEvent = events.at(-1);
+  const hasMore = safeStartIndex + events.length < allEvents.length;
+  return {
+    serverId: live.guildId,
+    meetingId: live.meeting.meetingId,
+    events: events.map((event) => ({
+      id: event.id,
+      type: event.type,
+      time: event.time,
+      speaker: event.speaker,
+      text: event.text,
+    })),
+    hasMore,
+    nextAfterEventId: hasMore ? nextEvent?.id : undefined,
+  };
+};
+
+export async function executeMeetingControlCommand(
+  client: Client,
+  command: MeetingControlCommand,
+): Promise<MeetingControlCommandResult> {
+  switch (command.commandType) {
+    case MEETING_CONTROL_COMMAND_TYPES.START_MEETING:
+      return executeStartMeeting(
+        client,
+        command.userId,
+        command.input as StartMeetingCommandInput,
+      );
+    case MEETING_CONTROL_COMMAND_TYPES.STOP_MEETING:
+      return executeStopMeeting(
+        client,
+        command.userId,
+        command.input as StopMeetingCommandInput,
+      );
+    case MEETING_CONTROL_COMMAND_TYPES.GET_LIVE_STATUS:
+      return executeGetLiveStatus(
+        client,
+        command.userId,
+        command.input as LiveMeetingCommandInput,
+      );
+    case MEETING_CONTROL_COMMAND_TYPES.GET_LIVE_TRANSCRIPT:
+      return executeGetLiveTranscript(
+        client,
+        command.userId,
+        command.input as LiveMeetingCommandInput,
+      );
+  }
+}

--- a/src/services/meetingControlQueueService.ts
+++ b/src/services/meetingControlQueueService.ts
@@ -1,0 +1,115 @@
+import crypto from "node:crypto";
+import {
+  getActiveMeetingLeaseForGuild,
+  isLeaseActive,
+} from "./activeMeetingLeaseService";
+import { getMeetingControlCommandRepository } from "../repositories/meetingControlCommandRepository";
+import type {
+  MeetingControlCommand,
+  MeetingControlCommandInput,
+  MeetingControlCommandResult,
+  MeetingControlCommandType,
+} from "../types/meetingControl";
+
+const COMMAND_TTL_SECONDS = 15 * 60;
+const DEFAULT_WAIT_TIMEOUT_MS = 25_000;
+const WAIT_POLL_INTERVAL_MS = 500;
+
+export type QueueMeetingControlCommandInput = {
+  commandType: MeetingControlCommandType;
+  userId: string;
+  input: MeetingControlCommandInput;
+  targetOwnerInstanceId?: string;
+  waitTimeoutMs?: number;
+};
+
+export type MeetingControlCommandSnapshot = {
+  requestId: string;
+  queueStatus: MeetingControlCommand["queueStatus"];
+  commandType: MeetingControlCommandType;
+  createdAt: string;
+  updatedAt: string;
+  result?: MeetingControlCommandResult;
+  error?: string;
+};
+
+const epochSeconds = () => Math.floor(Date.now() / 1000);
+const nowIso = () => new Date().toISOString();
+
+const sleep = (durationMs: number) =>
+  new Promise((resolve) => setTimeout(resolve, durationMs));
+
+const toSnapshot = (
+  command: MeetingControlCommand,
+): MeetingControlCommandSnapshot => ({
+  requestId: command.requestId,
+  queueStatus: command.queueStatus,
+  commandType: command.commandType,
+  createdAt: command.createdAt,
+  updatedAt: command.updatedAt,
+  result: command.result,
+  error: command.error,
+});
+
+export async function resolveTargetOwnerForGuild(guildId?: string) {
+  if (!guildId) return undefined;
+  const lease = await getActiveMeetingLeaseForGuild(guildId);
+  return lease && isLeaseActive(lease) ? lease.ownerInstanceId : undefined;
+}
+
+export async function enqueueMeetingControlCommand(
+  input: QueueMeetingControlCommandInput,
+): Promise<MeetingControlCommand> {
+  const createdAt = nowIso();
+  const command: MeetingControlCommand = {
+    requestId: crypto.randomUUID(),
+    queueStatus: "pending",
+    commandType: input.commandType,
+    userId: input.userId,
+    input: input.input,
+    targetOwnerInstanceId: input.targetOwnerInstanceId,
+    createdAt,
+    updatedAt: createdAt,
+    expiresAt: epochSeconds() + COMMAND_TTL_SECONDS,
+  };
+  await getMeetingControlCommandRepository().writeCommand(command);
+  return command;
+}
+
+export async function waitForMeetingControlCommand(
+  requestId: string,
+  timeoutMs = DEFAULT_WAIT_TIMEOUT_MS,
+): Promise<MeetingControlCommandSnapshot | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    const command =
+      await getMeetingControlCommandRepository().getCommand(requestId);
+    if (!command) return undefined;
+    if (command.queueStatus !== "pending") return toSnapshot(command);
+    await sleep(WAIT_POLL_INTERVAL_MS);
+  }
+  const command =
+    await getMeetingControlCommandRepository().getCommand(requestId);
+  return command ? toSnapshot(command) : undefined;
+}
+
+export async function queueMeetingControlCommand(
+  input: QueueMeetingControlCommandInput,
+): Promise<MeetingControlCommandSnapshot> {
+  const command = await enqueueMeetingControlCommand(input);
+  const waited = await waitForMeetingControlCommand(
+    command.requestId,
+    input.waitTimeoutMs,
+  );
+  return waited ?? toSnapshot(command);
+}
+
+export async function getMeetingControlCommandForUser(
+  requestId: string,
+  userId: string,
+): Promise<MeetingControlCommandSnapshot | undefined> {
+  const command =
+    await getMeetingControlCommandRepository().getCommand(requestId);
+  if (!command || command.userId !== userId) return undefined;
+  return toSnapshot(command);
+}

--- a/src/services/meetingControlWorkerService.ts
+++ b/src/services/meetingControlWorkerService.ts
@@ -1,0 +1,93 @@
+import type { Client } from "discord.js";
+import { getMeetingControlCommandRepository } from "../repositories/meetingControlCommandRepository";
+import { executeMeetingControlCommand } from "./meetingControlBotService";
+import { getRuntimeInstanceId } from "./runtimeInstanceService";
+
+const WORKER_POLL_INTERVAL_MS = 2_000;
+const WORKER_CLAIM_SECONDS = 60;
+const WORKER_CLAIM_RENEWAL_MS = 30_000;
+const WORKER_BATCH_SIZE = 5;
+
+let workerTimer: ReturnType<typeof setInterval> | undefined;
+let pollInProgress = false;
+
+const epochSeconds = () => Math.floor(Date.now() / 1000);
+const nowIso = () => new Date().toISOString();
+
+const renewClaim = async (requestId: string, instanceId: string) =>
+  getMeetingControlCommandRepository().claimCommand({
+    requestId,
+    instanceId,
+    nowEpochSeconds: epochSeconds(),
+    claimExpiresAt: epochSeconds() + WORKER_CLAIM_SECONDS,
+    updatedAt: nowIso(),
+  });
+
+const startClaimRenewal = (requestId: string, instanceId: string) =>
+  setInterval(() => {
+    void renewClaim(requestId, instanceId).catch((error) => {
+      console.error("Meeting control command claim renewal failed", error);
+    });
+  }, WORKER_CLAIM_RENEWAL_MS);
+
+async function pollMeetingControlCommands(client: Client) {
+  if (pollInProgress) return;
+  pollInProgress = true;
+  const repository = getMeetingControlCommandRepository();
+  const instanceId = getRuntimeInstanceId();
+  const now = epochSeconds();
+  try {
+    const commands = await repository.listClaimablePendingCommands({
+      instanceId,
+      nowEpochSeconds: now,
+      limit: WORKER_BATCH_SIZE,
+    });
+    for (const command of commands) {
+      const claimed = await repository.claimCommand({
+        requestId: command.requestId,
+        instanceId,
+        nowEpochSeconds: epochSeconds(),
+        claimExpiresAt: epochSeconds() + WORKER_CLAIM_SECONDS,
+        updatedAt: nowIso(),
+      });
+      if (!claimed) continue;
+      const renewalTimer = startClaimRenewal(claimed.requestId, instanceId);
+      try {
+        const result = await executeMeetingControlCommand(client, claimed);
+        await repository.completeCommand({
+          requestId: claimed.requestId,
+          instanceId,
+          updatedAt: nowIso(),
+          result,
+        });
+      } catch (error) {
+        await repository.failCommand({
+          requestId: claimed.requestId,
+          instanceId,
+          updatedAt: nowIso(),
+          error: error instanceof Error ? error.message : String(error),
+        });
+      } finally {
+        clearInterval(renewalTimer);
+      }
+    }
+  } catch (error) {
+    console.error("Meeting control command worker failed", error);
+  } finally {
+    pollInProgress = false;
+  }
+}
+
+export function startMeetingControlCommandWorker(client: Client) {
+  if (workerTimer) return;
+  void pollMeetingControlCommands(client);
+  workerTimer = setInterval(() => {
+    void pollMeetingControlCommands(client);
+  }, WORKER_POLL_INTERVAL_MS);
+}
+
+export function stopMeetingControlCommandWorker() {
+  if (!workerTimer) return;
+  clearInterval(workerTimer);
+  workerTimer = undefined;
+}

--- a/src/types/mcpOAuth.ts
+++ b/src/types/mcpOAuth.ts
@@ -1,4 +1,9 @@
-export const MCP_SCOPES = ["meetings:read", "transcripts:read"] as const;
+export const MCP_SCOPES = [
+  "meetings:read",
+  "transcripts:read",
+  "meetings:start",
+  "meetings:stop",
+] as const;
 
 export type McpScope = (typeof MCP_SCOPES)[number];
 

--- a/src/types/meetingControl.ts
+++ b/src/types/meetingControl.ts
@@ -1,0 +1,105 @@
+import type { MeetingStatus } from "./meetingLifecycle";
+
+export const MEETING_CONTROL_COMMAND_TYPES = {
+  START_MEETING: "start_meeting",
+  STOP_MEETING: "stop_meeting",
+  GET_LIVE_STATUS: "get_live_meeting_status",
+  GET_LIVE_TRANSCRIPT: "get_live_meeting_transcript",
+} as const;
+
+export type MeetingControlCommandType =
+  (typeof MEETING_CONTROL_COMMAND_TYPES)[keyof typeof MEETING_CONTROL_COMMAND_TYPES];
+
+export type MeetingControlQueueStatus = "pending" | "completed" | "failed";
+
+export type StartMeetingCommandInput = {
+  serverId?: string;
+  voiceChannelId?: string;
+  textChannelId?: string;
+  context?: string;
+  tags?: string[];
+};
+
+export type StopMeetingCommandInput = {
+  serverId?: string;
+  meetingId?: string;
+};
+
+export type LiveMeetingCommandInput = {
+  serverId?: string;
+  meetingId?: string;
+  afterEventId?: string;
+  limit?: number;
+};
+
+export type MeetingControlCommandInput =
+  | StartMeetingCommandInput
+  | StopMeetingCommandInput
+  | LiveMeetingCommandInput;
+
+export type MeetingControlStartedResult = {
+  status: "started";
+  serverId: string;
+  meetingId: string;
+  voiceChannelId: string;
+  voiceChannelName?: string;
+  textChannelId: string;
+  startedAt: string;
+  liveUrl?: string;
+};
+
+export type MeetingControlStoppedResult = {
+  status: "stopping" | "ended";
+  serverId: string;
+  meetingId: string;
+};
+
+export type MeetingControlLiveStatusResult = {
+  status: MeetingStatus;
+  serverId: string;
+  meetingId: string;
+  voiceChannelId: string;
+  voiceChannelName?: string;
+  textChannelId?: string;
+  startedAt?: string;
+  endedAt?: string;
+  isAutoRecording?: boolean;
+};
+
+export type MeetingControlLiveTranscriptEvent = {
+  id: string;
+  type: string;
+  time: string;
+  speaker?: string;
+  text: string;
+};
+
+export type MeetingControlLiveTranscriptResult = {
+  serverId: string;
+  meetingId: string;
+  events: MeetingControlLiveTranscriptEvent[];
+  hasMore: boolean;
+  nextAfterEventId?: string;
+};
+
+export type MeetingControlCommandResult =
+  | MeetingControlStartedResult
+  | MeetingControlStoppedResult
+  | MeetingControlLiveStatusResult
+  | MeetingControlLiveTranscriptResult;
+
+export type MeetingControlCommand = {
+  requestId: string;
+  queueStatus: MeetingControlQueueStatus;
+  commandType: MeetingControlCommandType;
+  userId: string;
+  input: MeetingControlCommandInput;
+  targetOwnerInstanceId?: string;
+  createdAt: string;
+  updatedAt: string;
+  expiresAt: number;
+  claimedByInstanceId?: string;
+  claimExpiresAt?: number;
+  result?: MeetingControlCommandResult;
+  error?: string;
+};

--- a/src/types/meetingLifecycle.ts
+++ b/src/types/meetingLifecycle.ts
@@ -1,5 +1,6 @@
 export const MEETING_START_REASONS = {
   MANUAL_COMMAND: "manual_command",
+  MCP: "mcp",
   AUTO_RECORD_CHANNEL: "auto_record_channel",
   AUTO_RECORD_ALL: "auto_record_all",
 } as const;
@@ -12,6 +13,7 @@ export const MEETING_END_REASONS = {
   CHANNEL_EMPTY: "channel_empty",
   TIMEOUT: "timeout",
   LIVE_VOICE: "live_voice",
+  MCP: "mcp",
   BOT_DISCONNECT: "bot_disconnect",
   WEB_UI: "web_ui",
   DISMISSED: "dismissed",

--- a/src/utils/meetingLifecycle.ts
+++ b/src/utils/meetingLifecycle.ts
@@ -9,6 +9,7 @@ import type { MeetingData } from "../types/meeting-data";
 
 export const MEETING_START_REASON_LABELS: Record<MeetingStartReason, string> = {
   [MEETING_START_REASONS.MANUAL_COMMAND]: "Started via /startmeeting",
+  [MEETING_START_REASONS.MCP]: "Started via MCP",
   [MEETING_START_REASONS.AUTO_RECORD_CHANNEL]: "Auto-recorded (channel rule)",
   [MEETING_START_REASONS.AUTO_RECORD_ALL]: "Auto-recorded (all channels rule)",
 };
@@ -20,6 +21,7 @@ export const MEETING_END_REASON_LABELS: Record<MeetingEndReason, string> = {
   [MEETING_END_REASONS.TIMEOUT]:
     "Ended after reaching the maximum meeting duration",
   [MEETING_END_REASONS.LIVE_VOICE]: "Ended via live voice command",
+  [MEETING_END_REASONS.MCP]: "Ended via MCP",
   [MEETING_END_REASONS.BOT_DISCONNECT]: "Ended because the bot disconnected",
   [MEETING_END_REASONS.WEB_UI]: "Ended via web UI",
   [MEETING_END_REASONS.DISMISSED]: "Stopped by a channel member",

--- a/src/utils/meetingPermissions.ts
+++ b/src/utils/meetingPermissions.ts
@@ -1,5 +1,18 @@
-import { PermissionFlagsBits } from "discord.js";
+import { GuildMember, PermissionFlagsBits } from "discord.js";
 import type { MeetingData } from "../types/meeting-data";
+
+export function canGuildMemberEndMeeting(
+  member: GuildMember | null | undefined,
+): boolean {
+  if (!member) return false;
+  return member.permissions.any([
+    PermissionFlagsBits.ModerateMembers,
+    PermissionFlagsBits.Administrator,
+    PermissionFlagsBits.ManageChannels,
+    PermissionFlagsBits.ManageGuild,
+    PermissionFlagsBits.ManageMessages,
+  ]);
+}
 
 export function canUserEndMeeting(
   meeting: MeetingData,
@@ -9,16 +22,5 @@ export function canUserEndMeeting(
     return true;
   }
 
-  const member = meeting.guild.members.cache.get(userId);
-  if (!member) {
-    return false;
-  }
-
-  return member.permissions.any([
-    PermissionFlagsBits.ModerateMembers,
-    PermissionFlagsBits.Administrator,
-    PermissionFlagsBits.ManageChannels,
-    PermissionFlagsBits.ManageGuild,
-    PermissionFlagsBits.ManageMessages,
-  ]);
+  return canGuildMemberEndMeeting(meeting.guild.members.cache.get(userId));
 }

--- a/src/webserver.ts
+++ b/src/webserver.ts
@@ -11,7 +11,7 @@ import * as trpcExpress from "@trpc/server/adapters/express";
 import { registerBillingRoutes } from "./api/billing";
 import { registerGuildRoutes } from "./api/guilds";
 import { registerLiveMeetingRoutes } from "./api/liveMeetings";
-import { registerMcpRoutes } from "./api/mcp";
+import { getMcpServerCard, registerMcpRoutes } from "./api/mcp";
 import { registerNotionOAuthRoutes } from "./api/notionOAuth";
 import {
   registerMcpOAuthSessionRoutes,
@@ -135,6 +135,9 @@ export function setupWebServer() {
 
   if (config.mcp.enabled) {
     registerMcpOAuthStatelessRoutes(app);
+    app.get("/.well-known/mcp/server-card.json", (_req, res) => {
+      res.json(getMcpServerCard());
+    });
     registerMcpRoutes(app);
   }
 

--- a/test/repositories/meetingControlCommandRepository.test.ts
+++ b/test/repositories/meetingControlCommandRepository.test.ts
@@ -86,6 +86,31 @@ describe("meetingControlCommandRepository", () => {
     ).resolves.toBeUndefined();
   });
 
+  test("does not list or claim expired pending commands", async () => {
+    const repository = getMeetingControlCommandRepository();
+    await repository.writeCommand(
+      makeCommand({ requestId: "request-1", expiresAt: 1_767_225_000 }),
+    );
+
+    await expect(
+      repository.listClaimablePendingCommands({
+        instanceId: "instance-1",
+        nowEpochSeconds: 1_767_225_001,
+        limit: 10,
+      }),
+    ).resolves.toHaveLength(0);
+
+    await expect(
+      repository.claimCommand({
+        requestId: "request-1",
+        instanceId: "instance-1",
+        nowEpochSeconds: 1_767_225_001,
+        claimExpiresAt: 1_767_225_060,
+        updatedAt: "2026-01-01T00:00:01.000Z",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
   test("completes commands claimed by the same worker", async () => {
     const repository = getMeetingControlCommandRepository();
     await repository.writeCommand(makeCommand());

--- a/test/repositories/meetingControlCommandRepository.test.ts
+++ b/test/repositories/meetingControlCommandRepository.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, test } from "@jest/globals";
+import {
+  getMeetingControlCommandRepository,
+  resetMeetingControlCommandMemoryRepository,
+} from "../../src/repositories/meetingControlCommandRepository";
+import type { MeetingControlCommand } from "../../src/types/meetingControl";
+
+const makeCommand = (
+  overrides?: Partial<MeetingControlCommand>,
+): MeetingControlCommand => ({
+  requestId: "request-1",
+  queueStatus: "pending",
+  commandType: "start_meeting",
+  userId: "user-1",
+  input: {},
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  expiresAt: 1_767_225_600,
+  ...overrides,
+});
+
+describe("meetingControlCommandRepository", () => {
+  afterEach(() => {
+    resetMeetingControlCommandMemoryRepository();
+  });
+
+  test("lists and claims unowned pending commands", async () => {
+    const repository = getMeetingControlCommandRepository();
+    await repository.writeCommand(makeCommand());
+
+    await expect(
+      repository.listClaimablePendingCommands({
+        instanceId: "instance-1",
+        nowEpochSeconds: 1_767_225_000,
+        limit: 10,
+      }),
+    ).resolves.toHaveLength(1);
+
+    const claimed = await repository.claimCommand({
+      requestId: "request-1",
+      instanceId: "instance-1",
+      nowEpochSeconds: 1_767_225_000,
+      claimExpiresAt: 1_767_225_060,
+      updatedAt: "2026-01-01T00:00:01.000Z",
+    });
+
+    expect(claimed).toMatchObject({
+      requestId: "request-1",
+      claimedByInstanceId: "instance-1",
+      claimExpiresAt: 1_767_225_060,
+    });
+  });
+
+  test("only lists targeted commands for the owner instance", async () => {
+    const repository = getMeetingControlCommandRepository();
+    await repository.writeCommand(
+      makeCommand({ requestId: "request-1", targetOwnerInstanceId: "owner-1" }),
+    );
+    await repository.writeCommand(
+      makeCommand({ requestId: "request-2", targetOwnerInstanceId: "owner-2" }),
+    );
+
+    await expect(
+      repository.listClaimablePendingCommands({
+        instanceId: "owner-1",
+        nowEpochSeconds: 1_767_225_000,
+        limit: 10,
+      }),
+    ).resolves.toMatchObject([{ requestId: "request-1" }]);
+  });
+
+  test("does not claim commands targeted to another owner instance", async () => {
+    const repository = getMeetingControlCommandRepository();
+    await repository.writeCommand(
+      makeCommand({ requestId: "request-1", targetOwnerInstanceId: "owner-1" }),
+    );
+
+    await expect(
+      repository.claimCommand({
+        requestId: "request-1",
+        instanceId: "owner-2",
+        nowEpochSeconds: 1_767_225_000,
+        claimExpiresAt: 1_767_225_060,
+        updatedAt: "2026-01-01T00:00:01.000Z",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  test("completes commands claimed by the same worker", async () => {
+    const repository = getMeetingControlCommandRepository();
+    await repository.writeCommand(makeCommand());
+    await repository.claimCommand({
+      requestId: "request-1",
+      instanceId: "instance-1",
+      nowEpochSeconds: 1_767_225_000,
+      claimExpiresAt: 1_767_225_060,
+      updatedAt: "2026-01-01T00:00:01.000Z",
+    });
+
+    await expect(
+      repository.completeCommand({
+        requestId: "request-1",
+        instanceId: "instance-1",
+        updatedAt: "2026-01-01T00:00:02.000Z",
+        result: {
+          status: "started",
+          serverId: "guild-1",
+          meetingId: "meeting-1",
+          voiceChannelId: "voice-1",
+          textChannelId: "text-1",
+          startedAt: "2026-01-01T00:00:02.000Z",
+        },
+      }),
+    ).resolves.toBe(true);
+
+    await expect(repository.getCommand("request-1")).resolves.toMatchObject({
+      queueStatus: "completed",
+      result: { status: "started", meetingId: "meeting-1" },
+    });
+  });
+});

--- a/test/services/activeMeetingLeaseService.test.ts
+++ b/test/services/activeMeetingLeaseService.test.ts
@@ -232,6 +232,7 @@ describe("activeMeetingLeaseService", () => {
       "meeting-1",
       "user-1",
       expect.any(String),
+      MEETING_END_REASONS.WEB_UI,
     );
     const calledWithTimestamp =
       mockedRequestActiveMeetingEnd.mock.calls[0]?.[3];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "noFallthroughCasesInSwitch": true,
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "noFallthroughCasesInSwitch": true,
-    "ignoreDeprecations": "5.0",
+    "ignoreDeprecations": "6.0",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/whitelizard.txt
+++ b/whitelizard.txt
@@ -30,6 +30,8 @@ src/audio.ts:getAudioBytes
 src\audio.ts:getAudioBytes
 src/commands/notesCorrections.ts:resolveChannelName
 src\commands\notesCorrections.ts:resolveChannelName
+src/commands/notesCorrections.ts:buildCorrectionSummaries
+src\commands\notesCorrections.ts:buildCorrectionSummaries
 src/embed.ts:resolveMeetingTitle
 src\embed.ts:resolveMeetingTitle
 src/trpc/routers/meetings.ts:updateNotesMutation
@@ -48,6 +50,8 @@ src/evals/transcriptionEval.ts:runTranscriptionBatch
 src\evals\transcriptionEval.ts:runTranscriptionBatch
 src/evals/transcriptionEval.ts:runLangfuseEval
 src\evals\transcriptionEval.ts:runLangfuseEval
+src/evals/transcriptionEval.ts:parseOptions
+src\evals\transcriptionEval.ts:parseOptions
 src/api/liveMeetings.ts:(anonymous)
 src\api\liveMeetings.ts:(anonymous)
 src/services/askConversationService.ts:askWithConversation


### PR DESCRIPTION
[AGENT]

## Summary
- Adds queue-backed Remote MCP live control tools for start, stop, live status, and live transcript.
- Adds the MeetingControlCommand DynamoDB queue, bot worker routing, MCP server card metadata, OAuth scopes, and lifecycle reasons.
- Updates Remote MCP docs, What's New, ADR, registry metadata, and tests.

## Testing
- yarn build
- yarn build:web (passes with existing Vite warnings for %VITE_API_BASE_URL% and chunk size)
- yarn test --coverage=false
- yarn lint:check
- yarn docs:check
- yarn prettier:check
- yarn markdownlint:check
- yarn checkov
- terraform -chdir='_infra' fmt -check 'main.tf'

## Risk / Rollout
- Terraform apply is required before split API/bot runtimes can rely on live Remote MCP controls.
- Draft PR until CI and review complete.