### PR TITLE
[AGENT] Fix Start meeting app action targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Discord bot that records voice meetings, transcribes them with OpenAI, generat
 
 ## Commands
 
-- `/startmeeting`: Begin recording the meeting (audio + chat logs). You can also right-click Chronote and choose **Apps** -> **Start meeting**.
+- `/startmeeting`: Begin recording the meeting (audio + chat logs). You can also right-click yourself, Chronote, or someone in your voice channel and choose **Apps** -> **Start meeting**.
 - `/autorecord`: Configure auto-recording for a server/channel.
 - `/context`: Manage prompt context.
 - `/dictionary`: Manage dictionary terms used in prompts.

--- a/apps/docs-site/docs/core-concepts/meeting-lifecycle.md
+++ b/apps/docs-site/docs/core-concepts/meeting-lifecycle.md
@@ -9,7 +9,7 @@ Every Chronote recording follows a predictable lifecycle. Understanding these st
 
 A meeting starts in three ways:
 
-- **Manual**: A user runs `/startmeeting` while in a voice channel, or right-clicks Chronote and selects **Apps** -> **Start meeting**. The slash command can optionally include a `context` description and `tags`.
+- **Manual**: A user runs `/startmeeting` while in a voice channel, or right-clicks themselves, Chronote, or someone in their voice channel and selects **Apps** -> **Start meeting**. The slash command can optionally include a `context` description and `tags`.
 - **Auto-record**: A user joins a voice channel that has auto-recording enabled. Chronote starts recording automatically and posts an "Auto-Recording Started" embed.
 - **Personal upload**: A user uploads an existing audio or video file from the web portal. Chronote creates a personal meeting owned by that user.
 

--- a/apps/docs-site/docs/features/feature-overview.md
+++ b/apps/docs-site/docs/features/feature-overview.md
@@ -9,7 +9,7 @@ This page is a reference for every Chronote command and feature. Each section de
 
 ### `/startmeeting`
 
-Starts a recorded meeting in the voice channel you are currently in. You can also right-click Chronote and select **Apps** -> **Start meeting** to start without context or tags.
+Starts a recorded meeting in the voice channel you are currently in. You can also right-click yourself, Chronote, or someone in your voice channel and select **Apps** -> **Start meeting** to start without context or tags.
 
 | Option    | Required | Description                                |
 | --------- | -------- | ------------------------------------------ |

--- a/apps/docs-site/docs/getting-started/overview.md
+++ b/apps/docs-site/docs/getting-started/overview.md
@@ -33,7 +33,7 @@ The onboarding wizard requires **Manage Server** permission. You can skip it and
 ## Step 3: Start your first meeting
 
 1. Join a voice channel.
-2. Run `/startmeeting` in a text channel, or right-click Chronote and select **Apps** -> **Start meeting**.
+2. Run `/startmeeting` in a text channel, or right-click yourself, Chronote, or someone in your voice channel and select **Apps** -> **Start meeting**.
 3. If you use `/startmeeting`, optionally add a `context` parameter (e.g., "Weekly standup for backend team") and `tags` (e.g., "standup, backend").
 
 Chronote joins the voice channel and begins recording. You will see a "Meeting Started" embed with an **End Meeting** button.

--- a/src/commands/startMeeting.ts
+++ b/src/commands/startMeeting.ts
@@ -55,6 +55,7 @@ import {
   startMeetingLeaseHeartbeat,
   tryAcquireMeetingLease,
 } from "../services/activeMeetingLeaseService";
+import { fetchGuildMember } from "../utils/guildMembers";
 
 type GuildLimits = Awaited<ReturnType<typeof getGuildLimits>>["limits"];
 
@@ -63,6 +64,7 @@ type StartMeetingInteraction =
   | UserContextMenuCommandInteraction;
 
 type StartMeetingOptions = {
+  deferredEphemeralReply?: boolean;
   ephemeralErrors?: boolean;
 };
 
