### PR TITLE
[AGENT] Fix desktop release signing path

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 concurrency:
   group: desktop-release-${{ inputs.tag }}
@@ -22,6 +23,7 @@ concurrency:
 
 env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+  DESKTOP_SIGNING_ENABLED: ${{ vars.DESKTOP_SIGNING_ENABLED || 'false' }}
 
 jobs:
   release-windows:
@@ -57,9 +59,77 @@ jobs:
       - name: Install desktop dependencies
         run: yarn desktop:install
 
+      - name: Validate signing configuration
+        if: env.DESKTOP_SIGNING_ENABLED == 'true'
+        shell: pwsh
+        env:
+          AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          AZURE_ARTIFACT_SIGNING_ENDPOINT: ${{ vars.AZURE_ARTIFACT_SIGNING_ENDPOINT }}
+          AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME: ${{ vars.AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME }}
+          AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME: ${{ vars.AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME }}
+        run: |
+          $required = @(
+            "AZURE_CLIENT_ID",
+            "AZURE_TENANT_ID",
+            "AZURE_SUBSCRIPTION_ID",
+            "AZURE_ARTIFACT_SIGNING_ENDPOINT",
+            "AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME",
+            "AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME"
+          )
+
+          $missing = $required | Where-Object { [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($_)) }
+          if ($missing.Count -gt 0) {
+            throw "Desktop signing is enabled, but required environment variables are missing: $($missing -join ', ')"
+          }
+
+      - name: Azure login for Artifact Signing
+        if: env.DESKTOP_SIGNING_ENABLED == 'true'
+        uses: azure/login@v3
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Install Azure Artifact Signing CLI
+        if: env.DESKTOP_SIGNING_ENABLED == 'true'
+        run: cargo install artifact-signing-cli --locked
+
+      - name: Write Tauri signing config
+        if: env.DESKTOP_SIGNING_ENABLED == 'true'
+        shell: pwsh
+        env:
+          AZURE_ARTIFACT_SIGNING_CLI: ${{ vars.AZURE_ARTIFACT_SIGNING_CLI || 'artifact-signing-cli' }}
+          AZURE_ARTIFACT_SIGNING_ENDPOINT: ${{ vars.AZURE_ARTIFACT_SIGNING_ENDPOINT }}
+          AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME: ${{ vars.AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME }}
+          AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME: ${{ vars.AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME }}
+        run: |
+          $signCommand = "$env:AZURE_ARTIFACT_SIGNING_CLI -e `"$env:AZURE_ARTIFACT_SIGNING_ENDPOINT`" -a `"$env:AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME`" -c `"$env:AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME`" %1"
+          $config = @{
+            bundle = @{
+              windows = @{
+                signCommand = $signCommand
+              }
+            }
+          }
+
+          $config | ConvertTo-Json -Depth 5 | Set-Content -Path apps/desktop/src-tauri/tauri.signing.conf.json -Encoding utf8
+
+      - name: Resolve desktop release build args
+        id: release-args
+        shell: pwsh
+        run: |
+          $buildArgs = "--ci --no-sign"
+          if ($env:DESKTOP_SIGNING_ENABLED -eq "true") {
+            $buildArgs = "--ci --config src-tauri/tauri.signing.conf.json"
+          }
+
+          "args=$buildArgs" >> $env:GITHUB_OUTPUT
+
       - name: Build and upload desktop release artifacts
         id: tauri-release
-        uses: tauri-apps/tauri-action@v1
+        uses: tauri-apps/tauri-action@v0.6.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -71,11 +141,42 @@ jobs:
 
             Draft Chronote Desktop Windows release artifacts.
 
-            These artifacts are unsigned for beta validation. Do not publish as stable until Windows Authenticode signing is configured and verified.
+            Keep unsigned beta artifacts in draft/prerelease status. Do not publish as stable unless Windows Authenticode signing is enabled and verified.
           releaseDraft: true
           prerelease: ${{ inputs.prerelease }}
