### PR TITLE
[AGENT] Fix MCP refresh step-up reauth

### DIFF
--- a/apps/docs-site/docs/integrations/remote-mcp.md
+++ b/apps/docs-site/docs/integrations/remote-mcp.md
@@ -67,7 +67,7 @@ For long transcripts, request a window at a time:
 - `meetings:stop`: Required to stop recordings through MCP.
 - `get_meeting_control_request` requires a valid MCP token and only returns requests created by the authenticated user.
 
-If a tool returns `insufficient_scope`, your MCP client should follow the `WWW-Authenticate` challenge, run OAuth step-up authorization for the listed scopes, and retry the request. If your client does not support step-up authorization, reconnect Chronote MCP and approve the read, transcript, start, and stop scopes you need.
+If a tool returns `insufficient_scope`, your MCP client should follow the `WWW-Authenticate` challenge, run OAuth step-up authorization for the listed scopes, and retry the request. During step-up, Chronote may require a fresh browser authorization instead of refreshing the existing token so the new scopes are explicitly approved. If your client does not support step-up authorization, reconnect Chronote MCP and approve the read, transcript, start, and stop scopes you need.
 
 ## OpenCode Example
 

--- a/src/api/__tests__/mcp.test.ts
+++ b/src/api/__tests__/mcp.test.ts
@@ -14,7 +14,10 @@ import {
   startMcpMeetingControl,
   stopMcpMeetingControl,
 } from "../../services/mcpMeetingControlService";
