### PR TITLE
[AGENT] Support MCP OAuth step-up challenges

### DIFF
--- a/apps/docs-site/docs/integrations/remote-mcp.md
+++ b/apps/docs-site/docs/integrations/remote-mcp.md
@@ -67,6 +67,8 @@ For long transcripts, request a window at a time:
 - `meetings:stop`: Required to stop recordings through MCP.
 - `get_meeting_control_request` requires a valid MCP token and only returns requests created by the authenticated user.
 
+If a tool returns `insufficient_scope`, your MCP client should follow the `WWW-Authenticate` challenge, run OAuth step-up authorization for the listed scopes, and retry the request. If your client does not support step-up authorization, reconnect Chronote MCP and approve the read, transcript, start, and stop scopes you need.
+
 ## OpenCode Example
 
 ```json

--- a/src/api/__tests__/mcp.test.ts
+++ b/src/api/__tests__/mcp.test.ts
@@ -36,7 +36,20 @@ jest.mock("../../services/mcpMeetingService", () => ({
 }));
 
 jest.mock("../../services/mcpOAuthService", () => ({
-  buildMcpBearerChallenge: jest.fn(() => "Bearer"),
+  buildMcpBearerChallenge: jest.fn(
+    (options?: string | { error?: string; scope?: string }) => {
+      if (!options) return "Bearer";
+      const scope = typeof options === "string" ? options : options.scope;
+      const error = typeof options === "string" ? undefined : options.error;
+      return [
+        "Bearer",
+        error ? `error="${error}"` : undefined,
+        scope ? `scope="${scope}"` : undefined,
+      ]
+        .filter(Boolean)
+        .join(" ");
+    },
+  ),
   formatMcpScope: jest.fn((scopes: string[]) => scopes.join(" ")),
   hasMcpScopes: jest.fn((granted: string[], required: string[]) =>
     required.every((scope) => granted.includes(scope)),
@@ -773,6 +786,32 @@ describe("MCP JSON-RPC handler", () => {
       id: null,
       error: { code: -32600, message: "Invalid JSON-RPC request." },
     });
+  });
+
+  it("returns a step-up OAuth challenge for single-tool insufficient scope", async () => {
+    jest.mocked(validateMcpAccessToken).mockResolvedValue(auth);
+    const postHandler = captureMcpPostHandler();
+    const response = createResponse();
+
+    await postHandler(
+      {
+        headers: { authorization: "Bearer token" },
+        body: {
+          jsonrpc: "2.0",
+          id: "start-scope",
+          method: "tools/call",
+          params: { name: "start_meeting", arguments: {} },
+        },
+      } as never,
+      response as never,
+      jest.fn(),
+    );
+
+    expect(response.statusCode).toBe(403);
+    expect(response.body).toEqual({ error: "insufficient_scope" });
+    expect(response.headers.get("WWW-Authenticate")).toBe(
+      'Bearer error="insufficient_scope" scope="meetings:read meetings:start"',
+    );
   });
 
   it("returns OAuth discovery challenge before origin rejection", async () => {

--- a/src/api/mcp.ts
+++ b/src/api/mcp.ts
@@ -462,9 +462,21 @@ const sendUnauthorized = (res: Response) => {
 };
 
 const sendInsufficientScope = (res: Response, scopes: McpScope[]) => {
-  res.set("WWW-Authenticate", buildMcpBearerChallenge(formatMcpScope(scopes)));
+  res.set(
+    "WWW-Authenticate",
+    buildMcpBearerChallenge({
+      error: "insufficient_scope",
+      errorDescription: "Additional OAuth scope required.",
+      scope: formatMcpScope(scopes),
+    }),
+  );
   res.status(403).json({ error: "insufficient_scope" });
 };
+
+const resolveStepUpScopes = (
+  grantedScopes: McpScope[],
+  requiredScopes: McpScope[],
+) => Array.from(new Set([...grantedScopes, ...requiredScopes]));
 
 const jsonRpcResult = (id: JsonRpcId | undefined, result: unknown) => ({
   jsonrpc: JSON_RPC_VERSION,
@@ -798,7 +810,10 @@ export function registerMcpRoutes(app: Express) {
       parsedRequestBodies,
     );
     if (requiredScopes && !hasMcpScopes(auth.scopes, requiredScopes)) {
-      sendInsufficientScope(res, requiredScopes);
+      sendInsufficientScope(
+        res,
+        resolveStepUpScopes(auth.scopes, requiredScopes),
+      );
       return;
     }
     const responses = await Promise.all(

--- a/src/services/__tests__/mcpOAuthService.test.ts
+++ b/src/services/__tests__/mcpOAuthService.test.ts
@@ -4,6 +4,7 @@ import {
   resetMcpOAuthMemoryRepository,
 } from "../../repositories/mcpOAuthRepository";
 import {
+  buildMcpBearerChallenge,
   exchangeMcpAuthorizationCode,
   getMcpResourceUrl,
   hashMcpToken,
@@ -251,6 +252,24 @@ describe("mcpOAuthService", () => {
 
   it("rejects unsupported scopes", () => {
     expect(() => parseMcpScopes("meetings:write")).toThrow(McpOAuthError);
+  });
+
+  it("builds RFC 9728 bearer challenges with step-up scope details", () => {
+    const challenge = buildMcpBearerChallenge({
+      error: "insufficient_scope",
+      errorDescription: 'Need "start" permission.',
+      scope: "meetings:read meetings:start",
+    });
+
+    expect(challenge).toContain("Bearer ");
+    expect(challenge).toContain(
+      'resource_metadata="http://localhost:3001/.well-known/oauth-protected-resource/mcp"',
+    );
+    expect(challenge).toContain('error="insufficient_scope"');
+    expect(challenge).toContain('scope="meetings:read meetings:start"');
+    expect(challenge).toContain(
+      'error_description="Need \\"start\\" permission."',
+    );
   });
 
   it("rejects unsupported dynamic client registration grant types", async () => {

--- a/src/services/__tests__/mcpOAuthService.test.ts
+++ b/src/services/__tests__/mcpOAuthService.test.ts
@@ -261,15 +261,16 @@ describe("mcpOAuthService", () => {
       scope: "meetings:read meetings:start",
     });
 
-    expect(challenge).toContain("Bearer ");
-    expect(challenge).toContain(
-      'resource_metadata="http://localhost:3001/.well-known/oauth-protected-resource/mcp"',
+    expect(challenge).toBe(
+      'Bearer resource_metadata="http://localhost:3001/.well-known/oauth-protected-resource/mcp", error="insufficient_scope", error_description="Need \\"start\\" permission.", scope="meetings:read meetings:start"',
     );
-    expect(challenge).toContain('error="insufficient_scope"');
-    expect(challenge).toContain('scope="meetings:read meetings:start"');
-    expect(challenge).toContain(
-      'error_description="Need \\"start\\" permission."',
-    );
+  });
+
+  it("omits scope from structured bearer challenges when not provided", () => {
+    const challenge = buildMcpBearerChallenge({ error: "invalid_token" });
+
+    expect(challenge).toContain('error="invalid_token"');
+    expect(challenge).not.toContain("scope=");
   });
 
   it("rejects unsupported dynamic client registration grant types", async () => {

--- a/src/services/mcpOAuthService.ts
+++ b/src/services/mcpOAuthService.ts
@@ -60,7 +60,7 @@ export const buildMcpBearerChallenge = (
     typeof scopeOrOptions === "string"
       ? { scope: scopeOrOptions }
       : scopeOrOptions;
-  const scope = options.scope ?? DEFAULT_SCOPE;
+  const scope = options.scope;
   const params = [
     bearerChallengeParam(
       "resource_metadata",
@@ -68,12 +68,12 @@ export const buildMcpBearerChallenge = (
     ),
   ];
   if (options.error) params.push(bearerChallengeParam("error", options.error));
-  if (scope) params.push(bearerChallengeParam("scope", scope));
   if (options.errorDescription) {
     params.push(
       bearerChallengeParam("error_description", options.errorDescription),
     );
   }
+  if (scope) params.push(bearerChallengeParam("scope", scope));
   return `${BEARER_TOKEN_TYPE} ${params.join(", ")}`;
 };
 

--- a/src/services/mcpOAuthService.ts
+++ b/src/services/mcpOAuthService.ts
@@ -21,6 +21,12 @@ const SUPPORTED_GRANT_TYPES = ["authorization_code", "refresh_token"];
 const SUPPORTED_RESPONSE_TYPES = ["code"];
 const SUPPORTED_TOKEN_ENDPOINT_AUTH_METHOD = "none";
 
+type McpBearerChallengeOptions = {
+  error?: string;
+  errorDescription?: string;
+  scope?: string;
+};
+
 export class McpOAuthError extends Error {
   constructor(
     readonly code: string,
@@ -41,8 +47,35 @@ export const getMcpProtectedResourceMetadataUrl = () =>
 
 export const getMcpIssuer = () => config.mcp.publicBaseUrl;
 
-export const buildMcpBearerChallenge = (scope = DEFAULT_SCOPE) =>
-  `${BEARER_TOKEN_TYPE} resource_metadata="${getMcpProtectedResourceMetadataUrl()}", scope="${scope}"`;
+const quoteBearerChallengeValue = (value: string) =>
+  `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+
+const bearerChallengeParam = (name: string, value: string) =>
+  `${name}=${quoteBearerChallengeValue(value)}`;
+
+export const buildMcpBearerChallenge = (
+  scopeOrOptions: string | McpBearerChallengeOptions = DEFAULT_SCOPE,
+) => {
+  const options =
+    typeof scopeOrOptions === "string"
+      ? { scope: scopeOrOptions }
+      : scopeOrOptions;
+  const scope = options.scope ?? DEFAULT_SCOPE;
+  const params = [
+    bearerChallengeParam(
+      "resource_metadata",
+      getMcpProtectedResourceMetadataUrl(),
+    ),
+  ];
+  if (options.error) params.push(bearerChallengeParam("error", options.error));
+  if (scope) params.push(bearerChallengeParam("scope", scope));
+  if (options.errorDescription) {
+    params.push(
+      bearerChallengeParam("error_description", options.errorDescription),
+    );
+  }
+  return `${BEARER_TOKEN_TYPE} ${params.join(", ")}`;
+};
 
 export const parseMcpScopes = (scope?: string): McpScope[] => {
   const values = (scope?.trim() || DEFAULT_SCOPE).split(/\s+/).filter(Boolean);


### PR DESCRIPTION
[AGENT]

## Summary
- Return spec-shaped MCP insufficient-scope challenges with error=insufficient_scope and resource_metadata.
- Include existing granted scopes plus missing tool scopes in step-up challenges.
- Document OAuth step-up behavior for Remote MCP clients.

## Testing
- yarn test src/api/__tests__/mcp.test.ts src/services/__tests__/mcpOAuthService.test.ts --runInBand --coverage=false
- yarn build
- yarn lint:check
- yarn docs:check
- yarn markdownlint:check
- npx prettier --check src/api/mcp.ts src/services/mcpOAuthService.ts src/api/__tests__/mcp.test.ts src/services/__tests__/mcpOAuthService.test.ts apps/docs-site/docs/integrations/remote-mcp.md
- git diff --check