-          args: --ci --no-sign
-          uploadUpdaterJson: false
+          args: ${{ steps.release-args.outputs.args }}
+          includeUpdaterJson: false
+
+      - name: Verify signed Windows artifacts
+        if: env.DESKTOP_SIGNING_ENABLED == 'true'
+        shell: pwsh
+        run: |
+          $releasePath = "apps/desktop/src-tauri/target/release"
+          $bundlePath = "apps/desktop/src-tauri/target/release/bundle"
+          $artifacts = @()
+
+          if (Test-Path $releasePath) {
+            $artifacts += Get-ChildItem -Path $releasePath -File -Filter *.exe
+          }
+
+          if (Test-Path $bundlePath) {
+            $artifacts += Get-ChildItem -Path $bundlePath -Recurse -File -Include *.exe,*.msi
+          }
+
+          if ($artifacts.Count -eq 0) {
+            throw "No Windows artifacts were found under $releasePath."
+          }
+
+          foreach ($artifact in $artifacts) {
+            $signature = Get-AuthenticodeSignature -FilePath $artifact.FullName
+            if ($signature.Status -ne "Valid") {
+              throw "Invalid Authenticode signature for $($artifact.FullName): $($signature.Status)"
+            }
+
+            if ($null -eq $signature.TimeStamperCertificate) {
+              throw "Missing Authenticode timestamp for $($artifact.FullName)."
+            }
+          }
 
       - name: Validate desktop artifacts
         run: yarn desktop:artifacts --write --checksum-paths=basename

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -15,7 +15,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 concurrency:
   group: desktop-release-${{ inputs.tag }}
@@ -30,6 +29,9 @@ jobs:
     name: Build Draft Windows Desktop Release
     runs-on: windows-latest
     environment: desktop-release
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -92,60 +92,23 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Install Azure Artifact Signing CLI
+      - name: Build desktop release artifacts
+        run: yarn desktop:package
+
+      - name: Sign Windows artifacts
         if: env.DESKTOP_SIGNING_ENABLED == 'true'
-        run: cargo install artifact-signing-cli --locked
-
-      - name: Write Tauri signing config
-        if: env.DESKTOP_SIGNING_ENABLED == 'true'
-        shell: pwsh
-        env:
-          AZURE_ARTIFACT_SIGNING_CLI: ${{ vars.AZURE_ARTIFACT_SIGNING_CLI || 'artifact-signing-cli' }}
-          AZURE_ARTIFACT_SIGNING_ENDPOINT: ${{ vars.AZURE_ARTIFACT_SIGNING_ENDPOINT }}
-          AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME: ${{ vars.AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME }}
-          AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME: ${{ vars.AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME }}
-        run: |
-          $signCommand = "$env:AZURE_ARTIFACT_SIGNING_CLI -e `"$env:AZURE_ARTIFACT_SIGNING_ENDPOINT`" -a `"$env:AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME`" -c `"$env:AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME`" %1"
-          $config = @{
-            bundle = @{
-              windows = @{
-                signCommand = $signCommand
-              }
-            }
-          }
-
-          $config | ConvertTo-Json -Depth 5 | Set-Content -Path apps/desktop/src-tauri/tauri.signing.conf.json -Encoding utf8
-
-      - name: Resolve desktop release build args
-        id: release-args
-        shell: pwsh
-        run: |
-          $buildArgs = "--ci --no-sign"
-          if ($env:DESKTOP_SIGNING_ENABLED -eq "true") {
-            $buildArgs = "--ci --config src-tauri/tauri.signing.conf.json"
-          }
-
-          "args=$buildArgs" >> $env:GITHUB_OUTPUT
-
-      - name: Build and upload desktop release artifacts
-        id: tauri-release
-        uses: tauri-apps/tauri-action@v0.6.2
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+        uses: azure/artifact-signing-action@v2
         with:
-          projectPath: apps/desktop
-          tagName: ${{ inputs.tag }}
-          releaseName: Chronote Desktop ${{ inputs.tag }}
-          releaseBody: |
-            [AGENT]
-
-            Draft Chronote Desktop Windows release artifacts.
-
-            Keep unsigned beta artifacts in draft/prerelease status. Do not publish as stable unless Windows Authenticode signing is enabled and verified.
-          releaseDraft: true
-          prerelease: ${{ inputs.prerelease }}
-          args: ${{ steps.release-args.outputs.args }}
-          includeUpdaterJson: false
+          endpoint: ${{ vars.AZURE_ARTIFACT_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ vars.AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ vars.AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME }}
+          files-folder: ${{ github.workspace }}\apps\desktop\src-tauri\target\release
+          files-folder-filter: exe,msi
+          files-folder-recurse: true
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+          description: Chronote Desktop
 
       - name: Verify signed Windows artifacts
         if: env.DESKTOP_SIGNING_ENABLED == 'true'
