### PR TITLE
[AGENT] Add reviewed Terraform apply workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -96,7 +96,7 @@ This file provides Copilot review context. AGENTS.md remains the source of truth
 
 - Variables (tfvars.example): Discord IDs/tokens, OpenAI keys, OAuth secrets, ENABLE_OAUTH (false by default in example), AWS/GitHub tokens.
 - ECS task environment passes all relevant vars from Terraform; OpenAI org/project optional; OAuth vars included but can be blank if disabled.
-- Terraform plan visibility is manual via `.github/workflows/terraform-plan.yml`; merges do not auto-apply Terraform. The workflow uses environment-scoped AWS credentials and a `TERRAFORM_TFVARS_JSON` secret.
+- Terraform plan/apply is manual via `.github/workflows/terraform-plan.yml` and `.github/workflows/terraform-apply.yml`; merges do not auto-apply Terraform. Apply uses a reviewed saved plan artifact plus GitHub environment approval. The workflows use environment-scoped AWS credentials and a `TERRAFORM_TFVARS_JSON` secret.
 - Backend deploy workflows wait for unexpired `ActiveMeetingTable` leases before replacing the ECS task. Keep production and staging guards aligned when editing deploy steps.
 - Future work suggestion: keep cache and Redis Terraform resources in `_infra/cache.tf`, and add new cache infrastructure there.
 

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -157,7 +157,7 @@ jobs:
         run: terraform -chdir=_infra validate -no-color
 
       - name: Show reviewed plan
-        run: terraform -chdir=_infra show -no-color tfplan > _infra/plan-artifact/terraform-plan-to-apply.txt
+        run: terraform -chdir=_infra show -no-color tfplan
 
       - name: Terraform apply reviewed plan
         run: terraform -chdir=_infra apply -no-color -input=false tfplan

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,12 +1,12 @@
-name: Terraform Plan
+name: Terraform Apply
 
-run-name: Terraform Plan ${{ inputs.github_environment }} by ${{ github.actor }}
+run-name: Terraform Apply ${{ inputs.github_environment }} by ${{ github.actor }}
 
 on:
   workflow_dispatch:
     inputs:
       github_environment:
-        description: GitHub environment containing Terraform plan credentials and tfvars
+        description: GitHub environment containing Terraform apply credentials and tfvars
         required: true
         type: choice
         default: sandbox
@@ -14,31 +14,58 @@ on:
           - sandbox
           - staging
       terraform_workspace:
-        description: Existing Terraform workspace to plan against
+        description: Existing Terraform workspace to apply against
         required: true
         type: string
         default: default
+      plan_run_id:
+        description: GitHub Actions run ID from the reviewed Terraform Plan workflow
+        required: true
+        type: string
+      artifact_name:
+        description: Plan artifact name from the reviewed Terraform Plan summary
+        required: true
+        type: string
+      plan_sha256:
+        description: SHA-256 from the reviewed Terraform Plan summary
+        required: true
+        type: string
+      confirmation:
+        description: Type apply to confirm this should apply the reviewed plan artifact
+        required: true
+        type: string
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
-  group: terraform-plan-${{ inputs.github_environment }}-${{ inputs.terraform_workspace }}
+  group: terraform-apply-${{ inputs.github_environment }}-${{ inputs.terraform_workspace }}
   cancel-in-progress: false
 
 jobs:
-  plan:
-    name: Terraform Plan
+  apply:
+    name: Terraform Apply
     runs-on: ubuntu-latest
     environment: ${{ inputs.github_environment }}
     env:
       TF_IN_AUTOMATION: "true"
       TF_INPUT: "false"
       AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