-import { validateMcpAccessToken } from "../../services/mcpOAuthService";
+import {
+  markMcpAccessTokenScopeChallenge,
+  validateMcpAccessToken,
+} from "../../services/mcpOAuthService";
 import type { McpAccessTokenInfo } from "../../types/mcpOAuth";
 
 jest.mock("../../services/mcpMeetingService", () => ({
@@ -54,6 +57,7 @@ jest.mock("../../services/mcpOAuthService", () => ({
   hasMcpScopes: jest.fn((granted: string[], required: string[]) =>
     required.every((scope) => granted.includes(scope)),
   ),
+  markMcpAccessTokenScopeChallenge: jest.fn(),
   validateMcpAccessToken: jest.fn(),
 }));
 
@@ -812,6 +816,10 @@ describe("MCP JSON-RPC handler", () => {
     expect(response.headers.get("WWW-Authenticate")).toBe(
       'Bearer error="insufficient_scope" scope="meetings:read meetings:start"',
     );
+    expect(markMcpAccessTokenScopeChallenge).toHaveBeenCalledWith("token", [
+      "meetings:read",
+      "meetings:start",
+    ]);
   });
 
   it("returns OAuth discovery challenge before origin rejection", async () => {

--- a/src/api/mcp.ts
+++ b/src/api/mcp.ts
@@ -5,6 +5,7 @@ import {
   buildMcpBearerChallenge,
   formatMcpScope,
   hasMcpScopes,
+  markMcpAccessTokenScopeChallenge,
   validateMcpAccessToken,
 } from "../services/mcpOAuthService";
 import {
@@ -461,7 +462,16 @@ const sendUnauthorized = (res: Response) => {
   res.status(401).json({ error: "unauthorized" });
 };
 
-const sendInsufficientScope = (res: Response, scopes: McpScope[]) => {
+const sendInsufficientScope = async (
+  res: Response,
+  accessToken: string,
+  scopes: McpScope[],
+) => {
+  try {
+    await markMcpAccessTokenScopeChallenge(accessToken, scopes);
+  } catch (error) {
+    console.error("Failed to mark MCP OAuth scope challenge", error);
+  }
   res.set(
     "WWW-Authenticate",
     buildMcpBearerChallenge({
@@ -810,8 +820,9 @@ export function registerMcpRoutes(app: Express) {
       parsedRequestBodies,
     );
     if (requiredScopes && !hasMcpScopes(auth.scopes, requiredScopes)) {
-      sendInsufficientScope(
+      await sendInsufficientScope(
         res,
+        rawToken,
         resolveStepUpScopes(auth.scopes, requiredScopes),
       );
       return;

--- a/src/api/mcpOAuth.ts
+++ b/src/api/mcpOAuth.ts
@@ -311,6 +311,7 @@ export function registerMcpOAuthStatelessRoutes(
             clientId: req.body.client_id,
             refreshToken: req.body.refresh_token,
             resource: req.body.resource,
+            scope: getString(req.body.scope),
           }),
         );
         return;

--- a/src/services/__tests__/mcpOAuthService.test.ts
+++ b/src/services/__tests__/mcpOAuthService.test.ts
@@ -400,6 +400,16 @@ describe("mcpOAuthService", () => {
         scope: "meetings:read meetings:start",
       }),
     ).rejects.toMatchObject({ code: "invalid_scope" });
+    await expect(
+      validateMcpAccessToken(tokens.access_token),
+    ).resolves.toMatchObject({ scopes: ["meetings:read"] });
+
+    const refreshedTokens = await refreshMcpAccessToken({
+      clientId: client.clientId,
+      refreshToken: tokens.refresh_token,
+      resource: getMcpResourceUrl(),
+    });
+    expect(refreshedTokens.scope).toBe("meetings:read");
   });
 
   it("rejects unsupported scopes", () => {

--- a/src/services/__tests__/mcpOAuthService.test.ts
+++ b/src/services/__tests__/mcpOAuthService.test.ts
@@ -7,6 +7,7 @@ import {
   buildMcpBearerChallenge,
   exchangeMcpAuthorizationCode,
   getMcpResourceUrl,
+  grantMcpOAuthConsent,
   hashMcpToken,
   issueMcpAuthorizationCode,
   McpOAuthError,
@@ -23,6 +24,13 @@ const codeChallenge = crypto
   .update(codeVerifier)
   .digest("base64url");
 const redirectUri = "http://localhost:8787/oauth/callback";
+
+const expireAccessToken = async (accessToken: string) => {
+  const repository = getMcpOAuthRepository();
+  const record = await repository.getToken("access", hashMcpToken(accessToken));
+  if (!record) throw new Error("Expected access token record.");
+  await repository.writeToken({ ...record, expiresAt: 1 });
+};
 
 describe("mcpOAuthService", () => {
   beforeEach(() => {
@@ -153,6 +161,7 @@ describe("mcpOAuthService", () => {
       codeVerifier,
       resource: getMcpResourceUrl(),
     });
+    await expireAccessToken(firstTokens.access_token);
 
     const secondTokens = await refreshMcpAccessToken({
       clientId: client.clientId,
@@ -228,6 +237,7 @@ describe("mcpOAuthService", () => {
       codeVerifier,
       resource: getMcpResourceUrl(),
     });
+    await expireAccessToken(firstTokens.access_token);
 
     const results = await Promise.allSettled([
       refreshMcpAccessToken({
@@ -248,6 +258,108 @@ describe("mcpOAuthService", () => {
     expect(
       results.filter((result) => result.status === "rejected"),
     ).toHaveLength(1);
+  });
+
+  it("rejects scope-less refresh while the paired access token is still valid", async () => {
+    const client = await registerMcpOAuthClient({
+      redirect_uris: [redirectUri],
+    });
+    const code = await issueMcpAuthorizationCode({
+      clientId: client.clientId,
+      userId: "user-1",
+      redirectUri,
+      resource: getMcpResourceUrl(),
+      codeChallenge,
+      codeChallengeMethod: "S256",
+    });
+    const tokens = await exchangeMcpAuthorizationCode({
+      clientId: client.clientId,
+      code,
+      redirectUri,
+      codeVerifier,
+      resource: getMcpResourceUrl(),
+    });
+
+    await expect(
+      refreshMcpAccessToken({
+        clientId: client.clientId,
+        refreshToken: tokens.refresh_token,
+        resource: getMcpResourceUrl(),
+      }),
+    ).rejects.toMatchObject({ code: "invalid_grant" });
+    await expect(
+      validateMcpAccessToken(tokens.access_token),
+    ).resolves.toBeUndefined();
+  });
+
+  it("refreshes with requested scopes after user consent", async () => {
+    const client = await registerMcpOAuthClient({
+      redirect_uris: [redirectUri],
+    });
+    const code = await issueMcpAuthorizationCode({
+      clientId: client.clientId,
+      userId: "user-1",
+      redirectUri,
+      resource: getMcpResourceUrl(),
+      codeChallenge,
+      codeChallengeMethod: "S256",
+    });
+    const tokens = await exchangeMcpAuthorizationCode({
+      clientId: client.clientId,
+      code,
+      redirectUri,
+      codeVerifier,
+      resource: getMcpResourceUrl(),
+    });
+    await grantMcpOAuthConsent({
+      userId: "user-1",
+      clientId: client.clientId,
+      scopes: ["meetings:read", "meetings:start"],
+    });
+
+    const refreshedTokens = await refreshMcpAccessToken({
+      clientId: client.clientId,
+      refreshToken: tokens.refresh_token,
+      resource: getMcpResourceUrl(),
+      scope: "meetings:read meetings:start",
+    });
+
+    expect(refreshedTokens.scope).toBe("meetings:read meetings:start");
+    await expect(
+      validateMcpAccessToken(refreshedTokens.access_token),
+    ).resolves.toMatchObject({
+      scopes: ["meetings:read", "meetings:start"],
+    });
+  });
+
+  it("rejects requested refresh scopes without user consent", async () => {
+    const client = await registerMcpOAuthClient({
+      redirect_uris: [redirectUri],
+    });
+    const code = await issueMcpAuthorizationCode({
+      clientId: client.clientId,
+      userId: "user-1",
+      redirectUri,
+      resource: getMcpResourceUrl(),
+      codeChallenge,
+      codeChallengeMethod: "S256",
+    });
+    const tokens = await exchangeMcpAuthorizationCode({
+      clientId: client.clientId,
+      code,
+      redirectUri,
+      codeVerifier,
+      resource: getMcpResourceUrl(),
+    });
+
+    await expect(
+      refreshMcpAccessToken({
+        clientId: client.clientId,
+        refreshToken: tokens.refresh_token,
+        resource: getMcpResourceUrl(),
+        scope: "meetings:read meetings:start",
+      }),
+    ).rejects.toMatchObject({ code: "invalid_scope" });
   });
 
   it("rejects unsupported scopes", () => {

--- a/src/services/__tests__/mcpOAuthService.test.ts
+++ b/src/services/__tests__/mcpOAuthService.test.ts
@@ -10,6 +10,7 @@ import {
   grantMcpOAuthConsent,
   hashMcpToken,
   issueMcpAuthorizationCode,
+  markMcpAccessTokenScopeChallenge,
   McpOAuthError,
   parseMcpScopes,
   refreshMcpAccessToken,
@@ -260,7 +261,7 @@ describe("mcpOAuthService", () => {
     ).toHaveLength(1);
   });
 
-  it("rejects scope-less refresh while the paired access token is still valid", async () => {
+  it("rotates scope-less refresh while the paired access token is still valid", async () => {
     const client = await registerMcpOAuthClient({
       redirect_uris: [redirectUri],
     });
@@ -279,6 +280,45 @@ describe("mcpOAuthService", () => {
       codeVerifier,
       resource: getMcpResourceUrl(),
     });
+
+    const refreshedTokens = await refreshMcpAccessToken({
+      clientId: client.clientId,
+      refreshToken: tokens.refresh_token,
+      resource: getMcpResourceUrl(),
+    });
+
+    await expect(
+      validateMcpAccessToken(tokens.access_token),
+    ).resolves.toBeUndefined();
+    await expect(
+      validateMcpAccessToken(refreshedTokens.access_token),
+    ).resolves.toMatchObject({ scopes: ["meetings:read"] });
+  });
+
+  it("requires reauthorization for scope-less refresh after a live scope challenge", async () => {
+    const client = await registerMcpOAuthClient({
+      redirect_uris: [redirectUri],
+    });
+    const code = await issueMcpAuthorizationCode({
+      clientId: client.clientId,
+      userId: "user-1",
+      redirectUri,
+      resource: getMcpResourceUrl(),
+      codeChallenge,
+      codeChallengeMethod: "S256",
+    });
+    const tokens = await exchangeMcpAuthorizationCode({
+      clientId: client.clientId,
+      code,
+      redirectUri,
+      codeVerifier,
+      resource: getMcpResourceUrl(),
+    });
+
+    await markMcpAccessTokenScopeChallenge(tokens.access_token, [
+      "meetings:read",
+      "meetings:start",
+    ]);
 
     await expect(
       refreshMcpAccessToken({

--- a/src/services/mcpOAuthService.ts
+++ b/src/services/mcpOAuthService.ts
@@ -5,6 +5,7 @@ import {
   MCP_SCOPES,
   type McpAccessTokenInfo,
   type McpOAuthClient,
+  type McpOAuthToken,
   type McpScope,
 } from "../types/mcpOAuth";
 
@@ -20,6 +21,7 @@ const DEFAULT_SCOPE = "meetings:read";
 const SUPPORTED_GRANT_TYPES = ["authorization_code", "refresh_token"];
 const SUPPORTED_RESPONSE_TYPES = ["code"];
 const SUPPORTED_TOKEN_ENDPOINT_AUTH_METHOD = "none";
+const SCOPE_CHALLENGE_TTL_SECONDS = 5 * 60;
 
 type McpBearerChallengeOptions = {
   error?: string;
@@ -199,6 +201,20 @@ const createPkceChallenge = (codeVerifier: string) =>
   crypto.createHash("sha256").update(codeVerifier).digest("base64url");
 
 const nowIso = () => new Date().toISOString();
+
+const getActiveScopeChallenge = (
+  token: McpOAuthToken | undefined,
+  now: number,
+) => {
+  if (
+    !token?.scopeChallenge ||
+    !token.scopeChallengeExpiresAt ||
+    token.scopeChallengeExpiresAt <= now
+  ) {
+    return undefined;
+  }
+  return parseMcpScopes(token.scopeChallenge);
+};
 
 const issueTokenPair = async (params: {
   clientId: string;
@@ -431,15 +447,18 @@ export async function refreshMcpAccessToken(params: {
     await repository.deleteToken("access", token.pairedTokenHash);
   }
   // MCP clients may try refresh before browser reauth during step-up. Without
-  // an explicit scope, that would just recreate the insufficient live token.
+  // an explicit scope, that would just recreate the challenged live token.
+  const challengeScopes = getActiveScopeChallenge(pairedAccessToken, now);
   if (
     !requestedScopes &&
     pairedAccessToken &&
-    pairedAccessToken.expiresAt > now
+    pairedAccessToken.expiresAt > now &&
+    challengeScopes &&
+    !hasMcpScopes(tokenScopes, challengeScopes)
   ) {
     throw new McpOAuthError(
       "invalid_grant",
-      "Refresh token cannot be used while the paired access token is still valid.",
+      "Refresh token cannot satisfy the pending scope challenge.",
     );
   }
   if (
@@ -461,6 +480,30 @@ export async function refreshMcpAccessToken(params: {
     userId: token.userId,
     scopes: requestedScopes ?? tokenScopes,
     resource: token.resource,
+  });
+}
+
+export async function markMcpAccessTokenScopeChallenge(
+  accessToken: string,
+  scopes: McpScope[],
+) {
+  const repository = getMcpOAuthRepository();
+  const now = epochSeconds();
+  const token = await repository.getToken("access", hashMcpToken(accessToken));
+  if (
+    !token ||
+    token.expiresAt <= now ||
+    token.resource !== getMcpResourceUrl()
+  ) {
+    return;
+  }
+  await repository.writeToken({
+    ...token,
+    scopeChallenge: formatMcpScope(scopes),
+    scopeChallengeExpiresAt: Math.min(
+      token.expiresAt,
+      now + SCOPE_CHALLENGE_TTL_SECONDS,
+    ),
   });
 }
 

--- a/src/services/mcpOAuthService.ts
+++ b/src/services/mcpOAuthService.ts
@@ -408,23 +408,58 @@ export async function refreshMcpAccessToken(params: {
   clientId: string;
   refreshToken: string;
   resource?: string;
+  scope?: string;
 }) {
   assertMcpResource(params.resource);
+  const requestedScopes = params.scope
+    ? parseMcpScopes(params.scope)
+    : undefined;
   const repository = getMcpOAuthRepository();
+  const now = epochSeconds();
   const tokenHash = hashMcpToken(params.refreshToken);
   const token = await repository.consumeToken("refresh", tokenHash);
   if (!token)
     throw new McpOAuthError("invalid_grant", "Invalid refresh token.");
+  if (token.expiresAt <= now || token.clientId !== params.clientId) {
+    throw new McpOAuthError("invalid_grant", "Invalid refresh token.");
+  }
+  const tokenScopes = parseMcpScopes(token.scope);
+  const pairedAccessToken = token.pairedTokenHash
+    ? await repository.getToken("access", token.pairedTokenHash)
+    : undefined;
   if (token.pairedTokenHash) {
     await repository.deleteToken("access", token.pairedTokenHash);
   }
-  if (token.expiresAt <= epochSeconds() || token.clientId !== params.clientId) {
-    throw new McpOAuthError("invalid_grant", "Invalid refresh token.");
+  // MCP clients may try refresh before browser reauth during step-up. Without
+  // an explicit scope, that would just recreate the insufficient live token.
+  if (
+    !requestedScopes &&
+    pairedAccessToken &&
+    pairedAccessToken.expiresAt > now
+  ) {
+    throw new McpOAuthError(
+      "invalid_grant",
+      "Refresh token cannot be used while the paired access token is still valid.",
+    );
+  }
+  if (
+    requestedScopes &&
+    !hasMcpScopes(tokenScopes, requestedScopes) &&
+    !(await hasMcpOAuthConsent({
+      userId: token.userId,
+      clientId: token.clientId,
+      scopes: requestedScopes,
+    }))
+  ) {
+    throw new McpOAuthError(
+      "invalid_scope",
+      "Requested scope requires user authorization.",
+    );
   }
   return issueTokenPair({
     clientId: token.clientId,
     userId: token.userId,
-    scopes: parseMcpScopes(token.scope),
+    scopes: requestedScopes ?? tokenScopes,
     resource: token.resource,
   });
 }

--- a/src/services/mcpOAuthService.ts
+++ b/src/services/mcpOAuthService.ts
@@ -420,7 +420,17 @@ export async function exchangeMcpAuthorizationCode(params: {
   });
 }
 
-const assertRefreshScopeChallengeSatisfied = (params: {
+function assertUsableRefreshToken(
+  token: McpOAuthToken | undefined,
+  clientId: string,
+  now: number,
+): asserts token is McpOAuthToken {
+  if (!token || token.expiresAt <= now || token.clientId !== clientId) {
+    throw new McpOAuthError("invalid_grant", "Invalid refresh token.");
+  }
+}
+
+const shouldForceScopeChallengeReauthorization = (params: {
   requestedScopes?: McpScope[];
   pairedAccessToken?: McpOAuthToken;
   tokenScopes: McpScope[];
@@ -437,12 +447,9 @@ const assertRefreshScopeChallengeSatisfied = (params: {
     !challengeScopes ||
     hasMcpScopes(params.tokenScopes, challengeScopes)
   ) {
-    return;
+    return false;
   }
-  throw new McpOAuthError(
-    "invalid_grant",
-    "Refresh token cannot satisfy the pending scope challenge.",
-  );
+  return true;
 };
 
 const assertRefreshScopeConsent = async (params: {
@@ -480,33 +487,43 @@ export async function refreshMcpAccessToken(params: {
   const repository = getMcpOAuthRepository();
   const now = epochSeconds();
   const tokenHash = hashMcpToken(params.refreshToken);
-  const token = await repository.consumeToken("refresh", tokenHash);
-  if (!token)
-    throw new McpOAuthError("invalid_grant", "Invalid refresh token.");
-  if (token.expiresAt <= now || token.clientId !== params.clientId) {
-    throw new McpOAuthError("invalid_grant", "Invalid refresh token.");
-  }
+  const token = await repository.getToken("refresh", tokenHash);
+  assertUsableRefreshToken(token, params.clientId, now);
   const tokenScopes = parseMcpScopes(token.scope);
   const pairedAccessToken = token.pairedTokenHash
     ? await repository.getToken("access", token.pairedTokenHash)
     : undefined;
-  if (token.pairedTokenHash) {
-    await repository.deleteToken("access", token.pairedTokenHash);
-  }
   // MCP clients may try refresh before browser reauth during step-up. Without
   // an explicit scope, that would just recreate the challenged live token.
-  assertRefreshScopeChallengeSatisfied({
-    requestedScopes,
-    pairedAccessToken,
-    tokenScopes,
-    now,
-  });
+  if (
+    shouldForceScopeChallengeReauthorization({
+      requestedScopes,
+      pairedAccessToken,
+      tokenScopes,
+      now,
+    })
+  ) {
+    const consumedToken = await repository.consumeToken("refresh", tokenHash);
+    assertUsableRefreshToken(consumedToken, params.clientId, now);
+    if (consumedToken.pairedTokenHash) {
+      await repository.deleteToken("access", consumedToken.pairedTokenHash);
+    }
+    throw new McpOAuthError(
+      "invalid_grant",
+      "Refresh token cannot satisfy the pending scope challenge.",
+    );
+  }
   await assertRefreshScopeConsent({ token, tokenScopes, requestedScopes });
+  const consumedToken = await repository.consumeToken("refresh", tokenHash);
+  assertUsableRefreshToken(consumedToken, params.clientId, now);
+  if (consumedToken.pairedTokenHash) {
+    await repository.deleteToken("access", consumedToken.pairedTokenHash);
+  }
   return issueTokenPair({
-    clientId: token.clientId,
-    userId: token.userId,
+    clientId: consumedToken.clientId,
+    userId: consumedToken.userId,
     scopes: requestedScopes ?? tokenScopes,
-    resource: token.resource,
+    resource: consumedToken.resource,
   });
 }
 

--- a/src/services/mcpOAuthService.ts
+++ b/src/services/mcpOAuthService.ts
@@ -420,6 +420,53 @@ export async function exchangeMcpAuthorizationCode(params: {
   });
 }
 
+const assertRefreshScopeChallengeSatisfied = (params: {
+  requestedScopes?: McpScope[];
+  pairedAccessToken?: McpOAuthToken;
+  tokenScopes: McpScope[];
+  now: number;
+}) => {
+  const challengeScopes = getActiveScopeChallenge(
+    params.pairedAccessToken,
+    params.now,
+  );
+  if (
+    params.requestedScopes ||
+    !params.pairedAccessToken ||
+    params.pairedAccessToken.expiresAt <= params.now ||
+    !challengeScopes ||
+    hasMcpScopes(params.tokenScopes, challengeScopes)
+  ) {
+    return;
+  }
+  throw new McpOAuthError(
+    "invalid_grant",
+    "Refresh token cannot satisfy the pending scope challenge.",
+  );
+};
+
+const assertRefreshScopeConsent = async (params: {
+  token: McpOAuthToken;
+  tokenScopes: McpScope[];
+  requestedScopes?: McpScope[];
+}) => {
+  if (
+    !params.requestedScopes ||
+    hasMcpScopes(params.tokenScopes, params.requestedScopes) ||
+    (await hasMcpOAuthConsent({
+      userId: params.token.userId,
+      clientId: params.token.clientId,
+      scopes: params.requestedScopes,
+    }))
+  ) {
+    return;
+  }
+  throw new McpOAuthError(
+    "invalid_scope",
+    "Requested scope requires user authorization.",
+  );
+};
+
 export async function refreshMcpAccessToken(params: {
   clientId: string;
   refreshToken: string;
@@ -448,33 +495,13 @@ export async function refreshMcpAccessToken(params: {
   }
   // MCP clients may try refresh before browser reauth during step-up. Without
   // an explicit scope, that would just recreate the challenged live token.
-  const challengeScopes = getActiveScopeChallenge(pairedAccessToken, now);
-  if (
-    !requestedScopes &&
-    pairedAccessToken &&
-    pairedAccessToken.expiresAt > now &&
-    challengeScopes &&
-    !hasMcpScopes(tokenScopes, challengeScopes)
-  ) {
-    throw new McpOAuthError(
-      "invalid_grant",
-      "Refresh token cannot satisfy the pending scope challenge.",
-    );
-  }
-  if (
-    requestedScopes &&
-    !hasMcpScopes(tokenScopes, requestedScopes) &&
-    !(await hasMcpOAuthConsent({
-      userId: token.userId,
-      clientId: token.clientId,
-      scopes: requestedScopes,
-    }))
-  ) {
-    throw new McpOAuthError(
-      "invalid_scope",
-      "Requested scope requires user authorization.",
-    );
-  }
+  assertRefreshScopeChallengeSatisfied({
+    requestedScopes,
+    pairedAccessToken,
+    tokenScopes,
+    now,
+  });
+  await assertRefreshScopeConsent({ token, tokenScopes, requestedScopes });
   return issueTokenPair({
     clientId: token.clientId,
     userId: token.userId,

--- a/src/types/mcpOAuth.ts
+++ b/src/types/mcpOAuth.ts
@@ -39,6 +39,8 @@ export type McpOAuthToken = {
   clientId: string;
   userId: string;
   scope: string;
+  scopeChallenge?: string;
+  scopeChallengeExpiresAt?: number;
   resource: string;
   createdAt: string;
   expiresAt: number;


### PR DESCRIPTION
[AGENT]

## Summary
- Force scope-less refresh-token reuse to fail while the paired access token is still live, so MCP clients fall through to browser step-up authorization instead of recreating the same insufficient token.
- Support explicit scope on refresh-token requests when existing user consent covers the requested scopes.
- Document that Chronote may require fresh browser authorization during step-up.

## Testing
- yarn test src/services/__tests__/mcpOAuthService.test.ts src/api/__tests__/mcp.test.ts --runInBand --coverage=false
- yarn lint:check
- 
px prettier --check src/services/mcpOAuthService.ts src/api/mcpOAuth.ts src/services/__tests__/mcpOAuthService.test.ts apps/docs-site/docs/integrations/remote-mcp.md
- git diff --check
- yarn build
- yarn docs:check

## Notes
- Keeps existing expired-token refresh rotation behavior.
- Leaves unrelated local opencode.json changes out of the branch.