@@ -187,8 +150,67 @@ jobs:
           name: chronote-desktop-checksums
           path: apps/desktop/src-tauri/target/release/bundle/SHA256SUMS.txt
 
-      - name: Upload checksums to draft release
+      - name: Create draft release
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.tag }}
-        run: gh release upload "$env:RELEASE_TAG" apps/desktop/src-tauri/target/release/bundle/SHA256SUMS.txt --clobber
+          PRERELEASE: ${{ inputs.prerelease }}
+        shell: pwsh
+        run: |
+          $notesPath = Join-Path $env:RUNNER_TEMP "desktop-release-notes.md"
+          $notes = @(
+            "[AGENT]",
+            "",
+            "Draft Chronote Desktop Windows release artifacts.",
+            "",
+            "Keep unsigned beta artifacts in draft/prerelease status. Do not publish as stable unless Windows Authenticode signing is enabled and verified."
+          )
+          Set-Content -Path $notesPath -Value $notes -Encoding utf8
+
+          gh release view "$env:RELEASE_TAG" --repo "$env:GITHUB_REPOSITORY" *> $null
+          if ($LASTEXITCODE -ne 0) {
+            $createArgs = @(
+              "release",
+              "create",
+              $env:RELEASE_TAG,
+              "--repo",
+              $env:GITHUB_REPOSITORY,
+              "--target",
+              $env:GITHUB_SHA,
+              "--draft",
+              "--title",
+              "Chronote Desktop $env:RELEASE_TAG",
+              "--notes-file",
+              $notesPath
+            )
+
+            if ($env:PRERELEASE -eq "true") {
+              $createArgs += "--prerelease"
+            }
+
+            & gh @createArgs
+          }
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        shell: pwsh
+        run: |
+          $bundlePath = "apps/desktop/src-tauri/target/release/bundle"
+          $assetExtensions = @(".exe", ".msi", ".json", ".sig")
+          $assetPaths = Get-ChildItem -Path $bundlePath -Recurse -File |
+            Where-Object { $assetExtensions -contains $_.Extension.ToLowerInvariant() } |
+            ForEach-Object { $_.FullName }
+
+          $checksumPath = Join-Path $bundlePath "SHA256SUMS.txt"
+          if (Test-Path $checksumPath) {
+            $assetPaths += $checksumPath
+          }
+
+          if ($assetPaths.Count -eq 0) {
+            throw "No desktop release assets found under $bundlePath."
+          }
+
+          $uploadArgs = @("release", "upload", $env:RELEASE_TAG) + $assetPaths + @("--clobber", "--repo", $env:GITHUB_REPOSITORY)
+          & gh @uploadArgs

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -159,6 +159,8 @@ jobs:
         env:
           TERRAFORM_TFVARS_JSON: ${{ secrets.TERRAFORM_TFVARS_JSON }}
           REDIS_AUTH_TOKEN: ${{ secrets.REDIS_AUTH_TOKEN }}
+          ENABLE_DESKTOP_API: ${{ vars.ENABLE_DESKTOP_API }}
+          DESKTOP_ALLOWED_USER_IDS: ${{ vars.DESKTOP_ALLOWED_USER_IDS }}
         run: |
           set -euo pipefail
 
@@ -185,8 +187,16 @@ jobs:
           if redis_auth_token:
               data["REDIS_AUTH_TOKEN"] = redis_auth_token
 