-      PLAN_ARTIFACT_NAME: terraform-plan-${{ inputs.github_environment }}-${{ inputs.terraform_workspace }}-${{ github.run_id }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Check confirmation
+        env:
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          set -euo pipefail
+
+          if [ "$CONFIRMATION" != "apply" ]; then
+            echo "ERROR: confirmation must be exactly 'apply'."
+            exit 1
+          fi
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -49,6 +76,33 @@ jobs:
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
+
+      - name: Download reviewed plan artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PLAN_RUN_ID: ${{ inputs.plan_run_id }}
+          ARTIFACT_NAME: ${{ inputs.artifact_name }}
+          EXPECTED_SHA256: ${{ inputs.plan_sha256 }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p _infra/plan-artifact
+          gh run download "$PLAN_RUN_ID" --name "$ARTIFACT_NAME" --dir _infra/plan-artifact
+
+          if [ ! -f _infra/plan-artifact/tfplan ]; then
+            echo "ERROR: artifact did not contain tfplan."
+            exit 1
+          fi
+
+          actual_sha256="$(sha256sum _infra/plan-artifact/tfplan | awk '{print $1}')"
+          if [ "$actual_sha256" != "$EXPECTED_SHA256" ]; then
+            echo "ERROR: plan SHA-256 mismatch."
+            echo "Expected: $EXPECTED_SHA256"
+            echo "Actual:   $actual_sha256"
+            exit 1
+          fi
+
+          cp _infra/plan-artifact/tfplan _infra/tfplan
 
       - name: Write Terraform variables
         env:
@@ -102,75 +156,31 @@ jobs:
       - name: Terraform validate
         run: terraform -chdir=_infra validate -no-color
 
-      - name: Terraform plan
-        id: plan
-        run: |
-          set +e
-          terraform -chdir=_infra plan -no-color -input=false -detailed-exitcode -out=tfplan | tee _infra/terraform-plan.txt
-          exit_code=${PIPESTATUS[0]}
-          set -e
+      - name: Show reviewed plan
+        run: terraform -chdir=_infra show -no-color tfplan > _infra/plan-artifact/terraform-plan-to-apply.txt
 
-          if [ "$exit_code" -eq 1 ]; then
-            echo "Terraform plan failed."
-            exit 1
-          fi
-
-          if [ "$exit_code" -eq 2 ]; then
-            echo "changes=true" >> "$GITHUB_OUTPUT"
-            echo "Terraform plan completed with pending changes."
-          else
-            echo "changes=false" >> "$GITHUB_OUTPUT"
-            echo "Terraform plan completed with no pending changes."
-          fi
-
-      - name: Record plan artifact metadata
-        id: artifact
-        if: steps.plan.outputs.changes == 'true'
-        run: |
-          set -euo pipefail
-
-          sha256sum _infra/tfplan | awk '{print $1}' > _infra/tfplan.sha256
-
-          echo "name=$PLAN_ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
-          echo "sha256=$(cat _infra/tfplan.sha256)" >> "$GITHUB_OUTPUT"
-
-      - name: Upload reviewed plan artifact
-        if: steps.plan.outputs.changes == 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.artifact.outputs.name }}
-          path: |
-            _infra/tfplan
-            _infra/tfplan.sha256
-            _infra/terraform-plan.txt
-          retention-days: 1
-          if-no-files-found: error
+      - name: Terraform apply reviewed plan
+        run: terraform -chdir=_infra apply -no-color -input=false tfplan
 
       - name: Write summary
         if: always()
         env:
           GITHUB_ENVIRONMENT: ${{ inputs.github_environment }}
           TERRAFORM_WORKSPACE: ${{ inputs.terraform_workspace }}
