### PR TITLE
[AGENT] Use secret for Terraform AWS access key ID

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -12,7 +12,6 @@ on:
         default: sandbox
         options:
           - sandbox
-          - staging
       terraform_workspace:
         description: Existing Terraform workspace to apply against
         required: true

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -67,18 +67,10 @@ jobs:
             exit 1
           fi
 
-      - name: Mask AWS access key ID
-        env:
-          AWS_ACCESS_KEY_ID: ${{ vars.AWS_ACCESS_KEY_ID }}
-        run: |
-          if [ -n "$AWS_ACCESS_KEY_ID" ]; then
-            echo "::add-mask::$AWS_ACCESS_KEY_ID"
-          fi
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ vars.AWS_ACCESS_KEY_ID }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -40,18 +40,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Mask AWS access key ID
-        env:
-          AWS_ACCESS_KEY_ID: ${{ vars.AWS_ACCESS_KEY_ID }}
-        run: |
-          if [ -n "$AWS_ACCESS_KEY_ID" ]; then
-            echo "::add-mask::$AWS_ACCESS_KEY_ID"
-          fi
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ vars.AWS_ACCESS_KEY_ID }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -12,7 +12,6 @@ on:
         default: sandbox
         options:
           - sandbox
-          - staging
       terraform_workspace:
         description: Existing Terraform workspace to plan against
         required: true

--- a/_infra/README.md
+++ b/_infra/README.md
@@ -224,6 +224,11 @@ Each GitHub environment used by the workflow must provide:
 - Secret `AWS_SECRET_ACCESS_KEY`
 - Secret `TERRAFORM_TFVARS_JSON`
 
+The workflow dispatch choices should only list GitHub Actions environments that
+already exist and have these secrets configured. Add `staging` to the workflow
+inputs only after creating the `staging` environment and setting its Terraform
+credentials and tfvars.
+
 `TERRAFORM_TFVARS_JSON` is the environment-specific Terraform variable file as
 JSON. Keep it aligned with the private `terraform.tfvars` values used for manual
 plans. The workflow validates that required variables are present and rejects a

--- a/_infra/README.md
+++ b/_infra/README.md
@@ -220,7 +220,7 @@ that saved plan. It does not generate a fresh unreviewed plan during apply.
 
 Each GitHub environment used by the workflow must provide:
 
-- Variable `AWS_ACCESS_KEY_ID`
+- Secret `AWS_ACCESS_KEY_ID`
 - Secret `AWS_SECRET_ACCESS_KEY`
 - Secret `TERRAFORM_TFVARS_JSON`
 


### PR DESCRIPTION
[AGENT]

## Summary
- Use the `AWS_ACCESS_KEY_ID` environment secret in Terraform plan/apply workflows.
- Remove the explicit masking step, which cannot safely mask a non-secret before the step environment is logged.
- Remove the unconfigured `staging` workflow dispatch target so Terraform runs only expose the configured `sandbox` GitHub environment.
- Update the infra README to document the Terraform workflow credential as a secret and require future workflow targets to have their environment secrets configured first.

## Why
The key ID is now configured as a `sandbox` environment secret. Using the secret directly lets GitHub mask it before workflow inputs and environments are logged. The repo does not currently have a `staging` GitHub Actions environment, so leaving it selectable would create a broken Terraform target.

## Testing
- `prettier --check .github/workflows/terraform-plan.yml .github/workflows/terraform-apply.yml _infra/README.md`
- `markdownlint-cli2 _infra/README.md`
- `git diff --check`
- CI passed.

## Risk
Low. This only changes where the Terraform workflows read the access key ID from and removes an unconfigured manual workflow target. The matching `sandbox` GitHub environment secret has been configured.