+          for name in ["ENABLE_DESKTOP_API", "DESKTOP_ALLOWED_USER_IDS"]:
+              value = os.environ.get(name, "").strip()
+              if value:
+                  data[name] = value
+
           required = ["GITHUB_TOKEN", "AWS_TOKEN_KEY", "DISCORD_CLIENT_ID"]
           string_fields = required + [
+              "ENABLE_DESKTOP_API",
+              "DESKTOP_ALLOWED_USER_IDS",
+              "SUPER_ADMIN_USER_IDS",
               "grafana_api_key",
               "grafana_url",
               "grafana_service_account_id",
@@ -233,6 +243,14 @@ jobs:
               raise SystemExit(
                   "grafana_service_account_id is required when grafana_url is configured."
               )
+
+          if data.get("ENABLE_DESKTOP_API", "").strip().lower() == "true":
+              has_allowed_ids = data.get("DESKTOP_ALLOWED_USER_IDS", "").strip()
+              has_super_admin_ids = data.get("SUPER_ADMIN_USER_IDS", "").strip()
+              if not has_allowed_ids and not has_super_admin_ids:
+                  raise SystemExit(
+                      "ENABLE_DESKTOP_API=true requires DESKTOP_ALLOWED_USER_IDS or SUPER_ADMIN_USER_IDS."
+                  )
           PY
 
       - name: Terraform init

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -73,6 +73,8 @@ jobs:
         env:
           TERRAFORM_TFVARS_JSON: ${{ secrets.TERRAFORM_TFVARS_JSON }}
           REDIS_AUTH_TOKEN: ${{ secrets.REDIS_AUTH_TOKEN }}
+          ENABLE_DESKTOP_API: ${{ vars.ENABLE_DESKTOP_API }}
+          DESKTOP_ALLOWED_USER_IDS: ${{ vars.DESKTOP_ALLOWED_USER_IDS }}
         run: |
           set -euo pipefail
 
@@ -99,8 +101,16 @@ jobs:
           if redis_auth_token:
               data["REDIS_AUTH_TOKEN"] = redis_auth_token
 
+          for name in ["ENABLE_DESKTOP_API", "DESKTOP_ALLOWED_USER_IDS"]:
+              value = os.environ.get(name, "").strip()
+              if value:
+                  data[name] = value
+
           required = ["GITHUB_TOKEN", "AWS_TOKEN_KEY", "DISCORD_CLIENT_ID"]
           string_fields = required + [
+              "ENABLE_DESKTOP_API",
+              "DESKTOP_ALLOWED_USER_IDS",
+              "SUPER_ADMIN_USER_IDS",
               "grafana_api_key",
               "grafana_url",
               "grafana_service_account_id",
@@ -147,6 +157,14 @@ jobs:
               raise SystemExit(
                   "grafana_service_account_id is required when grafana_url is configured."
               )
+
+          if data.get("ENABLE_DESKTOP_API", "").strip().lower() == "true":
+              has_allowed_ids = data.get("DESKTOP_ALLOWED_USER_IDS", "").strip()
+              has_super_admin_ids = data.get("SUPER_ADMIN_USER_IDS", "").strip()
+              if not has_allowed_ids and not has_super_admin_ids:
+                  raise SystemExit(
+                      "ENABLE_DESKTOP_API=true requires DESKTOP_ALLOWED_USER_IDS or SUPER_ADMIN_USER_IDS."
+                  )
           PY
 
       - name: Terraform init

--- a/docs/desktop-productization.md
+++ b/docs/desktop-productization.md
@@ -35,9 +35,34 @@ The smoke build uses two Rust features that must not be enabled for production r
 
 `.github/workflows/desktop-release.yml` is manually dispatched with a tag such as `desktop-v0.1.0-beta.1`.
 
-It creates a draft GitHub Release and uploads unsigned Windows artifacts plus `SHA256SUMS.txt`.
+It creates a draft GitHub Release and uploads Windows artifacts plus `SHA256SUMS.txt`.
 
-The workflow uses the protected `desktop-release` GitHub environment. Add signing secrets to that environment once Authenticode and updater-signing custody are decided.
+By default the workflow builds unsigned beta artifacts with `--no-sign`. Set `DESKTOP_SIGNING_ENABLED=true` in the protected `desktop-release` GitHub environment only after Azure Artifact Signing and signature verification are ready.
+
+Required `desktop-release` environment variables for signed builds:
+
+- `AZURE_CLIENT_ID`
+- `AZURE_TENANT_ID`
+- `AZURE_SUBSCRIPTION_ID`
+- `AZURE_ARTIFACT_SIGNING_ENDPOINT`
+- `AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME`
+- `AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME`
+- `DESKTOP_SIGNING_ENABLED=true`
+
+Optional override:
+
+- `AZURE_ARTIFACT_SIGNING_CLI`: defaults to `artifact-signing-cli`.
+
+The signed path uses GitHub OIDC through `azure/login`, installs the Azure Artifact Signing CLI, writes a CI-only Tauri config override with `bundle.windows.signCommand`, and verifies Authenticode signatures before validating checksums. Keep `DESKTOP_SIGNING_ENABLED=false` for unsigned beta drafts.
+
+### Production Desktop API Enablement
+
+Production Terraform plans and applies hydrate most variables from the protected environment's `TERRAFORM_TFVARS_JSON` secret. Desktop canary rollout has dedicated GitHub environment variable overlays so future applies do not silently turn the hosted desktop API off again:
+
+- `ENABLE_DESKTOP_API`: set to `true` for the beta/canary window.
+- `DESKTOP_ALLOWED_USER_IDS`: comma-separated Discord user IDs for beta access.
+
+If `ENABLE_DESKTOP_API=true`, the Terraform workflows fail unless either `DESKTOP_ALLOWED_USER_IDS` or `SUPER_ADMIN_USER_IDS` is configured. This keeps hosted desktop routes gated even when the API is intentionally enabled.
 
 ## Local Commands
 
@@ -73,9 +98,8 @@ Two signing concerns are intentionally separate:
 - Windows Authenticode signing: makes Windows trust the installer/executable publisher.
 - Tauri updater signing: lets installed clients verify update artifacts.
 
-Deferred decisions:
+Remaining deferred decisions:
 
-- Authenticode provider setup timing and Azure account ownership.
 - Tauri updater key custody and rotation.
 - Beta/stable updater endpoint layout.
 
@@ -97,31 +121,53 @@ Recommended GitHub/Tauri integration:
 4. Add environment-scoped signing configuration for the endpoint, signing account name, and certificate profile name.
 5. Use Tauri's `bundle.windows.signCommand` through a CI-only config override so the app executable and installer are signed during bundling, not only after packaging.
 6. Timestamp every Authenticode signature with `http://timestamp.acs.microsoft.com`; Artifact Signing certificates are short-lived, so timestamping is required for signatures to remain valid beyond the certificate validity window.
-7. Remove `--no-sign` from `.github/workflows/desktop-release.yml` only after signed artifact validation is added.
+7. Set `DESKTOP_SIGNING_ENABLED=true` only after the provider setup and timestamped signature validation are verified.
 8. Verify both the installer and installed executable signatures before promoting any stable release.
 
 Stable release blockers:
 
-- Authenticode signing configured in `tauri.conf.json` or via a protected signing command.
+- Authenticode signing enabled through the protected `desktop-release` environment.
 - Signed artifact validation in CI.
 - Updater artifact signing if updater is enabled.
 
-## Manual Hardware Smoke Checklist
+## QA Card: Windows Installer Smoke
 
-Before broad beta or stable release, run on a real Windows machine:
+Purpose: verify the installer lifecycle and real-device recorder path before broad beta or stable release.
 
-1. Install the generated desktop artifact.
-2. Launch Chronote Desktop from the Start menu.
-3. Sign in with a desktop-allowed Chronote account.
-4. Verify microphone and system/output devices are listed.
-5. Record at least 15 seconds with microphone input and system audio playing.
-6. Confirm both source meters move during recording.
-7. Stop and upload.
-8. Open the created meeting during processing.
-9. Confirm the meeting appears in My Meetings.
-10. Confirm transcript/notes contain the expected personal recording labels.
-11. Sign out and relaunch to verify session clearing.
-12. Uninstall and confirm the app is removed.
+Prerequisites:
+
+- A Windows test machine that has not already installed the same Chronote Desktop build, or a machine where the previous build was removed first.
+- A Chronote account listed in `DESKTOP_ALLOWED_USER_IDS` or `SUPER_ADMIN_USER_IDS`.
+- A working microphone and a local audio source, such as a browser tab playing a short test clip.
+- The release MSI or NSIS artifact plus `SHA256SUMS.txt` from the draft GitHub Release.
+
+Smoke steps:
+
+1. Verify the downloaded installer checksum against `SHA256SUMS.txt`.
+2. Install the generated desktop artifact.
+3. Launch Chronote Desktop from the Start menu.
+4. Sign in with the desktop-allowed Chronote account.
+5. Verify microphone and system/output devices are listed.
+6. Record at least 15 seconds with microphone input and system audio playing.
+7. Confirm both source meters move during recording.
+8. Stop and upload.
+9. Open the created meeting during processing.
+10. Confirm the meeting appears in My Meetings.
+11. Confirm transcript/notes contain the expected personal recording labels.
+12. Sign out and relaunch to verify session clearing.
+13. Close the app, uninstall it, and confirm the Start menu entry is removed.
+14. Reboot or sign out/in if Windows keeps stale shortcuts, then confirm Chronote Desktop no longer launches.
+
+Pass criteria:
+
+- Install completes without requiring developer tools or local source checkout.
+- Launch, sign-in, recording, upload, and meeting navigation work against `https://api.chronote.gg` and `https://chronote.gg`.
+- Uninstall removes the app entry and does not leave a launchable stale installation.
+
+Failure capture:
+
+- Record installer filename, checksum status, Windows version, installer type, and whether the artifact was signed.
+- Capture app logs and upload/meeting IDs only in private support or ops notes; do not post tokens or signed upload fields in public issues.
 
 ## Rollback Checklist
 

--- a/docs/desktop-productization.md
+++ b/docs/desktop-productization.md
@@ -49,11 +49,7 @@ Required `desktop-release` environment variables for signed builds:
 - `AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME`
 - `DESKTOP_SIGNING_ENABLED=true`
 
-Optional override:
-
-- `AZURE_ARTIFACT_SIGNING_CLI`: defaults to `artifact-signing-cli`.
-
-The signed path uses GitHub OIDC through `azure/login`, installs the Azure Artifact Signing CLI, writes a CI-only Tauri config override with `bundle.windows.signCommand`, and verifies Authenticode signatures before validating checksums. Keep `DESKTOP_SIGNING_ENABLED=false` for unsigned beta drafts.
+The signed path uses GitHub OIDC through `azure/login`, signs built `.exe` and `.msi` files with `azure/artifact-signing-action`, and verifies Authenticode signatures before validating checksums or uploading release assets. Keep `DESKTOP_SIGNING_ENABLED=false` for unsigned beta drafts.
 
 ### Production Desktop API Enablement
 
@@ -113,13 +109,13 @@ Recommended Authenticode provider:
 - Identity validation is the slow path. Microsoft documents 1 to 20 business days, possibly longer if more documents are requested.
 - Prefer Artifact Signing over a checked-in or CI-stored PFX because certificate lifecycle and keys stay in Microsoft's managed HSM-backed service.
 
-Recommended GitHub/Tauri integration:
+Recommended GitHub packaging integration:
 
 1. Create an Artifact Signing account, complete public identity validation for the publisher entity, and create a Public Trust certificate profile.
 2. Grant only the release workflow identity the `Artifact Signing Certificate Profile Signer` role.
 3. Prefer GitHub OIDC through `azure/login` instead of a long-lived `AZURE_CLIENT_SECRET` when configuring the protected `desktop-release` environment.
 4. Add environment-scoped signing configuration for the endpoint, signing account name, and certificate profile name.
-5. Use Tauri's `bundle.windows.signCommand` through a CI-only config override so the app executable and installer are signed during bundling, not only after packaging.
+5. Use Azure's Artifact Signing GitHub Action after Tauri packaging and before release upload so the workflow stays on OIDC instead of long-lived client secrets.
 6. Timestamp every Authenticode signature with `http://timestamp.acs.microsoft.com`; Artifact Signing certificates are short-lived, so timestamping is required for signatures to remain valid beyond the certificate validity window.
 7. Set `DESKTOP_SIGNING_ENABLED=true` only after the provider setup and timestamped signature validation are verified.
 8. Verify both the installer and installed executable signatures before promoting any stable release.


### PR DESCRIPTION
[AGENT]

Fixes the desktop release follow-up after the first manual beta dispatch failed before build.

What changed:
- Builds desktop release artifacts directly with the repo's desktop package command, avoiding the invalid Tauri action reference.
- Keeps unsigned beta drafts as the default, then creates/uploads release assets after checksum generation.
- Adds a gated Azure Artifact Signing path using GitHub OIDC and `azure/artifact-signing-action@v2`, with signature and timestamp validation for future signed releases.
- Adds Terraform environment-variable overlays and a guard for durable hosted desktop API canary enablement.
- Documents signing setup and the Windows installer smoke QA card.

Validation:
- `git diff --check`
- `yarn prettier:check`
- `actionlint .github/workflows/desktop-release.yml .github/workflows/terraform-plan.yml .github/workflows/terraform-apply.yml`

Rollout note:
- Keep `DESKTOP_SIGNING_ENABLED=false` for unsigned beta drafts. After merge, rerun the desktop release dispatch for `desktop-v0.1.0-beta.1`.