### PR TITLE
[AGENT] Align Terraform AWS access key source

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-access-key-id: ${{ vars.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-access-key-id: ${{ vars.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 

--- a/_infra/README.md
+++ b/_infra/README.md
@@ -220,7 +220,7 @@ that saved plan. It does not generate a fresh unreviewed plan during apply.
 
 Each GitHub environment used by the workflow must provide:
 
-- Secret `AWS_ACCESS_KEY_ID`
+- Variable `AWS_ACCESS_KEY_ID`
 - Secret `AWS_SECRET_ACCESS_KEY`
 - Secret `TERRAFORM_TFVARS_JSON`
 


### PR DESCRIPTION
[AGENT]

## Summary
- Use the existing `AWS_ACCESS_KEY_ID` environment variable for Terraform plan/apply workflows.
- Keep `AWS_SECRET_ACCESS_KEY` and `TERRAFORM_TFVARS_JSON` as environment secrets.
- Update the infra README to match the workflow credential contract.

## Why
The merged Terraform Plan workflow failed while configuring AWS credentials because it looked for `AWS_ACCESS_KEY_ID` as a secret, while the existing deploy workflows and environment configuration use an environment variable.

## Testing
- `prettier --check .github/workflows/terraform-plan.yml .github/workflows/terraform-apply.yml _infra/README.md`
- `markdownlint-cli2 _infra/README.md`
- `terraform validate -no-color`
- `git diff --check`
- CI passed after rerunning one unrelated visual-regression flake.

## Risk
Low. This aligns Terraform workflow credential lookup with the deploy workflows and existing GitHub environment configuration.