@@ -238,6 +240,11 @@ const replyStartMeetingError = async (
   content: string,
   options?: StartMeetingOptions,
 ) => {
+  if (options?.deferredEphemeralReply) {
+    await interaction.editReply(content);
+    return;
+  }
+
   if (!options?.ephemeralErrors) {
     await interaction.reply(content);
     return;
@@ -298,20 +305,6 @@ const ensureBotCanSend = (
   }
   return null;
 };
-
-async function resolveInteractionMember(
-  guild: NonNullable<StartMeetingInteraction["guild"]>,
-  userId: string,
-): Promise<GuildMember | null> {
-  const cached = guild.members.cache.get(userId);
-  if (cached) return cached;
-
-  try {
-    return await guild.members.fetch(userId);
-  } catch {
-    return null;
-  }
-}
 
 const ensureNoActiveMeeting = async (guildId: string) => {
   if (hasMeeting(guildId)) {
@@ -542,7 +535,7 @@ export async function handleRequestStartMeeting(
     return;
   }
 
-  const member = await resolveInteractionMember(guild, interaction.user.id);
+  const member = await fetchGuildMember(guild, interaction.user.id);
   if (!member) {
     await replyStartMeetingError(
       interaction,
@@ -570,6 +563,14 @@ export async function handleRequestStartMeeting(
   });
   if (!startResult.ok) {
     if (startResult.upgradePrompt) {
+      if (options?.deferredEphemeralReply) {
+        const upgradePrompt = buildUpgradePrompt(startResult.error);
+        await interaction.editReply({
+          components: upgradePrompt.components,
+          content: upgradePrompt.content,
+        });
+        return;
+      }
       await interaction.reply(buildUpgradePrompt(startResult.error));
       return;
     }
@@ -578,6 +579,17 @@ export async function handleRequestStartMeeting(
   }
 
   const { meeting, liveMeetingUrl } = startResult;
+
+  if (options?.deferredEphemeralReply) {
+    const message = await textChannel.send(
+      buildManualMeetingStartedMessage(meeting, liveMeetingUrl),
+    );
+    meeting.startMessageId = message.id;
+    await interaction.editReply(
+      `Meeting started in **${meeting.voiceChannel.name}**.`,
+    );
+    return;
+  }
 
   const reply = await interaction.reply({
     ...buildManualMeetingStartedMessage(meeting, liveMeetingUrl),

--- a/src/commands/startMeeting.ts
+++ b/src/commands/startMeeting.ts
@@ -299,6 +299,20 @@ const ensureBotCanSend = (
   return null;
 };
 
+async function resolveInteractionMember(
+  guild: NonNullable<StartMeetingInteraction["guild"]>,
+  userId: string,
+): Promise<GuildMember | null> {
+  const cached = guild.members.cache.get(userId);
+  if (cached) return cached;
+
+  try {
+    return await guild.members.fetch(userId);
+  } catch {
+    return null;
+  }
+}
+
 const ensureNoActiveMeeting = async (guildId: string) => {
   if (hasMeeting(guildId)) {
     const meeting = getMeeting(guildId);
@@ -528,9 +542,15 @@ export async function handleRequestStartMeeting(
     return;
   }
 
-  const untypedMember = interaction.member;
-  if (!untypedMember || !interaction.guild) return;
-  const member = untypedMember as GuildMember;
+  const member = await resolveInteractionMember(guild, interaction.user.id);
+  if (!member) {
+    await replyStartMeetingError(
+      interaction,
+      "Unable to find your server member profile.",
+      options,
+    );
+    return;
+  }
   const voiceResult = resolveMemberVoiceChannel(member);
   if (!voiceResult.ok) {
     await replyStartMeetingError(interaction, voiceResult.error, options);

--- a/src/commands/startMeetingContextMenu.ts
+++ b/src/commands/startMeetingContextMenu.ts
@@ -2,6 +2,8 @@ import {
   ApplicationCommandType,
   ContextMenuCommandBuilder,
   type Client,
+  type Guild,
+  type GuildMember,
   type UserContextMenuCommandInteraction,
 } from "discord.js";
 import { handleRequestStartMeeting } from "./startMeeting";
@@ -12,6 +14,119 @@ export const startMeetingContextCommand = new ContextMenuCommandBuilder()
   .setName(START_MEETING_CONTEXT_COMMAND_NAME)
   .setType(ApplicationCommandType.User)
   .setDMPermission(false);
+
+type TargetVoiceValidation =
+  | { ok: true }
+  | {
+      ok: false;
+      reason: string;
+      message: string;
+      invokerVoiceChannelId?: string | null;
+      targetVoiceChannelId?: string | null;
+    };
+
+const START_MEETING_CONTEXT_DM_ACK =
+  "I sent you a DM with why Start meeting did not run.";
+
+async function fetchGuildMember(
+  guild: Guild,
+  userId: string,
+): Promise<GuildMember | null> {
+  const cached = guild.members.cache.get(userId);
+  if (cached) return cached;
+
+  try {
+    return await guild.members.fetch(userId);
+  } catch {
+    return null;
+  }
+}
+
+async function validateTargetVoiceChannel(
+  interaction: UserContextMenuCommandInteraction,
+  botUserId: string,
+): Promise<TargetVoiceValidation> {
+  const guild = interaction.guild;
+  if (!guild) {
+    return {
+      ok: false,
+      reason: "missing-guild",
+      message: "Start meeting can only be used in a server.",
+    };
+  }
+
+  const invokerMember = await fetchGuildMember(guild, interaction.user.id);
+  const invokerVoiceChannelId = invokerMember?.voice.channelId ?? null;
+  if (!invokerVoiceChannelId) {
+    return {
+      ok: false,
+      reason: "invoker-not-in-voice",
+      message:
+        "Join a voice channel, then use Start meeting on yourself, Chronote, or someone in that voice channel.",
+      invokerVoiceChannelId,
+    };
+  }
+
+  const targetUserId = interaction.targetUser.id;
+  if (targetUserId === botUserId || targetUserId === interaction.user.id) {
+    return { ok: true };
+  }
+
+  const targetMember = await fetchGuildMember(guild, targetUserId);
+  const targetVoiceChannelId = targetMember?.voice.channelId ?? null;
+  if (!targetVoiceChannelId) {
+    return {
+      ok: false,
+      reason: "target-not-in-voice",
+      message:
+        "I did not start a meeting because the selected user is not in a voice channel. Use Start meeting on yourself, Chronote, or someone in your current voice channel.",
+      invokerVoiceChannelId,
+      targetVoiceChannelId,
+    };
+  }
+
+  if (targetVoiceChannelId !== invokerVoiceChannelId) {
+    return {
+      ok: false,
+      reason: "target-in-different-voice",
+      message:
+        "I did not start a meeting because the selected user is in a different voice channel. Use Start meeting on yourself, Chronote, or someone in your current voice channel.",
+      invokerVoiceChannelId,
+      targetVoiceChannelId,
+    };
+  }
+
+  return { ok: true };
+}
+
+async function replyWithDmError(
+  interaction: UserContextMenuCommandInteraction,
+  validation: Exclude<TargetVoiceValidation, { ok: true }>,
+) {
+  console.log("Start meeting context menu blocked", {
+    guildId: interaction.guildId,
+    reason: validation.reason,
+    invokerVoiceChannelId: validation.invokerVoiceChannelId,
+    targetVoiceChannelId: validation.targetVoiceChannelId,
+  });
+
+  let dmSent = true;
+  try {
+    await interaction.user.send(validation.message);
+  } catch (error) {
+    dmSent = false;
+    console.warn("Failed to DM Start meeting context menu error", {
+      guildId: interaction.guildId,
+      reason: validation.reason,
+      error,
+    });
+  }
+
+  await interaction.reply({
+    content: dmSent ? START_MEETING_CONTEXT_DM_ACK : validation.message,
+    ephemeral: true,
+  });
+}
 
 export async function handleStartMeetingContextCommand(
   client: Client,
@@ -26,11 +141,9 @@ export async function handleStartMeetingContextCommand(
     return;
   }
 
-  if (interaction.targetUser.id !== botUserId) {
-    await interaction.reply({
-      content: `Right-click <@${botUserId}> to start a meeting.`,
-      ephemeral: true,
-    });
+  const validation = await validateTargetVoiceChannel(interaction, botUserId);
+  if (!validation.ok) {
+    await replyWithDmError(interaction, validation);
     return;
   }
 

--- a/src/commands/startMeetingContextMenu.ts
+++ b/src/commands/startMeetingContextMenu.ts
@@ -2,10 +2,9 @@ import {
   ApplicationCommandType,
   ContextMenuCommandBuilder,
   type Client,
-  type Guild,
-  type GuildMember,
   type UserContextMenuCommandInteraction,
 } from "discord.js";
+import { fetchGuildMember } from "../utils/guildMembers";
 import { handleRequestStartMeeting } from "./startMeeting";
 
 export const START_MEETING_CONTEXT_COMMAND_NAME = "Start meeting";
@@ -27,20 +26,6 @@ type TargetVoiceValidation =
 
 const START_MEETING_CONTEXT_DM_ACK =
   "I sent you a DM with why Start meeting did not run.";
-
-async function fetchGuildMember(
-  guild: Guild,
-  userId: string,
-): Promise<GuildMember | null> {
-  const cached = guild.members.cache.get(userId);
-  if (cached) return cached;
-
-  try {
-    return await guild.members.fetch(userId);
-  } catch {
-    return null;
-  }
-}
 
 async function validateTargetVoiceChannel(
   interaction: UserContextMenuCommandInteraction,
@@ -122,9 +107,8 @@ async function replyWithDmError(
     });
   }
 
-  await interaction.reply({
+  await interaction.editReply({
     content: dmSent ? START_MEETING_CONTEXT_DM_ACK : validation.message,
-    ephemeral: true,
   });
 }
 
@@ -141,11 +125,16 @@ export async function handleStartMeetingContextCommand(
     return;
   }
 
+  await interaction.deferReply({ ephemeral: true });
+
   const validation = await validateTargetVoiceChannel(interaction, botUserId);
   if (!validation.ok) {
     await replyWithDmError(interaction, validation);
     return;
   }
 
-  await handleRequestStartMeeting(interaction, { ephemeralErrors: true });
+  await handleRequestStartMeeting(interaction, {
+    deferredEphemeralReply: true,
+    ephemeralErrors: true,
+  });
 }

--- a/src/utils/guildMembers.ts
+++ b/src/utils/guildMembers.ts
@@ -1,0 +1,15 @@
+import type { Guild, GuildMember } from "discord.js";
+
+export async function fetchGuildMember(
+  guild: Guild,
+  userId: string,
+): Promise<GuildMember | null> {
+  const cached = guild.members.cache.get(userId);
+  if (cached) return cached;
+
+  try {
+    return await guild.members.fetch(userId);
+  } catch {
+    return null;
+  }
+}

--- a/test/commands/startMeetingContextMenu.test.ts
+++ b/test/commands/startMeetingContextMenu.test.ts
@@ -16,19 +16,71 @@ const mockedHandleRequestStartMeeting =
     typeof handleRequestStartMeeting
   >;
 
+type MockGuildMember = {
+  voice: { channelId: string | null };
+};
+
+type MockInteraction = UserContextMenuCommandInteraction & {
+  reply: jest.Mock;
+  user: { id: string; send: jest.Mock };
+};
+
 const makeClient = (botId: string | null = "bot-1"): Client =>
   ({ user: botId ? { id: botId } : null }) as Client;
 
-const makeInteraction = (targetUserId = "bot-1") =>
+const makeMember = (voiceChannelId: string | null): MockGuildMember => ({
+  voice: { channelId: voiceChannelId },
+});
+
+const makeGuild = (members: Record<string, MockGuildMember>) => {
+  const cache = new Map(Object.entries(members));
+  return {
+    id: "guild-1",
+    members: {
+      cache,
+      fetch: jest.fn(async (userId: string) => {
+        const member = cache.get(userId);
+        if (!member) throw new Error("Member not found");
+        return member;
+      }),
+    },
+  };
+};
+
+const makeInteraction = (
+  targetUserId = "bot-1",
+  userId = "user-1",
+  members: Record<string, MockGuildMember> = {
+    "user-1": makeMember("voice-1"),
+    "bot-1": makeMember(null),
+  },
+) =>
   ({
+    guildId: "guild-1",
+    guild: makeGuild(members),
+    user: { id: userId, send: jest.fn().mockResolvedValue(undefined) },
     targetUser: { id: targetUserId },
     reply: jest.fn().mockResolvedValue(undefined),
-  }) as unknown as UserContextMenuCommandInteraction;
+  }) as unknown as MockInteraction;
 
 describe("start meeting context menu", () => {
+  let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
+  let consoleWarnSpy: jest.SpiedFunction<typeof console.warn>;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    consoleLogSpy = jest
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
+    consoleWarnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
     mockedHandleRequestStartMeeting.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
   });
 
   it("registers a guild-only user context menu command", () => {
@@ -52,14 +104,102 @@ describe("start meeting context menu", () => {
     expect(interaction.reply).not.toHaveBeenCalled();
   });
 
-  it("blocks invocations on users other than Chronote", async () => {
-    const interaction = makeInteraction("user-1");
+  it("starts a meeting when invoked on yourself", async () => {
+    const interaction = makeInteraction("user-1", "user-1");
+
+    await handleStartMeetingContextCommand(makeClient("bot-1"), interaction);
+
+    expect(mockedHandleRequestStartMeeting).toHaveBeenCalledWith(interaction, {
+      ephemeralErrors: true,
+    });
+    expect(interaction.reply).not.toHaveBeenCalled();
+  });
+
+  it("starts a meeting when invoked on someone in the same voice channel", async () => {
+    const interaction = makeInteraction("user-2", "user-1", {
+      "user-1": makeMember("voice-1"),
+      "user-2": makeMember("voice-1"),
+      "bot-1": makeMember(null),
+    });
+
+    await handleStartMeetingContextCommand(makeClient("bot-1"), interaction);
+
+    expect(mockedHandleRequestStartMeeting).toHaveBeenCalledWith(interaction, {
+      ephemeralErrors: true,
+    });
+    expect(interaction.reply).not.toHaveBeenCalled();
+  });
+
+  it("DMs when invoked on someone in a different voice channel", async () => {
+    const interaction = makeInteraction("user-2", "user-1", {
+      "user-1": makeMember("voice-1"),
+      "user-2": makeMember("voice-2"),
+      "bot-1": makeMember(null),
+    });
+
+    await handleStartMeetingContextCommand(makeClient("bot-1"), interaction);
+
+    expect(mockedHandleRequestStartMeeting).not.toHaveBeenCalled();
+    expect(interaction.user.send).toHaveBeenCalledWith(
+      "I did not start a meeting because the selected user is in a different voice channel. Use Start meeting on yourself, Chronote, or someone in your current voice channel.",
+    );
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: "I sent you a DM with why Start meeting did not run.",
+      ephemeral: true,
+    });
+  });
+
+  it("DMs when invoked on someone outside voice", async () => {
+    const interaction = makeInteraction("user-2", "user-1", {
+      "user-1": makeMember("voice-1"),
+      "user-2": makeMember(null),
+      "bot-1": makeMember(null),
+    });
+
+    await handleStartMeetingContextCommand(makeClient("bot-1"), interaction);
+
+    expect(mockedHandleRequestStartMeeting).not.toHaveBeenCalled();
+    expect(interaction.user.send).toHaveBeenCalledWith(
+      "I did not start a meeting because the selected user is not in a voice channel. Use Start meeting on yourself, Chronote, or someone in your current voice channel.",
+    );
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: "I sent you a DM with why Start meeting did not run.",
+      ephemeral: true,
+    });
+  });
+
+  it("falls back to an ephemeral reply when the DM fails", async () => {
+    const interaction = makeInteraction("user-2", "user-1", {
+      "user-1": makeMember("voice-1"),
+      "user-2": makeMember("voice-2"),
+      "bot-1": makeMember(null),
+    });
+    interaction.user.send.mockRejectedValue(new Error("DM disabled"));
 
     await handleStartMeetingContextCommand(makeClient("bot-1"), interaction);
 
     expect(mockedHandleRequestStartMeeting).not.toHaveBeenCalled();
     expect(interaction.reply).toHaveBeenCalledWith({
-      content: "Right-click <@bot-1> to start a meeting.",
+      content:
+        "I did not start a meeting because the selected user is in a different voice channel. Use Start meeting on yourself, Chronote, or someone in your current voice channel.",
+      ephemeral: true,
+    });
+  });
+
+  it("DMs when the invoker is not in a voice channel", async () => {
+    const interaction = makeInteraction("bot-1", "user-1", {
+      "user-1": makeMember(null),
+      "bot-1": makeMember(null),
+    });
+
+    await handleStartMeetingContextCommand(makeClient("bot-1"), interaction);
+
+    expect(mockedHandleRequestStartMeeting).not.toHaveBeenCalled();
+    expect(interaction.user.send).toHaveBeenCalledWith(
+      "Join a voice channel, then use Start meeting on yourself, Chronote, or someone in that voice channel.",
+    );
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: "I sent you a DM with why Start meeting did not run.",
       ephemeral: true,
     });
   });

--- a/test/commands/startMeetingContextMenu.test.ts
+++ b/test/commands/startMeetingContextMenu.test.ts
@@ -21,6 +21,8 @@ type MockGuildMember = {
 };
 
 type MockInteraction = UserContextMenuCommandInteraction & {
+  deferReply: jest.Mock;
+  editReply: jest.Mock;
   reply: jest.Mock;
   user: { id: string; send: jest.Mock };
 };
@@ -60,8 +62,15 @@ const makeInteraction = (
     guild: makeGuild(members),
     user: { id: userId, send: jest.fn().mockResolvedValue(undefined) },
     targetUser: { id: targetUserId },
+    deferReply: jest.fn().mockResolvedValue(undefined),
+    editReply: jest.fn().mockResolvedValue(undefined),
     reply: jest.fn().mockResolvedValue(undefined),
   }) as unknown as MockInteraction;
+
+const expectedStartOptions = {
+  deferredEphemeralReply: true,
+  ephemeralErrors: true,
+};
 
 describe("start meeting context menu", () => {
   let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
@@ -98,9 +107,11 @@ describe("start meeting context menu", () => {
 
     await handleStartMeetingContextCommand(makeClient("bot-1"), interaction);
 
-    expect(mockedHandleRequestStartMeeting).toHaveBeenCalledWith(interaction, {
-      ephemeralErrors: true,
-    });
+    expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(mockedHandleRequestStartMeeting).toHaveBeenCalledWith(
+      interaction,
+      expectedStartOptions,
+    );
     expect(interaction.reply).not.toHaveBeenCalled();
   });
 
@@ -109,9 +120,11 @@ describe("start meeting context menu", () => {
 
     await handleStartMeetingContextCommand(makeClient("bot-1"), interaction);
 
-    expect(mockedHandleRequestStartMeeting).toHaveBeenCalledWith(interaction, {
-      ephemeralErrors: true,
-    });
+    expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(mockedHandleRequestStartMeeting).toHaveBeenCalledWith(
+      interaction,
+      expectedStartOptions,
+    );
     expect(interaction.reply).not.toHaveBeenCalled();
   });
 
@@ -124,9 +137,11 @@ describe("start meeting context menu", () => {
 
     await handleStartMeetingContextCommand(makeClient("bot-1"), interaction);
 
-    expect(mockedHandleRequestStartMeeting).toHaveBeenCalledWith(interaction, {
-      ephemeralErrors: true,
-    });
+    expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(mockedHandleRequestStartMeeting).toHaveBeenCalledWith(
+      interaction,
+      expectedStartOptions,
+    );
     expect(interaction.reply).not.toHaveBeenCalled();
   });
 
@@ -143,10 +158,11 @@ describe("start meeting context menu", () => {
     expect(interaction.user.send).toHaveBeenCalledWith(
       "I did not start a meeting because the selected user is in a different voice channel. Use Start meeting on yourself, Chronote, or someone in your current voice channel.",
     );
-    expect(interaction.reply).toHaveBeenCalledWith({
+    expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(interaction.editReply).toHaveBeenCalledWith({
       content: "I sent you a DM with why Start meeting did not run.",
-      ephemeral: true,
     });
+    expect(interaction.reply).not.toHaveBeenCalled();
   });
 
   it("DMs when invoked on someone outside voice", async () => {
@@ -162,10 +178,11 @@ describe("start meeting context menu", () => {
     expect(interaction.user.send).toHaveBeenCalledWith(
       "I did not start a meeting because the selected user is not in a voice channel. Use Start meeting on yourself, Chronote, or someone in your current voice channel.",
     );
-    expect(interaction.reply).toHaveBeenCalledWith({
+    expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(interaction.editReply).toHaveBeenCalledWith({
       content: "I sent you a DM with why Start meeting did not run.",
-      ephemeral: true,
     });
+    expect(interaction.reply).not.toHaveBeenCalled();
   });
 
   it("falls back to an ephemeral reply when the DM fails", async () => {
@@ -179,11 +196,12 @@ describe("start meeting context menu", () => {
     await handleStartMeetingContextCommand(makeClient("bot-1"), interaction);
 
     expect(mockedHandleRequestStartMeeting).not.toHaveBeenCalled();
-    expect(interaction.reply).toHaveBeenCalledWith({
+    expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(interaction.editReply).toHaveBeenCalledWith({
       content:
         "I did not start a meeting because the selected user is in a different voice channel. Use Start meeting on yourself, Chronote, or someone in your current voice channel.",
-      ephemeral: true,
     });
+    expect(interaction.reply).not.toHaveBeenCalled();
   });
 
   it("DMs when the invoker is not in a voice channel", async () => {
@@ -198,10 +216,11 @@ describe("start meeting context menu", () => {
     expect(interaction.user.send).toHaveBeenCalledWith(
       "Join a voice channel, then use Start meeting on yourself, Chronote, or someone in that voice channel.",
     );
-    expect(interaction.reply).toHaveBeenCalledWith({
+    expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(interaction.editReply).toHaveBeenCalledWith({
       content: "I sent you a DM with why Start meeting did not run.",
-      ephemeral: true,
     });
+    expect(interaction.reply).not.toHaveBeenCalled();
   });
 
   it("blocks while the bot user is unavailable", async () => {
@@ -210,6 +229,7 @@ describe("start meeting context menu", () => {
     await handleStartMeetingContextCommand(makeClient(null), interaction);
 
     expect(mockedHandleRequestStartMeeting).not.toHaveBeenCalled();
+    expect(interaction.deferReply).not.toHaveBeenCalled();
     expect(interaction.reply).toHaveBeenCalledWith({
       content: "The bot is still starting up. Try again in a moment.",
       ephemeral: true,


### PR DESCRIPTION
[AGENT]

## Summary
- Allow the Discord user context menu Start meeting action when invoked on yourself, Chronote, or another user in your current voice channel.
- DM the invoking user when the selected target is outside their voice channel or not in voice, with an ephemeral fallback if DMs fail.
- Remove a silent no-reply path in manual meeting startup by resolving the invoking guild member from cache/fetch.
- Update README and public docs for the expanded app-action behavior.

## Tests
- `yarn test --coverage=false test/commands/startMeetingContextMenu.test.ts`
- `yarn lint:check`
- `yarn build`
- `yarn docs:check`
- `npx prettier --check README.md apps/docs-site/docs/core-concepts/meeting-lifecycle.md apps/docs-site/docs/features/feature-overview.md apps/docs-site/docs/getting-started/overview.md src/commands/startMeeting.ts src/commands/startMeetingContextMenu.ts test/commands/startMeetingContextMenu.test.ts`