### PR TITLE
[AGENT] Split production and sandbox environments

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -96,8 +96,8 @@ This file provides Copilot review context. AGENTS.md remains the source of truth
 
 - Variables (tfvars.example): Discord IDs/tokens, OpenAI keys, OAuth secrets, ENABLE_OAUTH (false by default in example), AWS/GitHub tokens.
 - ECS task environment passes all relevant vars from Terraform; OpenAI org/project optional; OAuth vars included but can be blank if disabled.
-- Terraform plan/apply is manual via `.github/workflows/terraform-plan.yml` and `.github/workflows/terraform-apply.yml`; merges do not auto-apply Terraform. Apply uses a reviewed saved plan artifact plus GitHub environment approval. The workflows use environment-scoped AWS credentials and a `TERRAFORM_TFVARS_JSON` secret.
-- Backend deploy workflows wait for unexpired `ActiveMeetingTable` leases before replacing the ECS task. Keep production and staging guards aligned when editing deploy steps.
+- Terraform plan/apply is manual via `.github/workflows/terraform-plan.yml` and `.github/workflows/terraform-apply.yml`; merges do not auto-apply Terraform. Apply uses a reviewed saved plan artifact plus GitHub environment approval. Production uses GitHub environment `production` with Terraform workspace `default`; sandbox uses GitHub environment `sandbox` with Terraform workspace `sandbox`.
+- Backend deploy workflows wait for unexpired `ActiveMeetingTable` leases before replacing the ECS task. Keep production and sandbox guards aligned when editing deploy steps.
 - Future work suggestion: keep cache and Redis Terraform resources in `_infra/cache.tf`, and add new cache infrastructure there.
 
 ## Known nuances / gotchas

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -343,6 +343,8 @@ jobs:
 
           echo "Sandbox deploy target preflight passed."
 
+  # Keep each deploy job scoped to the sandbox environment so AWS credentials and
+  # target variables do not need to be passed through job outputs.
   deploybackend:
     name: Deploy Backend (Sandbox)
     needs: [deploy-target-preflight]

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,6 +1,6 @@
-name: Meeting Notes Bot Deploy (Staging)
+name: Meeting Notes Bot Deploy (Sandbox)
 
-run-name: Staging Deploy ${{ github.actor }}
+run-name: Sandbox Deploy ${{ github.actor }}
 
 on:
   workflow_dispatch:
@@ -251,8 +251,8 @@ jobs:
       - name: Run Playwright tests (mock mode)
         run: yarn test:e2e
 
-  deploybackend:
-    name: Deploy Backend (Staging)
+  deploy-target-preflight:
+    name: Deploy Target Preflight
     needs:
       [
         lint,
@@ -266,7 +266,88 @@ jobs:
         e2e-tests,
       ]
     runs-on: ubuntu-latest
