### PR TITLE
[AGENT] Preserve Terraform plan exit codes

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -70,7 +70,10 @@ jobs:
       - name: Mask AWS access key ID
         env:
           AWS_ACCESS_KEY_ID: ${{ vars.AWS_ACCESS_KEY_ID }}
-        run: echo "::add-mask::$AWS_ACCESS_KEY_ID"
+        run: |
+          if [ -n "$AWS_ACCESS_KEY_ID" ]; then
+            echo "::add-mask::$AWS_ACCESS_KEY_ID"
+          fi
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -67,6 +67,11 @@ jobs:
             exit 1
           fi
 
+      - name: Mask AWS access key ID
+        env:
+          AWS_ACCESS_KEY_ID: ${{ vars.AWS_ACCESS_KEY_ID }}
+        run: echo "::add-mask::$AWS_ACCESS_KEY_ID"
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
@@ -76,6 +81,8 @@ jobs:
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_wrapper: false
 
       - name: Download reviewed plan artifact
         env:

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -43,7 +43,10 @@ jobs:
       - name: Mask AWS access key ID
         env:
           AWS_ACCESS_KEY_ID: ${{ vars.AWS_ACCESS_KEY_ID }}
-        run: echo "::add-mask::$AWS_ACCESS_KEY_ID"
+        run: |
+          if [ -n "$AWS_ACCESS_KEY_ID" ]; then
+            echo "::add-mask::$AWS_ACCESS_KEY_ID"
+          fi
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -40,6 +40,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Mask AWS access key ID
+        env:
+          AWS_ACCESS_KEY_ID: ${{ vars.AWS_ACCESS_KEY_ID }}
+        run: echo "::add-mask::$AWS_ACCESS_KEY_ID"
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
@@ -49,6 +54,8 @@ jobs:
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_wrapper: false
 
       - name: Write Terraform variables
         env:


### PR DESCRIPTION
[AGENT]

## Summary
- Disable the Terraform CLI wrapper in plan/apply workflows so shell exit-code handling sees Terraform's real status.
- Mask the environment-variable AWS access key ID before configuring AWS credentials.

## Why
A production plan run printed `Plan: 0 to add, 2 to change, 0 to destroy` but the workflow still recorded `changes=false` and skipped the reviewed plan artifact. The wrapper from `hashicorp/setup-terraform` can interfere with shell-based `-detailed-exitcode` handling.

## Testing
- `prettier --check .github/workflows/terraform-plan.yml .github/workflows/terraform-apply.yml`
- `git diff --check`
- CI passed.

`actionlint` is not installed in the local environment.

## Risk
Low. The workflows still run the same Terraform commands; this preserves their real exit codes and reduces credential identifier exposure in logs.