### PR TITLE
[AGENT] Improve autorecord permission diagnostics

### DIFF
--- a/apps/docs-site/docs/admin/setup-and-access.md
+++ b/apps/docs-site/docs/admin/setup-and-access.md
@@ -71,12 +71,14 @@ Auto-record starts when any user joins a configured voice channel. It ends when 
 
 Chronote needs these Discord permissions:
 
-| Permission    | Scope          | Purpose                                    |
-| ------------- | -------------- | ------------------------------------------ |
-| View Channel  | Text channels  | Read messages and post meeting notes       |
-| Send Messages | Text channels  | Post embeds, notes, and status updates     |
-| Connect       | Voice channels | Join voice channels to record              |
-| Speak         | Voice channels | Required by Discord for voice bot presence |
+| Permission           | Scope          | Purpose                                    |
+| -------------------- | -------------- | ------------------------------------------ |
+| View Channel         | Text channels  | Access the notes channel                   |
+| Send Messages        | Text channels  | Post embeds, notes, and status updates     |
+| Read Message History | Text channels  | Update meeting status and summary messages |
+| Embed Links          | Text channels  | Post summary and notes embeds              |
+| Connect              | Voice channels | Join voice channels to record              |
+| Speak                | Voice channels | Required by Discord for voice bot presence |
 
 ### Command permissions
 

--- a/apps/docs-site/docs/admin/setup-and-access.md
+++ b/apps/docs-site/docs/admin/setup-and-access.md
@@ -76,7 +76,6 @@ Chronote needs these Discord permissions:
 | View Channel         | Text channels  | Access the notes channel                   |
 | Send Messages        | Text channels  | Post embeds, notes, and status updates     |
 | Read Message History | Text channels  | Update meeting status and summary messages |
-| Embed Links          | Text channels  | Post summary and notes embeds              |
 | Connect              | Voice channels | Join voice channels to record              |
 | Speak                | Voice channels | Required by Discord for voice bot presence |
 

--- a/apps/docs-site/docs/features/feature-overview.md
+++ b/apps/docs-site/docs/features/feature-overview.md
@@ -16,7 +16,7 @@ Starts a recorded meeting in the voice channel you are currently in. You can als
 | `context` | No       | Describe the meeting topic (max 500 chars) |
 | `tags`    | No       | Comma-separated tags (max 500 chars)       |
 
-**Requirements**: You must be in a voice channel. The bot needs Connect and Speak permissions in that voice channel, and View Channel, Send Messages, Read Message History, and Embed Links in the text channel. No other meeting can be active in the server.
+**Requirements**: You must be in a voice channel. The bot needs Connect and Speak permissions in that voice channel, and View Channel, Send Messages, and Read Message History in the text channel. No other meeting can be active in the server.
 
 **Output**: A "Meeting Started" embed with End Meeting and Edit Tags buttons, plus a Live transcript button when the Chronote portal is configured.
 

--- a/apps/docs-site/docs/features/feature-overview.md
+++ b/apps/docs-site/docs/features/feature-overview.md
@@ -16,7 +16,7 @@ Starts a recorded meeting in the voice channel you are currently in. You can als
 | `context` | No       | Describe the meeting topic (max 500 chars) |
 | `tags`    | No       | Comma-separated tags (max 500 chars)       |
 
-**Requirements**: You must be in a voice channel. The bot needs Connect and Speak permissions in that voice channel, and View Channel and Send Messages in the text channel. No other meeting can be active in the server.
+**Requirements**: You must be in a voice channel. The bot needs Connect and Speak permissions in that voice channel, and View Channel, Send Messages, Read Message History, and Embed Links in the text channel. No other meeting can be active in the server.
 
 **Output**: A "Meeting Started" embed with End Meeting and Edit Tags buttons, plus a Live transcript button when the Chronote portal is configured.
 