-          PLAN_CHANGES: ${{ steps.plan.outputs.changes || 'unknown' }}
-          PLAN_ARTIFACT_NAME: ${{ steps.artifact.outputs.name || '' }}
-          PLAN_SHA256: ${{ steps.artifact.outputs.sha256 || '' }}
+          PLAN_RUN_ID: ${{ inputs.plan_run_id }}
+          ARTIFACT_NAME: ${{ inputs.artifact_name }}
+          PLAN_SHA256: ${{ inputs.plan_sha256 }}
         run: |
           {
-            echo "## Terraform Plan"
+            echo "## Terraform Apply"
             echo
             echo "- GitHub environment: \`$GITHUB_ENVIRONMENT\`"
             echo "- Terraform workspace: \`$TERRAFORM_WORKSPACE\`"
-            echo "- Pending changes: \`$PLAN_CHANGES\`"
-
-            if [ -n "$PLAN_ARTIFACT_NAME" ]; then
-              echo "- Plan run ID: \`$GITHUB_RUN_ID\`"
-              echo "- Apply artifact: \`$PLAN_ARTIFACT_NAME\`"
-              echo "- Plan SHA-256: \`$PLAN_SHA256\`"
-              echo
-              echo "Use \`.github/workflows/terraform-apply.yml\` with this run ID, artifact name, and SHA-256 after reviewing the plan output."
-            fi
+            echo "- Reviewed plan run ID: \`$PLAN_RUN_ID\`"
+            echo "- Reviewed plan artifact: \`$ARTIFACT_NAME\`"
+            echo "- Reviewed plan SHA-256: \`$PLAN_SHA256\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Remove generated tfvars
+      - name: Remove generated files
         if: always()
-        run: rm -f _infra/terraform.auto.tfvars.json _infra/tfplan _infra/tfplan.sha256 _infra/terraform-plan.txt
+        run: rm -rf _infra/terraform.auto.tfvars.json _infra/tfplan _infra/plan-artifact

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@
 
 - Variables (tfvars.example): Discord IDs/tokens, OpenAI keys, OAuth secrets, ENABLE_OAUTH (false by default in example), AWS/GitHub tokens.
 - ECS task environment passes all relevant vars from Terraform; OpenAI org/project optional; OAuth vars included but can be blank if disabled.
-- Terraform plan visibility is manual via `.github/workflows/terraform-plan.yml`; merges do not auto-apply Terraform. The workflow expects environment-scoped AWS credentials and a `TERRAFORM_TFVARS_JSON` secret. Keep `grafana_api_key` empty after Grafana token rotation is active, and use `grafana_service_account_id` plus the rotated Secrets Manager token.
+- Terraform plan/apply is manual via `.github/workflows/terraform-plan.yml` and `.github/workflows/terraform-apply.yml`; merges do not auto-apply Terraform. Apply uses a reviewed saved plan artifact plus GitHub environment approval. The workflows expect environment-scoped AWS credentials and a `TERRAFORM_TFVARS_JSON` secret. Keep `grafana_api_key` empty after Grafana token rotation is active, and use `grafana_service_account_id` plus the rotated Secrets Manager token.
 - Backend deploy workflows must wait for unexpired `ActiveMeetingTable` leases to clear before replacing the ECS task, so merges do not kill in-progress recordings. Keep production and staging deploy guards aligned.
 - Future work suggestion: keep cache and Redis Terraform resources in `_infra/cache.tf`, and add new cache infrastructure there.
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ These checks run before PR merge and deployment. Use `yarn run check` for the fu
 - Prompt sync (Langfuse) keeps repo prompt files aligned with Langfuse. Command: `yarn prompts:check`.
 - LLM connection sync (Langfuse) keeps LLM connection YAML aligned with Langfuse. Command: `yarn llm-connections:check`.
 - IaC scan (Checkov via uvx) catches Terraform misconfigurations. Command: `yarn checkov`. Docs: https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html and https://docs.astral.sh/uv/concepts/tools/
-- Terraform drift visibility is manual through `.github/workflows/terraform-plan.yml`. It runs `terraform plan` against a selected GitHub environment and workspace, but does not apply changes.
+- Terraform drift visibility and reconciliation are manual through `.github/workflows/terraform-plan.yml` and `.github/workflows/terraform-apply.yml`. Apply uses a reviewed saved plan artifact and GitHub environment approval.
 
 CI runs the same set as `yarn run check:ci` (see `.github/workflows/ci.yml`).
 

--- a/_infra/README.md
+++ b/_infra/README.md
@@ -207,11 +207,16 @@ If you prefer separate variable files, use:
 - Staging: copy `terraform.staging.tfvars.example` to `terraform.staging.tfvars`, then run
   `terraform -chdir=_infra plan -var-file=terraform.staging.tfvars`
 
-## Terraform plan workflow
+## Terraform plan and apply workflows
 
-`.github/workflows/terraform-plan.yml` is a manual plan-only workflow. It does
-not run on merge and does not apply changes. Use it before planned infra work or
-when checking drift after deploys.
+`.github/workflows/terraform-plan.yml` is a manual plan workflow. It does not run
+on merge. Use it before planned infra work or when checking drift after deploys.
+When the plan has changes, it uploads a short-lived `tfplan` artifact and writes
+the artifact name, plan run ID, and SHA-256 to the workflow summary.
+
+`.github/workflows/terraform-apply.yml` is a manual apply workflow. It downloads a
+reviewed plan artifact from a specific plan run, verifies the SHA-256, and applies
+that saved plan. It does not generate a fresh unreviewed plan during apply.
 
 Each GitHub environment used by the workflow must provide:
 
@@ -225,7 +230,39 @@ plans. The workflow validates that required variables are present and rejects a
 non-empty `grafana_api_key` after Grafana token rotation is active. Use
 `grafana_service_account_id` and the rotated Secrets Manager token instead.
 
+Recommended apply flow:
+
+1. Run **Terraform Plan** for the target GitHub environment and Terraform
+   workspace.
+2. Review the plan log and workflow summary.
+3. If the plan is acceptable, run **Terraform Apply** with the plan run ID,
+   artifact name, and SHA-256 from the plan summary.
+4. Type `apply` in the confirmation input.
+5. Approve the GitHub environment gate for production-like environments.
+
+Plan artifacts contain a binary Terraform plan and can include sensitive values.
+They are retained for one day. Do not download or share them outside the
+maintainer workflow.
+
 Merges do not reconcile Terraform drift. The deploy workflows update ECS task
 definitions, S3 objects, and CloudFront invalidations directly, while Terraform
 owns the baseline infrastructure. Review plan output before applying, especially
 ECS task definition replacement and provider normalization diffs.
+
+## Emergency drift repair
+
+Prefer the plan/apply workflows for all routine infrastructure changes. If a
+production incident requires a direct AWS repair, make the smallest possible
+change, record exactly what changed in an issue, and reconcile Terraform state as
+soon as the incident is stable.
+
+For directly-created resources already declared in Terraform, import them into
+state before the next apply. Example:
+
+```bash
+terraform -chdir=_infra init -input=false
+terraform -chdir=_infra import aws_dynamodb_table.meeting_control_command_table meeting-notes-prod-MeetingControlCommandTable
+```
+
+After importing, run the Terraform Plan workflow with the real environment
+tfvars and verify the repaired resource is no longer shown as drift.


### PR DESCRIPTION
[AGENT]

## Summary

- Add a manual Terraform Apply workflow that downloads a reviewed plan artifact by run ID, verifies its SHA-256, and applies the saved plan.
- Update Terraform Plan to upload a short-lived plan artifact and publish apply metadata in the workflow summary.
- Document the plan/apply flow, plan artifact sensitivity, and emergency drift repair/import steps.

## Why

Remote MCP live-control drift exposed that this repo had plan visibility but no safe apply path. This adds an approval-gated workflow and keeps apply tied to a reviewed saved plan instead of generating a fresh unreviewed plan during apply.

Related: #221. The issue should stay open until this workflow is merged and a production Terraform Plan run confirms no remaining drift.

## Validation

- `terraform validate -no-color`
- Prettier check on changed workflow/docs files
- Markdownlint on changed docs files
- CI passed on PR #222

## Risk Notes

- Plan artifacts may contain sensitive Terraform values, so retention is set to one day and docs warn maintainers not to download/share them outside the workflow.
- Apply still requires GitHub environment approval plus exact `apply` confirmation.