-    environment: staging
+    environment: sandbox
+    env:
+      DEPLOY_ENVIRONMENT: sandbox
+      VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
+      ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+      ECS_CLUSTER: ${{ vars.ECS_CLUSTER }}
+      ECS_SERVICE: ${{ vars.ECS_SERVICE }}
+      ECS_TASK_FAMILY: ${{ vars.ECS_TASK_FAMILY }}
+      ECS_LOG_GROUP: ${{ vars.ECS_LOG_GROUP }}
+      SECRETS_PREFIX: ${{ vars.SECRETS_PREFIX }}
+      FRONTEND_BUCKET: ${{ vars.FRONTEND_BUCKET }}
+      DOCS_BUCKET: ${{ vars.DOCS_BUCKET }}
+      AWS_ACCESS_KEY_ID: ${{ vars.AWS_ACCESS_KEY_ID }}
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      FRONTEND_DISTRIBUTION_ID: ${{ vars.FRONTEND_DISTRIBUTION_ID }}
+      HAS_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY != '' }}
+    steps:
+      - name: Reject production resources for sandbox deploys
+        run: |
+          set -euo pipefail
+
+          required_names=(
+            AWS_ACCESS_KEY_ID
+            AWS_REGION
+            ECR_REPOSITORY
+            ECS_CLUSTER
+            ECS_SERVICE
+            ECS_TASK_FAMILY
+            ECS_LOG_GROUP
+            FRONTEND_BUCKET
+            FRONTEND_DISTRIBUTION_ID
+            SECRETS_PREFIX
+            VITE_API_BASE_URL
+          )
+
+          missing_values=()
+          for name in "${required_names[@]}"; do
+            if [ -z "${!name:-}" ]; then
+              missing_values+=("$name")
+            fi
+          done
+
+          if [ "$HAS_AWS_SECRET_ACCESS_KEY" != "true" ]; then
+            missing_values+=("AWS_SECRET_ACCESS_KEY")
+          fi
+
+          if [ ${#missing_values[@]} -gt 0 ]; then
+            echo "ERROR: sandbox deploy is missing required configuration."
+            printf ' - %s\n' "${missing_values[@]}"
+            exit 1
+          fi
+
+          production_hits=()
+          for value in \
+            "$VITE_API_BASE_URL" \
+            "$ECR_REPOSITORY" \
+            "$ECS_CLUSTER" \
+            "$ECS_SERVICE" \
+            "$ECS_TASK_FAMILY" \
+            "$ECS_LOG_GROUP" \
+            "$SECRETS_PREFIX" \
+            "$FRONTEND_BUCKET" \
+            "$DOCS_BUCKET"; do
+            normalized="${value,,}"
+            if [[ "$normalized" == *"prod"* ]] || [[ "$normalized" == "https://api.chronote.gg"* ]]; then
+              production_hits+=("$value")
+            fi
+          done
+
+          if [ ${#production_hits[@]} -gt 0 ]; then
+            echo "ERROR: sandbox deploy variables still reference production resources."
+            printf ' - %s\n' "${production_hits[@]}"
+            exit 1
+          fi
+
+          echo "Sandbox deploy target preflight passed."
+
+  deploybackend:
+    name: Deploy Backend (Sandbox)
+    needs: [deploy-target-preflight]
+    runs-on: ubuntu-latest
+    environment: sandbox
     env:
       ECS_CLUSTER: ${{ vars.ECS_CLUSTER }}
       ECS_SERVICE: ${{ vars.ECS_SERVICE }}
@@ -512,14 +593,14 @@ jobs:
           ACTOR: ${{ github.actor }}
         run: |
           if [ "$JOB_STATUS" == "success" ]; then
-            echo "## ✅ Staging Deployment Successful!" >> $GITHUB_STEP_SUMMARY
+            echo "## ✅ Sandbox Deployment Successful!" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "- **Commit:** $COMMIT_SHA" >> $GITHUB_STEP_SUMMARY
             echo "- **Branch:** $REF_NAME" >> $GITHUB_STEP_SUMMARY
             echo "- **Deployed by:** $ACTOR" >> $GITHUB_STEP_SUMMARY
             echo "- **Deployment time:** $(date -u +"%Y-%m-%d %H:%M:%S UTC")" >> $GITHUB_STEP_SUMMARY
           else
-            echo "## ❌ Staging Deployment Failed!" >> $GITHUB_STEP_SUMMARY
+            echo "## ❌ Sandbox Deployment Failed!" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "- **Commit:** $COMMIT_SHA" >> $GITHUB_STEP_SUMMARY
             echo "- **Branch:** $REF_NAME" >> $GITHUB_STEP_SUMMARY
@@ -528,21 +609,10 @@ jobs:
           fi
 
   deploy-frontend:
-    name: Deploy Frontend (Staging)
-    needs:
-      [
-        lint,
-        markdownlint,
-        test,
-        code-stats,
-        prompts-check,
-        llm-connections-check,
-        build,
-        docs-check,
-        e2e-tests,
-      ]
+    name: Deploy Frontend (Sandbox)
+    needs: [deploy-target-preflight]
     runs-on: ubuntu-latest
-    environment: staging
+    environment: sandbox
     env:
       VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
     steps:
@@ -594,21 +664,10 @@ jobs:
           aws cloudfront create-invalidation --distribution-id "$FRONTEND_DISTRIBUTION_ID" --paths "/*"
 
   deploy-docs:
-    name: Deploy Docs (Staging)
-    needs:
-      [
-        lint,
-        markdownlint,
-        test,
-        code-stats,
-        prompts-check,
-        llm-connections-check,
-        build,
-        docs-check,
-        e2e-tests,
-      ]
+    name: Deploy Docs (Sandbox)
+    needs: [deploy-target-preflight]
     runs-on: ubuntu-latest
-    environment: staging
+    environment: sandbox
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -305,7 +305,7 @@ jobs:
         e2e-tests,
       ]
     runs-on: ubuntu-latest
-    environment: sandbox
+    environment: production
     env:
       ECS_CLUSTER: ${{ vars.ECS_CLUSTER }}
       ECS_SERVICE: ${{ vars.ECS_SERVICE }}
@@ -609,7 +609,7 @@ jobs:
         e2e-tests,
       ]
     runs-on: ubuntu-latest
-    environment: sandbox
+    environment: production
     env:
       VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
     steps:
@@ -678,7 +678,7 @@ jobs:
         e2e-tests,
       ]
     runs-on: ubuntu-latest
-    environment: sandbox
+    environment: production
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -12,11 +12,12 @@ on:
         default: sandbox
         options:
           - sandbox
+          - production
       terraform_workspace:
         description: Existing Terraform workspace to apply against
         required: true
         type: string
-        default: default
+        default: sandbox
       plan_run_id:
         description: GitHub Actions run ID from the reviewed Terraform Plan workflow
         required: true
@@ -77,6 +78,23 @@ jobs:
         uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false
+
+      - name: Check environment and workspace pairing
+        env:
+          GITHUB_ENVIRONMENT: ${{ inputs.github_environment }}
+          TERRAFORM_WORKSPACE: ${{ inputs.terraform_workspace }}
+        run: |
+          set -euo pipefail
+
+          if [ "$GITHUB_ENVIRONMENT" = "production" ] && [ "$TERRAFORM_WORKSPACE" != "default" ]; then
+            echo "ERROR: production Terraform applies must use the default workspace."
+            exit 1
+          fi
+
+          if [ "$GITHUB_ENVIRONMENT" = "sandbox" ] && [ "$TERRAFORM_WORKSPACE" != "sandbox" ]; then
+            echo "ERROR: sandbox Terraform applies must use the sandbox workspace."
+            exit 1
+          fi
 
       - name: Download reviewed plan artifact
         env:

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -14,7 +14,7 @@ on:
           - sandbox
           - production
       terraform_workspace:
-        description: Existing Terraform workspace to apply against
+        description: Existing Terraform workspace from the reviewed plan; production uses default, sandbox uses sandbox
         required: true
         type: string
         default: sandbox

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -12,11 +12,12 @@ on:
         default: sandbox
         options:
           - sandbox
+          - production
       terraform_workspace:
         description: Existing Terraform workspace to plan against
         required: true
         type: string
-        default: default
+        default: sandbox
 
 permissions:
   contents: read
@@ -50,6 +51,23 @@ jobs:
         uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false
+
+      - name: Check environment and workspace pairing
+        env:
+          GITHUB_ENVIRONMENT: ${{ inputs.github_environment }}
+          TERRAFORM_WORKSPACE: ${{ inputs.terraform_workspace }}
+        run: |
+          set -euo pipefail
+
+          if [ "$GITHUB_ENVIRONMENT" = "production" ] && [ "$TERRAFORM_WORKSPACE" != "default" ]; then
+            echo "ERROR: production Terraform plans must use the default workspace."
+            exit 1
+          fi
+
+          if [ "$GITHUB_ENVIRONMENT" = "sandbox" ] && [ "$TERRAFORM_WORKSPACE" != "sandbox" ]; then
+            echo "ERROR: sandbox Terraform plans must use the sandbox workspace."
+            exit 1
+          fi
 
       - name: Write Terraform variables
         env:
@@ -95,10 +113,12 @@ jobs:
       - name: Terraform init
         run: terraform -chdir=_infra init -input=false
 
-      - name: Select Terraform workspace
+      - name: Select or create Terraform workspace
         env:
           TERRAFORM_WORKSPACE: ${{ inputs.terraform_workspace }}
-        run: terraform -chdir=_infra workspace select "$TERRAFORM_WORKSPACE"
+        run: |
+          set -euo pipefail
+          terraform -chdir=_infra workspace select "$TERRAFORM_WORKSPACE" || terraform -chdir=_infra workspace new "$TERRAFORM_WORKSPACE"
 
       - name: Terraform validate
         run: terraform -chdir=_infra validate -no-color

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -14,7 +14,7 @@ on:
           - sandbox
           - production
       terraform_workspace:
-        description: Existing Terraform workspace to plan against
+        description: Terraform workspace to plan against; production uses default, sandbox uses sandbox
         required: true
         type: string
         default: sandbox

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,8 +97,8 @@
 
 - Variables (tfvars.example): Discord IDs/tokens, OpenAI keys, OAuth secrets, ENABLE_OAUTH (false by default in example), AWS/GitHub tokens.
 - ECS task environment passes all relevant vars from Terraform; OpenAI org/project optional; OAuth vars included but can be blank if disabled.
-- Terraform plan/apply is manual via `.github/workflows/terraform-plan.yml` and `.github/workflows/terraform-apply.yml`; merges do not auto-apply Terraform. Apply uses a reviewed saved plan artifact plus GitHub environment approval. The workflows expect environment-scoped AWS credentials and a `TERRAFORM_TFVARS_JSON` secret. Keep `grafana_api_key` empty after Grafana token rotation is active, and use `grafana_service_account_id` plus the rotated Secrets Manager token.
-- Backend deploy workflows must wait for unexpired `ActiveMeetingTable` leases to clear before replacing the ECS task, so merges do not kill in-progress recordings. Keep production and staging deploy guards aligned.
+- Terraform plan/apply is manual via `.github/workflows/terraform-plan.yml` and `.github/workflows/terraform-apply.yml`; merges do not auto-apply Terraform. Apply uses a reviewed saved plan artifact plus GitHub environment approval. The workflows expect environment-scoped AWS credentials and a `TERRAFORM_TFVARS_JSON` secret. Production uses GitHub environment `production` with Terraform workspace `default`; sandbox uses GitHub environment `sandbox` with Terraform workspace `sandbox`. Keep `grafana_api_key` empty after Grafana token rotation is active, and use `grafana_service_account_id` plus the rotated Secrets Manager token.
+- Backend deploy workflows must wait for unexpired `ActiveMeetingTable` leases to clear before replacing the ECS task, so merges do not kill in-progress recordings. Keep production and sandbox deploy guards aligned.
 - Future work suggestion: keep cache and Redis Terraform resources in `_infra/cache.tf`, and add new cache infrastructure there.
 
 ## Known nuances / gotchas

--- a/_infra/README.md
+++ b/_infra/README.md
@@ -205,6 +205,12 @@ Terraform also writes deploy variables back to GitHub. Keep `github_owner` and
 `github_repository` pointed at the repository that owns the deployment workflows
 (currently `Chronote-gg/Chronote`).
 
+GitHub environments contain environment-scoped secrets. Terraform protects the
+managed GitHub environment from destruction so a production plan cannot replace
+an existing state entry that still points at the old `sandbox` environment. If a
+plan shows `github_repository_environment.repo_env` needs replacement, stop and
+migrate/import the GitHub environment state before applying.
+
 If you prefer separate variable files, use:
 
 - Prod: `terraform -chdir=_infra plan -var-file=terraform.tfvars`

--- a/_infra/README.md
+++ b/_infra/README.md
@@ -188,22 +188,28 @@ If you set `DOCS_DOMAIN` in `terraform.tfvars`, Terraform will:
 
 Deploy workflows use those variables to publish `apps/docs-site` to `docs.chronote.gg`.
 
-## Environments (prod vs staging)
+## Environments (production, sandbox, staging)
 
 Terraform now supports environment-specific resource naming via `environment`
 and `project_name` in `terraform.tfvars`.
 
 Recommended workflow:
 
-1. Use a separate workspace for staging: `terraform workspace new staging`
-2. Set `environment="staging"` and `github_environment="staging"` in
-   `terraform.tfvars` for staging runs.
-3. For production, keep `environment="prod"` and your existing GitHub Actions
-   environment name (currently `sandbox`).
+1. Use the default Terraform workspace for production only.
+2. Use a separate `sandbox` Terraform workspace for sandbox resources.
+3. Set `environment="prod"` and `github_environment="production"` for production.
+4. Set `environment="sandbox"` and `github_environment="sandbox"` for sandbox.
+5. Do not point the `sandbox` GitHub Actions environment at production resources.
+
+Terraform also writes deploy variables back to GitHub. Keep `github_owner` and
+`github_repository` pointed at the repository that owns the deployment workflows
+(currently `Chronote-gg/Chronote`).
 
 If you prefer separate variable files, use:
 
 - Prod: `terraform -chdir=_infra plan -var-file=terraform.tfvars`
+- Sandbox: copy `terraform.sandbox.tfvars.example` to `terraform.sandbox.tfvars`, then run
+  `terraform -chdir=_infra plan -var-file=terraform.sandbox.tfvars`
 - Staging: copy `terraform.staging.tfvars.example` to `terraform.staging.tfvars`, then run
   `terraform -chdir=_infra plan -var-file=terraform.staging.tfvars`
 
@@ -225,9 +231,10 @@ Each GitHub environment used by the workflow must provide:
 - Secret `TERRAFORM_TFVARS_JSON`
 
 The workflow dispatch choices should only list GitHub Actions environments that
-already exist and have these secrets configured. Add `staging` to the workflow
-inputs only after creating the `staging` environment and setting its Terraform
-credentials and tfvars.
+already exist and have these secrets configured. Production plans must use the
+`production` GitHub environment with the `default` Terraform workspace. Sandbox
+plans must use the `sandbox` GitHub environment with the `sandbox` Terraform
+workspace.
 
 `TERRAFORM_TFVARS_JSON` is the environment-specific Terraform variable file as
 JSON. Keep it aligned with the private `terraform.tfvars` values used for manual

--- a/_infra/main.tf
+++ b/_infra/main.tf
@@ -501,6 +501,10 @@ data "github_repository" "repo" {
 resource "github_repository_environment" "repo_env" {
   repository  = data.github_repository.repo.name
   environment = var.github_environment
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "github_actions_environment_variable" "envvar_aws_region" {

--- a/_infra/main.tf
+++ b/_infra/main.tf
@@ -38,7 +38,7 @@ variable "project_name" {
 }
 
 variable "environment" {
-  description = "Deployment environment (e.g., prod, staging)"
+  description = "Deployment environment (e.g., prod, sandbox, staging)"
   type        = string
   default     = "prod"
 }

--- a/_infra/main.tf
+++ b/_infra/main.tf
@@ -46,7 +46,19 @@ variable "environment" {
 variable "github_environment" {
   description = "GitHub Actions environment name to populate with deploy variables"
   type        = string
-  default     = "sandbox"
+  default     = "production"
+}
+
+variable "github_owner" {
+  description = "GitHub organization or user that owns the repository receiving deploy variables"
+  type        = string
+  default     = "Chronote-gg"
+}
+
+variable "github_repository" {
+  description = "GitHub repository receiving deploy variables"
+  type        = string
+  default     = "Chronote"
 }
 
 
@@ -420,7 +432,7 @@ provider "aws" {
 data "aws_caller_identity" "current" {}
 
 provider "github" {
-  owner = "BASIC-BIT"
+  owner = var.github_owner
   token = var.GITHUB_TOKEN
 }
 
@@ -483,7 +495,7 @@ EOF
 }
 
 data "github_repository" "repo" {
-  full_name = "BASIC-BIT/meeting-notes-discord-bot"
+  full_name = "${var.github_owner}/${var.github_repository}"
 }
 
 resource "github_repository_environment" "repo_env" {

--- a/_infra/terraform.sandbox.tfvars.example
+++ b/_infra/terraform.sandbox.tfvars.example
@@ -1,0 +1,67 @@
+# Required
+DISCORD_CLIENT_ID="your-sandbox-discord-client-id"
+GITHUB_TOKEN="your-github-token"
+AWS_TOKEN_KEY="your-aws-token-key"
+
+# Environment setup
+environment="sandbox"
+project_name="meeting-notes"
+github_environment="sandbox"
+github_owner="Chronote-gg"
+github_repository="Chronote"
+
+# OAuth / URLs
+ENABLE_OAUTH="true"
+ENABLE_MCP="true"
+API_DOMAIN="api.sandbox.chronote.gg"
+DISCORD_CALLBACK_URL="https://api.sandbox.chronote.gg/auth/discord/callback"
+FRONTEND_DOMAIN="sandbox.chronote.gg"
+DOCS_DOMAIN="docs-sandbox.chronote.gg"
+DOCS_SITE_URL="https://docs-sandbox.chronote.gg"
+HOSTED_ZONE_NAME="chronote.gg."
+FRONTEND_ALLOWED_ORIGINS="https://sandbox.chronote.gg"
+FRONTEND_SITE_URL="https://sandbox.chronote.gg"
+NOTION_CLIENT_ID=""
+NOTION_REDIRECT_URI="https://api.sandbox.chronote.gg/api/notion/callback"
+
+# Stripe (sandbox uses test mode)
+STRIPE_MODE="test"
+STRIPE_SUCCESS_URL="https://sandbox.chronote.gg/upgrade/success"
+STRIPE_CANCEL_URL="https://sandbox.chronote.gg/upgrade/select-server?canceled=true"
+STRIPE_PORTAL_RETURN_URL="https://sandbox.chronote.gg/portal/select-server"
+BILLING_LANDING_URL="https://sandbox.chronote.gg/upgrade"
+
+# Optional overrides
+TRANSCRIPTS_PREFIX=""
+BEDROCK_DATA_AUTOMATION_PROFILE_ARN=""
+BEDROCK_DATA_AUTOMATION_PROJECT_ARN=""
+BEDROCK_DATA_AUTOMATION_INPUT_BUCKET=""
+BEDROCK_DATA_AUTOMATION_OUTPUT_BUCKET=""
+BEDROCK_DATA_AUTOMATION_INPUT_PREFIX=""
+BEDROCK_DATA_AUTOMATION_OUTPUT_PREFIX=""
+BEDROCK_DATA_AUTOMATION_POLL_INTERVAL_MS=""
+BEDROCK_DATA_AUTOMATION_TIMEOUT_MS=""
+LANGFUSE_BASE_URL=""
+LANGFUSE_PUBLIC_KEY=""
+LANGFUSE_SECRET_KEY=""
+LANGFUSE_TRACING_ENABLED="true"
+LANGFUSE_TRACING_ENVIRONMENT="sandbox"
+LANGFUSE_RELEASE=""
+LANGFUSE_PROMPT_LABEL="production"
+LANGFUSE_PROMPT_MEETING_SUMMARY="chronote-meeting-summary-chat"
+LANGFUSE_PROMPT_CACHE_TTL_MS="60000"
+DOCS_ALGOLIA_APP_ID=""
+DOCS_ALGOLIA_API_KEY=""
+DOCS_ALGOLIA_INDEX_NAME=""
+REDIS_URL=""
+REDIS_AUTH_TOKEN="change-me-redis-auth-token"
+
+# Alerting
+alert_email=""
+alert_discord_channel_id=""
+
+# Observability
+grafana_api_key=""
+grafana_url=""
+grafana_service_account_id=""
+grafana_token_rotation_days=25

--- a/_infra/terraform.staging.tfvars.example
+++ b/_infra/terraform.staging.tfvars.example
@@ -6,6 +6,8 @@ AWS_TOKEN_KEY="your-aws-token-key"
 environment="staging"
 project_name="meeting-notes"
 github_environment="staging"
+github_owner="Chronote-gg"
+github_repository="Chronote"
 
 # OAuth / URLs
 ENABLE_OAUTH="true"

--- a/_infra/terraform.tfvars.example
+++ b/_infra/terraform.tfvars.example
@@ -2,9 +2,11 @@
 DISCORD_CLIENT_ID="your-discord-client-id-here"
 GITHUB_TOKEN="your-github-token-here"
 AWS_TOKEN_KEY="your-aws-token-key-here"
-environment="prod"                           # prod | staging
+environment="prod"                           # prod | sandbox | staging
 project_name="meeting-notes"
-github_environment="sandbox"                 # GitHub Actions environment name
+github_environment="production"              # GitHub Actions environment name
+github_owner="Chronote-gg"
+github_repository="Chronote"
 
 # Optional (leave blank to use defaults)
 ENABLE_OAUTH="false"                          # defaults false


### PR DESCRIPTION
[AGENT]

## Summary

- Moves production deploy jobs from the misnamed `sandbox` GitHub environment to a real `production` environment.
- Converts the manual staging deploy workflow into the real sandbox deploy workflow, with a preflight that rejects production-looking targets.
- Updates Terraform plan/apply workflows so `production` pairs with workspace `default` and `sandbox` pairs with workspace `sandbox`.
- Makes Terraform's GitHub target configurable and defaults it to `Chronote-gg/Chronote`.
- Adds `_infra/terraform.sandbox.tfvars.example` and updates infra/agent docs.

## GitHub Environment Configuration Already Done

- Created `production` environment.
- Copied current production deploy variables from the old `sandbox` environment into `production`.
- Set `production` secrets: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `TERRAFORM_TFVARS_JSON`.
- Set `sandbox` Terraform secrets: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `TERRAFORM_TFVARS_JSON`.
- Left existing `sandbox` deploy variables unchanged for now, because `master` still uses `sandbox` until this PR is merged.

## Validation

- `npx prettier --check .github/workflows/deploy.yml .github/workflows/deploy-staging.yml .github/workflows/terraform-plan.yml .github/workflows/terraform-apply.yml AGENTS.md .github/copilot-instructions.md _infra/README.md`
- `terraform fmt -check _infra/main.tf`
- `terraform -chdir=_infra validate -no-color` (valid, with existing DynamoDB deprecation warnings)
- `git diff --check`
- `yarn markdownlint:check`

Note: `yarn install --frozen-lockfile` in the fresh worktree failed while building `@discordjs/opus` on Windows/Node 24 after dependencies were linked. `yarn markdownlint:check` still ran successfully afterward.

## Follow-Up After Merge

- Run the production deploy from `master` once through the `production` environment if desired.
- Then run Terraform Plan for `sandbox` + workspace `sandbox`.
- Review and apply the sandbox plan.
- After sandbox apply writes non-prod deploy vars into the `sandbox` environment, the sandbox deploy workflow can be dispatched safely.