--- a/apps/docs-site/docs/getting-started/overview.md
+++ b/apps/docs-site/docs/getting-started/overview.md
@@ -15,7 +15,7 @@ This guide walks you through adding Chronote to your Discord server and running 
 
 Use the invite link from [chronote.gg](https://chronote.gg) to add the bot. Discord will prompt you to select a server and confirm permissions. Chronote needs:
 
-- **View Channels**, **Send Messages**, **Read Message History**, and **Embed Links** in text channels where it will post notes.
+- **View Channels**, **Send Messages**, and **Read Message History** in text channels where it will post notes.
 - **Connect** and **Speak** in voice channels it will record.
 
 After the bot joins, it sends a DM to the installer (or server owner) with a link to the onboarding wizard.
@@ -69,7 +69,6 @@ Chronote processes the recording:
 | View Channel         | Text channels  | Access notes channels                                 |
 | Send Messages        | Text channels  | Post meeting embeds and notes                         |
 | Read Message History | Text channels  | Update meeting status and summary messages            |
-| Embed Links          | Text channels  | Post summary and notes embeds                         |
 | Connect              | Voice channels | Join and record audio                                 |
 | Speak                | Voice channels | Required by Discord for voice bots                    |
 | Manage Channels      | Server-wide    | Required for `/autorecord`, `/context`, `/dictionary` |

--- a/apps/docs-site/docs/getting-started/overview.md
+++ b/apps/docs-site/docs/getting-started/overview.md
@@ -15,7 +15,7 @@ This guide walks you through adding Chronote to your Discord server and running 
 
 Use the invite link from [chronote.gg](https://chronote.gg) to add the bot. Discord will prompt you to select a server and confirm permissions. Chronote needs:
 
-- **View Channels** and **Send Messages** in text channels where it will post notes.
+- **View Channels**, **Send Messages**, **Read Message History**, and **Embed Links** in text channels where it will post notes.
 - **Connect** and **Speak** in voice channels it will record.
 
 After the bot joins, it sends a DM to the installer (or server owner) with a link to the onboarding wizard.
@@ -64,10 +64,12 @@ Chronote processes the recording:
 
 ## Permissions summary
 
-| Permission      | Where          | Why                                                   |
-| --------------- | -------------- | ----------------------------------------------------- |
-| View Channel    | Text channels  | Read messages and post notes                          |
-| Send Messages   | Text channels  | Post meeting embeds and notes                         |
-| Connect         | Voice channels | Join and record audio                                 |
-| Speak           | Voice channels | Required by Discord for voice bots                    |
-| Manage Channels | Server-wide    | Required for `/autorecord`, `/context`, `/dictionary` |
+| Permission           | Where          | Why                                                   |
+| -------------------- | -------------- | ----------------------------------------------------- |
+| View Channel         | Text channels  | Access notes channels                                 |
+| Send Messages        | Text channels  | Post meeting embeds and notes                         |
+| Read Message History | Text channels  | Update meeting status and summary messages            |
+| Embed Links          | Text channels  | Post summary and notes embeds                         |
+| Connect              | Voice channels | Join and record audio                                 |
+| Speak                | Voice channels | Required by Discord for voice bots                    |
+| Manage Channels      | Server-wide    | Required for `/autorecord`, `/context`, `/dictionary` |

--- a/apps/docs-site/docs/troubleshooting/common-issues.md
+++ b/apps/docs-site/docs/troubleshooting/common-issues.md
@@ -24,7 +24,7 @@ Use this page to diagnose and fix common Chronote issues. Each section describes
 
 1. **Another meeting is active.** Auto-record waits for the current meeting to finish.
 2. **Auto-record is suppressed.** After a meeting is explicitly ended, auto-record is suppressed for that channel until it fully empties. Make sure everyone leaves the channel, then rejoin.
-3. **Missing bot permissions.** The bot needs Connect and Speak in the voice channel, and View Channel, Send Messages, Read Message History, and Embed Links in the configured text channel. If Chronote can send messages but is missing one of the other text permissions, it posts a warning in the configured text channel. If it cannot view or send in that channel, it tries to DM the user who triggered auto-record. Fix the channel overrides, then have everyone leave and rejoin the voice channel.
+3. **Missing bot permissions.** The bot needs Connect and Speak in the voice channel, and View Channel, Send Messages, and Read Message History in the configured text channel. If Chronote can send messages but is missing one of the other text permissions, it posts a warning in the configured text channel. If it cannot view or send in that channel, it tries to DM the user who triggered auto-record. Fix the channel overrides, then have everyone leave and rejoin the voice channel.
 4. **Auto-record is not configured for this channel.** Run `/autorecord list` to check the current rules.
 5. **Weekly minutes exhausted.** Same as above.
 
@@ -75,7 +75,7 @@ Use this page to diagnose and fix common Chronote issues. Each section describes
 **Causes and fixes**:
 
 1. **Still processing.** Long meetings (over 30 minutes) can take several minutes to process. Wait for the processing indicator to clear.
-2. **Missing text channel permissions.** The bot needs View Channel, Send Messages, Read Message History, and Embed Links in the text channel. If permissions were changed during the meeting, the bot may not be able to update the status message or post results.
+2. **Missing text channel permissions.** The bot needs View Channel, Send Messages, and Read Message History in the text channel. If permissions were changed during the meeting, the bot may not be able to update the status message or post results.
 3. **Meeting was cancelled.** For auto-recorded meetings with too little content, the meeting is cancelled instead of generating notes. Look for an "Auto-Recording Cancelled" embed.
 
 ## Web portal shows no meetings

--- a/apps/docs-site/docs/troubleshooting/common-issues.md
+++ b/apps/docs-site/docs/troubleshooting/common-issues.md
@@ -24,7 +24,7 @@ Use this page to diagnose and fix common Chronote issues. Each section describes
 
 1. **Another meeting is active.** Auto-record waits for the current meeting to finish.
 2. **Auto-record is suppressed.** After a meeting is explicitly ended, auto-record is suppressed for that channel until it fully empties. Make sure everyone leaves the channel, then rejoin.
-3. **Missing bot permissions.** The bot needs Connect and Speak in the voice channel, and View Channel and Send Messages in the configured text channel.
+3. **Missing bot permissions.** The bot needs Connect and Speak in the voice channel, and View Channel, Send Messages, Read Message History, and Embed Links in the configured text channel. If Chronote can send messages but is missing one of the other text permissions, it posts a warning in the configured text channel. If it cannot view or send in that channel, it tries to DM the user who triggered auto-record. Fix the channel overrides, then have everyone leave and rejoin the voice channel.
 4. **Auto-record is not configured for this channel.** Run `/autorecord list` to check the current rules.
 5. **Weekly minutes exhausted.** Same as above.
 
@@ -75,7 +75,7 @@ Use this page to diagnose and fix common Chronote issues. Each section describes
 **Causes and fixes**:
 
 1. **Still processing.** Long meetings (over 30 minutes) can take several minutes to process. Wait for the processing indicator to clear.
-2. **Missing text channel permissions.** The bot needs Send Messages permission in the text channel. If permissions were changed during the meeting, the bot may not be able to post results.
+2. **Missing text channel permissions.** The bot needs View Channel, Send Messages, Read Message History, and Embed Links in the text channel. If permissions were changed during the meeting, the bot may not be able to update the status message or post results.
 3. **Meeting was cancelled.** For auto-recorded meetings with too little content, the meeting is cancelled instead of generating notes. Look for an "Auto-Recording Cancelled" embed.
 
 ## Web portal shows no meetings

--- a/src/commands/autorecord.ts
+++ b/src/commands/autorecord.ts
@@ -15,6 +15,11 @@ import {
 import { CONFIG_KEYS } from "../config/keys";
 import { resolveConfigString } from "../services/unifiedConfigService";
 import { parseTags } from "../utils/tags";
+import {
+  checkBotPermissions,
+  formatMissingPermissions,
+  getMissingMeetingTextChannelPermissions,
+} from "../utils/permissions";
 
 export async function handleAutoRecordCommand(
   interaction: ChatInputCommandInteraction,
@@ -113,28 +118,14 @@ async function handleEnableAutoRecord(
     return;
   }
 
-  const voicePermissions = voiceChannel.permissionsFor(botMember);
-  const textPermissions = textChannel.permissionsFor(botMember);
-
-  if (
-    !voicePermissions ||
-    !voicePermissions.has(PermissionsBitField.Flags.ViewChannel) ||
-    !voicePermissions.has(PermissionsBitField.Flags.Connect)
-  ) {
+  const permissionCheck = checkBotPermissions(
+    voiceChannel,
+    textChannel,
+    botMember,
+  );
+  if (!permissionCheck.success) {
     await interaction.reply({
-      content: `I don't have permission to join ${voiceChannel.name}.`,
-      ephemeral: true,
-    });
-    return;
-  }
-
-  if (
-    !textPermissions ||
-    !textPermissions.has(PermissionsBitField.Flags.ViewChannel) ||
-    !textPermissions.has(PermissionsBitField.Flags.SendMessages)
-  ) {
-    await interaction.reply({
-      content: `I don't have permission to send messages in ${textChannel.name}.`,
+      content: `I can't enable auto-recording yet. ${permissionCheck.errorMessage}`,
       ephemeral: true,
     });
     return;
@@ -303,15 +294,13 @@ async function handleEnableAllAutoRecord(
     return;
   }
 
-  const textPermissions = textChannel.permissionsFor(botMember);
-
-  if (
-    !textPermissions ||
-    !textPermissions.has(PermissionsBitField.Flags.ViewChannel) ||
-    !textPermissions.has(PermissionsBitField.Flags.SendMessages)
-  ) {
+  const missingTextPermissions = getMissingMeetingTextChannelPermissions(
+    textChannel,
+    botMember,
+  );
+  if (missingTextPermissions.length > 0) {
     await interaction.reply({
-      content: `I don't have permission to send messages in ${textChannel.name}.`,
+      content: `I can't enable auto-recording for all channels yet. I am missing ${formatMissingPermissions(missingTextPermissions)} in **${textChannel.name}**.`,
       ephemeral: true,
     });
     return;

--- a/src/commands/startMeeting.ts
+++ b/src/commands/startMeeting.ts
@@ -21,7 +21,14 @@ import {
 } from "../meetings";
 import { randomUUID } from "node:crypto";
 import { GuildChannel } from "discord.js/typings";
-import { checkBotPermissions } from "../utils/permissions";
+import {
+  buildAutoRecordPermissionChannelMessage,
+  buildAutoRecordPermissionDmMessage,
+  canBotSendMessages,
+  checkBotPermissions,
+  getMissingMeetingTextChannelPermissions,
+  getMissingVoiceChannelPermissions,
+} from "../utils/permissions";
 import { handleEndMeetingOther } from "./endMeeting";
 import { saveMeetingStartToDatabase } from "./saveMeetingHistory";
 import { parseTags } from "../utils/tags";
@@ -93,6 +100,107 @@ const buildLimitReachedMessage = (nextAvailableAtIso?: string | null) => {
       )}:R>.`
     : "Try again later.";
   return `Weekly meeting minutes limit reached for this plan. ${nextLabel}`;
+};
+
+const sendAutoRecordStartBlockedMessage = async (
+  textChannel: TextChannel,
+  message: string,
+) => {
+  try {
+    await textChannel.send(message);
+  } catch (error) {
+    console.warn("Failed to send auto-record start failure message", {
+      guildId: textChannel.guild.id,
+      textChannelId: textChannel.id,
+      error,
+    });
+  }
+};
+
+const fetchAutoRecordTriggerMember = async (
+  guild: Guild,
+  userId?: string,
+): Promise<GuildMember | null> => {
+  if (!userId) return null;
+  const cached = guild.members.cache.get(userId);
+  if (cached) return cached;
+
+  try {
+    return await guild.members.fetch(userId);
+  } catch (error) {
+    console.warn("Failed to fetch auto-record trigger member", {
+      guildId: guild.id,
+      userId,
+      error,
+    });
+    return null;
+  }
+};
+
+const notifyAutoRecordPermissionFailure = async (options: {
+  voiceChannel: VoiceBasedChannel;
+  textChannel: TextChannel;
+  botMember: GuildMember;
+  startTriggeredByUserId?: string;
+}) => {
+  const { voiceChannel, textChannel, botMember, startTriggeredByUserId } =
+    options;
+  const missingVoicePermissions = getMissingVoiceChannelPermissions(
+    voiceChannel,
+    botMember,
+  );
+  const missingTextPermissions = getMissingMeetingTextChannelPermissions(
+    textChannel,
+    botMember,
+  );
+  const summary = {
+    voiceChannelName: voiceChannel.name,
+    textChannelName: textChannel.name,
+    missingVoicePermissions,
+    missingTextPermissions,
+  };
+
+  if (canBotSendMessages(textChannel, botMember)) {
+    await sendAutoRecordStartBlockedMessage(
+      textChannel,
+      buildAutoRecordPermissionChannelMessage(summary),
+    );
+    return;
+  }
+
+  const triggerMember = await fetchAutoRecordTriggerMember(
+    voiceChannel.guild,
+    startTriggeredByUserId,
+  );
+  if (!triggerMember) {
+    console.warn("Cannot DM auto-record start failure without trigger member", {
+      guildId: voiceChannel.guild.id,
+      voiceChannelId: voiceChannel.id,
+      textChannelId: textChannel.id,
+      missingVoicePermissions,
+      missingTextPermissions,
+    });
+    return;
+  }
+
+  const isAdmin = triggerMember.permissions.has(
+    PermissionsBitField.Flags.ManageChannels,
+  );
+  try {
+    await triggerMember.send(
+      buildAutoRecordPermissionDmMessage({ ...summary, isAdmin }),
+    );
+  } catch (error) {
+    console.warn("Failed to DM auto-record start failure", {
+      guildId: voiceChannel.guild.id,
+      voiceChannelId: voiceChannel.id,
+      textChannelId: textChannel.id,
+      userId: triggerMember.id,
+      missingVoicePermissions,
+      missingTextPermissions,
+      error,
+    });
+  }
 };
 
 async function getLimitNotice(
@@ -475,6 +583,30 @@ export async function handleAutoStartMeeting(
   },
 ) {
   const guildId = voiceChannel.guild.id;
+  const botMember = voiceChannel.guild.members.cache.get(client.user!.id);
+  if (!botMember) {
+    await textChannel.send(
+      `Cannot start auto-recording - bot not found in server.`,
+    );
+    return false;
+  }
+
+  const permissionCheck = checkBotPermissions(
+    voiceChannel,
+    textChannel,
+    botMember,
+  );
+
+  if (!permissionCheck.success) {
+    await notifyAutoRecordPermissionFailure({
+      voiceChannel,
+      textChannel,
+      botMember,
+      startTriggeredByUserId: options?.startTriggeredByUserId,
+    });
+    return false;
+  }
+
   const staleLease = await getActiveMeetingLeaseForGuild(guildId);
   if (staleLease && isLeaseActive(staleLease)) {
     await textChannel.send(
@@ -501,36 +633,6 @@ export async function handleAutoStartMeeting(
     }
     // Clean up finished meeting
     deleteMeeting(guildId);
-  }
-
-  // Check if bot has necessary permissions
-  const botMember = voiceChannel.guild.members.cache.get(client.user!.id);
-  if (!botMember) {
-    await textChannel.send(
-      `Cannot start auto-recording - bot not found in server.`,
-    );
-    return false;
-  }
-
-  // Check bot permissions
-  const permissionCheck = checkBotPermissions(
-    voiceChannel,
-    textChannel,
-    botMember,
-  );
-
-  if (!permissionCheck.success) {
-    // Try to send error message if we have text channel permissions
-    try {
-      await textChannel.send(
-        `Cannot start auto-recording - ${permissionCheck.errorMessage}`,
-      );
-    } catch {
-      console.error(
-        `No permissions to send messages in text channel ${textChannel.id}`,
-      );
-    }
-    return false;
   }
 
   const meetingId = randomUUID();

--- a/src/utils/__tests__/permissions.test.ts
+++ b/src/utils/__tests__/permissions.test.ts
@@ -120,6 +120,19 @@ describe("permissions", () => {
     );
   });
 
+  it("produces a coherent message when both permission arrays are unexpectedly empty", () => {
+    const message = buildAutoRecordPermissionChannelMessage({
+      voiceChannelName: "voice",
+      textChannelName: "notes",
+      missingVoicePermissions: [],
+      missingTextPermissions: [],
+    });
+
+    expect(message).toBe(
+      "Cannot start auto-recording because Chronote is missing permissions in one or more channels (permissions may have just been updated).",
+    );
+  });
+
   it("asks non-admin trigger users to contact an admin", () => {
     expect(
       buildAutoRecordPermissionDmMessage({

--- a/src/utils/__tests__/permissions.test.ts
+++ b/src/utils/__tests__/permissions.test.ts
@@ -1,0 +1,148 @@
+import {
+  type GuildMember,
+  type PermissionResolvable,
+  PermissionsBitField,
+  type TextChannel,
+  type VoiceBasedChannel,
+} from "discord.js";
+import {
+  buildAutoRecordPermissionChannelMessage,
+  buildAutoRecordPermissionDmMessage,
+  canBotSendMessages,
+  checkBotPermissions,
+  formatMissingPermissions,
+  getMissingMeetingTextChannelPermissions,
+} from "../permissions";
+
+const member = {} as GuildMember;
+
+const buildPermissions = (...flags: PermissionResolvable[]) =>
+  new PermissionsBitField(flags);
+
+const buildVoiceChannel = (
+  permissions: PermissionsBitField | null,
+): VoiceBasedChannel =>
+  ({
+    name: "voice",
+    permissionsFor: jest.fn(() => permissions),
+  }) as unknown as VoiceBasedChannel;
+
+const buildTextChannel = (
+  permissions: PermissionsBitField | null,
+): TextChannel =>
+  ({
+    name: "notes",
+    permissionsFor: jest.fn(() => permissions),
+  }) as unknown as TextChannel;
+
+describe("permissions", () => {
+  it("accepts the full autorecord permission set", () => {
+    const voiceChannel = buildVoiceChannel(
+      buildPermissions(
+        PermissionsBitField.Flags.ViewChannel,
+        PermissionsBitField.Flags.Connect,
+      ),
+    );
+    const textChannel = buildTextChannel(
+      buildPermissions(
+        PermissionsBitField.Flags.ViewChannel,
+        PermissionsBitField.Flags.SendMessages,
+        PermissionsBitField.Flags.ReadMessageHistory,
+        PermissionsBitField.Flags.EmbedLinks,
+      ),
+    );
+
+    expect(checkBotPermissions(voiceChannel, textChannel, member)).toEqual({
+      success: true,
+    });
+  });
+
+  it("reports text permissions needed for meeting message updates", () => {
+    const missing = getMissingMeetingTextChannelPermissions(
+      buildTextChannel(
+        buildPermissions(
+          PermissionsBitField.Flags.ViewChannel,
+          PermissionsBitField.Flags.SendMessages,
+        ),
+      ),
+      member,
+    );
+
+    expect(missing).toEqual(["Read Message History", "Embed Links"]);
+  });
+
+  it("allows plain channel warnings when only rich message permissions are missing", () => {
+    const textChannel = buildTextChannel(
+      buildPermissions(
+        PermissionsBitField.Flags.ViewChannel,
+        PermissionsBitField.Flags.SendMessages,
+      ),
+    );
+
+    expect(canBotSendMessages(textChannel, member)).toBe(true);
+  });
+
+  it("includes the missing permissions in failure messages", () => {
+    const result = checkBotPermissions(
+      buildVoiceChannel(
+        buildPermissions(
+          PermissionsBitField.Flags.ViewChannel,
+          PermissionsBitField.Flags.Connect,
+        ),
+      ),
+      buildTextChannel(buildPermissions(PermissionsBitField.Flags.ViewChannel)),
+      member,
+    );
+
+    expect(result).toEqual({
+      success: false,
+      errorMessage:
+        "I am missing **Send Messages**, **Read Message History**, **Embed Links** in **notes**.",
+    });
+  });
+
+  it("formats permission names for Discord messages", () => {
+    expect(formatMissingPermissions(["Read Message History"])).toBe(
+      "**Read Message History**",
+    );
+  });
+
+  it("builds a channel warning with scoped missing permissions", () => {
+    expect(
+      buildAutoRecordPermissionChannelMessage({
+        voiceChannelName: "voice",
+        textChannelName: "notes",
+        missingVoicePermissions: ["Connect"],
+        missingTextPermissions: ["Read Message History", "Embed Links"],
+      }),
+    ).toBe(
+      "Cannot start auto-recording because Chronote is missing permissions in voice channel **voice**: **Connect**; notes channel **notes**: **Read Message History**, **Embed Links**.",
+    );
+  });
+
+  it("asks non-admin trigger users to contact an admin", () => {
+    expect(
+      buildAutoRecordPermissionDmMessage({
+        isAdmin: false,
+        voiceChannelName: "voice",
+        textChannelName: "notes",
+        missingVoicePermissions: [],
+        missingTextPermissions: ["Send Messages"],
+      }),
+    ).toContain("please ask an admin");
+  });
+
+  it("gives admins the exact missing permission summary", () => {
+    expect(
+      buildAutoRecordPermissionDmMessage({
+        isAdmin: true,
+        voiceChannelName: "voice",
+        textChannelName: "notes",
+        missingVoicePermissions: [],
+        missingTextPermissions: ["Send Messages"],
+      }),
+    ).toBe(
+      "Cannot start auto-recording because Chronote is missing permissions in notes channel **notes**: **Send Messages**. Grant those permissions, then have everyone leave and rejoin the voice channel to trigger auto-record again.",
+    );
+  });
+});

--- a/src/utils/__tests__/permissions.test.ts
+++ b/src/utils/__tests__/permissions.test.ts
@@ -48,7 +48,6 @@ describe("permissions", () => {
         PermissionsBitField.Flags.ViewChannel,
         PermissionsBitField.Flags.SendMessages,
         PermissionsBitField.Flags.ReadMessageHistory,
-        PermissionsBitField.Flags.EmbedLinks,
       ),
     );
 
@@ -68,10 +67,10 @@ describe("permissions", () => {
       member,
     );
 
-    expect(missing).toEqual(["Read Message History", "Embed Links"]);
+    expect(missing).toEqual(["Read Message History"]);
   });
 
-  it("allows plain channel warnings when only rich message permissions are missing", () => {
+  it("allows plain channel warnings when only history access is missing", () => {
     const textChannel = buildTextChannel(
       buildPermissions(
         PermissionsBitField.Flags.ViewChannel,
@@ -97,7 +96,7 @@ describe("permissions", () => {
     expect(result).toEqual({
       success: false,
       errorMessage:
-        "I am missing **Send Messages**, **Read Message History**, **Embed Links** in **notes**.",
+        "I am missing **Send Messages**, **Read Message History** in **notes**.",
     });
   });
 
@@ -113,10 +112,10 @@ describe("permissions", () => {
         voiceChannelName: "voice",
         textChannelName: "notes",
         missingVoicePermissions: ["Connect"],
-        missingTextPermissions: ["Read Message History", "Embed Links"],
+        missingTextPermissions: ["Read Message History"],
       }),
     ).toBe(
-      "Cannot start auto-recording because Chronote is missing permissions in voice channel **voice**: **Connect**; notes channel **notes**: **Read Message History**, **Embed Links**.",
+      "Cannot start auto-recording because Chronote is missing permissions in voice channel **voice**: **Connect**; notes channel **notes**: **Read Message History**.",
     );
   });
 

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,9 +1,88 @@
 import {
   GuildMember,
+  type PermissionResolvable,
   PermissionsBitField,
   TextChannel,
   VoiceBasedChannel,
 } from "discord.js";
+
+type RequiredPermission = {
+  flag: PermissionResolvable;
+  label: string;
+};
+
+type MissingMeetingPermissionSummary = {
+  voiceChannelName: string;
+  textChannelName: string;
+  missingVoicePermissions: string[];
+  missingTextPermissions: string[];
+};
+
+const VOICE_CHANNEL_MEETING_PERMISSIONS = [
+  { flag: PermissionsBitField.Flags.ViewChannel, label: "View Channel" },
+  { flag: PermissionsBitField.Flags.Connect, label: "Connect" },
+] satisfies RequiredPermission[];
+
+const TEXT_CHANNEL_MEETING_PERMISSIONS = [
+  { flag: PermissionsBitField.Flags.ViewChannel, label: "View Channel" },
+  { flag: PermissionsBitField.Flags.SendMessages, label: "Send Messages" },
+  {
+    flag: PermissionsBitField.Flags.ReadMessageHistory,
+    label: "Read Message History",
+  },
+  { flag: PermissionsBitField.Flags.EmbedLinks, label: "Embed Links" },
+] satisfies RequiredPermission[];
+
+const getMissingPermissions = (
+  permissions: Readonly<PermissionsBitField> | null,
+  requiredPermissions: RequiredPermission[],
+) => {
+  if (!permissions) {
+    return requiredPermissions.map((permission) => permission.label);
+  }
+
+  return requiredPermissions
+    .filter((permission) => !permissions.has(permission.flag))
+    .map((permission) => permission.label);
+};
+
+export const formatMissingPermissions = (permissions: string[]) =>
+  permissions.map((permission) => `**${permission}**`).join(", ");
+
+export const formatMissingMeetingPermissions = ({
+  voiceChannelName,
+  textChannelName,
+  missingVoicePermissions,
+  missingTextPermissions,
+}: MissingMeetingPermissionSummary) => {
+  const parts: string[] = [];
+  if (missingVoicePermissions.length > 0) {
+    parts.push(
+      `voice channel **${voiceChannelName}**: ${formatMissingPermissions(missingVoicePermissions)}`,
+    );
+  }
+  if (missingTextPermissions.length > 0) {
+    parts.push(
+      `notes channel **${textChannelName}**: ${formatMissingPermissions(missingTextPermissions)}`,
+    );
+  }
+  return parts.join("; ");
+};
+
+export const buildAutoRecordPermissionChannelMessage = (
+  summary: MissingMeetingPermissionSummary,
+) =>
+  `Cannot start auto-recording because Chronote is missing permissions in ${formatMissingMeetingPermissions(summary)}.`;
+
+export const buildAutoRecordPermissionDmMessage = (
+  summary: MissingMeetingPermissionSummary & { isAdmin: boolean },
+) => {
+  if (summary.isAdmin) {
+    return `${buildAutoRecordPermissionChannelMessage(summary)} Grant those permissions, then have everyone leave and rejoin the voice channel to trigger auto-record again.`;
+  }
+
+  return "Chronote tried to auto-record when you joined voice, but it cannot post meeting status or notes in the configured notes channel. A server admin needs to grant Chronote View Channel, Send Messages, Read Message History, and Embed Links in the notes channel, plus View Channel and Connect in the voice channel. If you expected this meeting to record, please ask an admin to check Chronote's channel permissions.";
+};
 
 /**
  * Checks if the bot has permission to join a voice channel
@@ -15,11 +94,18 @@ export function canBotJoinVoiceChannel(
   voiceChannel: VoiceBasedChannel,
   botMember: GuildMember,
 ): boolean {
-  const permissions = voiceChannel.permissionsFor(botMember);
-  return !!(
-    permissions &&
-    permissions.has(PermissionsBitField.Flags.ViewChannel) &&
-    permissions.has(PermissionsBitField.Flags.Connect)
+  return (
+    getMissingVoiceChannelPermissions(voiceChannel, botMember).length === 0
+  );
+}
+
+export function getMissingVoiceChannelPermissions(
+  voiceChannel: VoiceBasedChannel,
+  botMember: GuildMember,
+): string[] {
+  return getMissingPermissions(
+    voiceChannel.permissionsFor(botMember),
+    VOICE_CHANNEL_MEETING_PERMISSIONS,
   );
 }
 
@@ -41,6 +127,16 @@ export function canBotSendMessages(
   );
 }
 
+export function getMissingMeetingTextChannelPermissions(
+  textChannel: TextChannel,
+  botMember: GuildMember,
+): string[] {
+  return getMissingPermissions(
+    textChannel.permissionsFor(botMember),
+    TEXT_CHANNEL_MEETING_PERMISSIONS,
+  );
+}
+
 export interface PermissionCheckResult {
   success: boolean;
   errorMessage?: string;
@@ -58,17 +154,25 @@ export function checkBotPermissions(
   textChannel: TextChannel,
   botMember: GuildMember,
 ): PermissionCheckResult {
-  if (!canBotJoinVoiceChannel(voiceChannel, botMember)) {
+  const missingVoicePermissions = getMissingVoiceChannelPermissions(
+    voiceChannel,
+    botMember,
+  );
+  if (missingVoicePermissions.length > 0) {
     return {
       success: false,
-      errorMessage: `I do not have permission to join **${voiceChannel.name}**.`,
+      errorMessage: `I am missing ${formatMissingPermissions(missingVoicePermissions)} in **${voiceChannel.name}**.`,
     };
   }
 
-  if (!canBotSendMessages(textChannel, botMember)) {
+  const missingTextPermissions = getMissingMeetingTextChannelPermissions(
+    textChannel,
+    botMember,
+  );
+  if (missingTextPermissions.length > 0) {
     return {
       success: false,
-      errorMessage: `I do not have permission to send messages in **${textChannel.name}**.`,
+      errorMessage: `I am missing ${formatMissingPermissions(missingTextPermissions)} in **${textChannel.name}**.`,
     };
   }
 

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -54,7 +54,7 @@ export const formatMissingMeetingPermissions = ({
   textChannelName,
   missingVoicePermissions,
   missingTextPermissions,
-}: MissingMeetingPermissionSummary) => {
+}: MissingMeetingPermissionSummary): string => {
   const parts: string[] = [];
   if (missingVoicePermissions.length > 0) {
     parts.push(
@@ -65,6 +65,9 @@ export const formatMissingMeetingPermissions = ({
     parts.push(
       `notes channel **${textChannelName}**: ${formatMissingPermissions(missingTextPermissions)}`,
     );
+  }
+  if (parts.length === 0) {
+    return "one or more channels (permissions may have just been updated)";
   }
   return parts.join("; ");
 };

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -30,7 +30,6 @@ const TEXT_CHANNEL_MEETING_PERMISSIONS = [
     flag: PermissionsBitField.Flags.ReadMessageHistory,
     label: "Read Message History",
   },
-  { flag: PermissionsBitField.Flags.EmbedLinks, label: "Embed Links" },
 ] satisfies RequiredPermission[];
 
 const getMissingPermissions = (
@@ -84,7 +83,7 @@ export const buildAutoRecordPermissionDmMessage = (
     return `${buildAutoRecordPermissionChannelMessage(summary)} Grant those permissions, then have everyone leave and rejoin the voice channel to trigger auto-record again.`;
   }
 
-  return "Chronote tried to auto-record when you joined voice, but it cannot post meeting status or notes in the configured notes channel. A server admin needs to grant Chronote View Channel, Send Messages, Read Message History, and Embed Links in the notes channel, plus View Channel and Connect in the voice channel. If you expected this meeting to record, please ask an admin to check Chronote's channel permissions.";
+  return "Chronote tried to auto-record when you joined voice, but it cannot post meeting status or notes in the configured notes channel. A server admin needs to grant Chronote View Channel, Send Messages, and Read Message History in the notes channel, plus View Channel and Connect in the voice channel. If you expected this meeting to record, please ask an admin to check Chronote's channel permissions.";
 };
 
 /**


### PR DESCRIPTION
[AGENT]

## Summary
- Require the text-channel permissions Chronote needs for meeting status and notes messages.
- Send autorecord permission failures to the configured notes channel when possible, otherwise best-effort DM the triggering user with admin-aware copy.
- Update public docs and add permission helper tests.

## Testing
- `yarn test --runTestsByPath src/utils/__tests__/permissions.test.ts --coverage=false`
- `yarn build`
- `npx eslint src/utils/permissions.ts src/commands/startMeeting.ts src/commands/autorecord.ts src/utils/__tests__/permissions.test.ts`
- `yarn docs:check`

## Risk / Rollout
- No data migration or feature flag required.
- DM delivery remains best-effort when Discord blocks bot DMs.
- PR opened as draft to avoid triggering paid review before checks are reviewed.