### PR TITLE
[AGENT] Retain recording artifacts on upload failure

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -33,6 +33,9 @@ const LOGIN_TIMEOUT_SECONDS: u64 = 300;
 const DESKTOP_SCOPES: &str = "profile:read personal_uploads:write meetings:read";
 const RECORDING_SOURCE_SIGNAL_EVENT: &str = "recording-source-signal";
 const WAV_HEADER_BYTES: u64 = 44;
+const RETAINED_RECORDING_MANIFEST_FILE: &str = "recording.json";
+const RETAINED_RECORDING_MANIFEST_VERSION: u32 = 1;
+const RETAINED_RECORDING_STATUS_FAILED_UPLOAD: &str = "failed_upload";
 
 #[derive(Default)]
 struct AppState {
@@ -196,6 +199,47 @@ struct RecordingCompleteSourceRequest {
 #[serde(rename_all = "camelCase")]
 struct UploadJobResponse {
     job: UploadJob,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RetainedRecordingSource {
+    source_id: String,
+    kind: String,
+    label: String,
+    content_type: String,
+    file_name: String,
+    file_size: u64,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RetainedRecordingManifest {
+    version: u32,
+    recording_id: String,
+    started_at: String,
+    stopped_at: String,
+    retained_at: String,
+    title: Option<String>,
+    tags: Vec<String>,
+    status: String,
+    error_message: Option<String>,
+    sources: Vec<RetainedRecordingSource>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RetainedRecording {
+    recording_id: String,
+    started_at: String,
+    stopped_at: String,
+    retained_at: String,
+    title: Option<String>,
+    tags: Vec<String>,
+    status: String,
+    error_message: Option<String>,
+    local_path: String,
+    sources: Vec<RetainedRecordingSource>,
 }
 
 #[derive(Deserialize)]
@@ -368,12 +412,15 @@ async fn stop_and_upload_recording(
     state: State<'_, AppState>,
 ) -> Result<UploadResult, String> {
     let api_base_url = normalize_api_base_url(&api_base_url)?;
+    let title = normalize_optional_title(title);
+    let tags = normalize_tags(tags);
     let active = {
         let mut recording = state.recording.lock().map_err(lock_error)?;
         recording
             .take()
             .ok_or_else(|| "No recording is in progress.".to_string())?
     };
+    let started_at = active.started_at.clone();
     let sources = stop_recording_sources(active)?;
     let cleanup_dir = sources
         .first()
@@ -390,17 +437,146 @@ async fn stop_and_upload_recording(
             &access_token,
             &client,
             intent,
-            title.filter(|value| !value.trim().is_empty()),
-            tags,
+            title.clone(),
+            tags.clone(),
         )
         .await
     }
     .await;
-    if let Some(cleanup_dir) = cleanup_dir {
-        let _ = fs::remove_dir_all(cleanup_dir);
+    match upload_result {
+        Ok(job) => {
+            if let Some(cleanup_dir) = cleanup_dir {
+                let _ = fs::remove_dir_all(cleanup_dir);
+            }
+            Ok(UploadResult { job })
+        }
+        Err(error) => {
+            if let Some(cleanup_dir) = cleanup_dir {
+                if let Err(manifest_error) = write_retained_recording_manifest(
+                    &cleanup_dir,
+                    &started_at,
+                    &sources,
+                    title,
+                    tags,
+                    &error,
+                ) {
+                    return Err(format!(
+                        "{error} Recording files were retained, but Chronote could not write recovery metadata: {manifest_error}"
+                    ));
+                }
+            }
+            Err(format!("{error} Recording saved locally for retry."))
+        }
     }
-    let job = upload_result?;
-    Ok(UploadResult { job })
+}
+
+#[tauri::command]
+fn list_retained_recordings() -> Result<Vec<RetainedRecording>, String> {
+    let base = recording_base_directory()?;
+    if !base.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut recordings = Vec::new();
+    let entries = fs::read_dir(base).map_err(|error| error.to_string())?;
+    for entry in entries {
+        let entry = entry.map_err(|error| error.to_string())?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let manifest_path = retained_manifest_path(&path);
+        if !manifest_path.exists() {
+            continue;
+        }
+        let manifest = match read_retained_recording_manifest(&path) {
+            Ok(manifest) => manifest,
+            Err(error) => {
+                eprintln!(
+                    "Skipping unreadable retained recording manifest {}: {}",
+                    manifest_path.display(),
+                    error
+                );
+                continue;
+            }
+        };
+        recordings.push(RetainedRecording {
+            recording_id: manifest.recording_id,
+            started_at: manifest.started_at,
+            stopped_at: manifest.stopped_at,
+            retained_at: manifest.retained_at,
+            title: manifest.title,
+            tags: manifest.tags,
+            status: manifest.status,
+            error_message: manifest.error_message,
+            local_path: path.display().to_string(),
+            sources: manifest.sources,
+        });
+    }
+    recordings.sort_by(|a, b| b.retained_at.cmp(&a.retained_at));
+    Ok(recordings)
+}
+
+#[tauri::command]
+async fn retry_retained_recording(
+    api_base_url: String,
+    recording_id: String,
+    state: State<'_, AppState>,
+) -> Result<UploadResult, String> {
+    let api_base_url = normalize_api_base_url(&api_base_url)?;
+    let directory = retained_recording_directory(&recording_id)?;
+    let mut manifest = read_retained_recording_manifest(&directory)?;
+    let sources = captured_sources_from_retained_manifest(&directory, &manifest)?;
+    let client = reqwest::Client::new();
+    let upload_result = async {
+        let access_token = access_token_for(&api_base_url, &state, &client).await?;
+        let intent =
+            create_recording_upload_intent(&api_base_url, &access_token, &client, &sources).await?;
+        upload_sources(&client, &intent, &sources).await?;
+        complete_recording_upload(
+            &api_base_url,
+            &access_token,
+            &client,
+            intent,
+            manifest.title.clone(),
+            manifest.tags.clone(),
+        )
+        .await
+    }
+    .await;
+    match upload_result {
+        Ok(job) => {
+            let _ = fs::remove_dir_all(directory);
+            Ok(UploadResult { job })
+        }
+        Err(error) => {
+            manifest.retained_at = now_iso();
+            manifest.status = RETAINED_RECORDING_STATUS_FAILED_UPLOAD.to_string();
+            manifest.error_message = Some(error.clone());
+            write_retained_recording_manifest_file(&directory, &manifest)?;
+            Err(format!(
+                "{error} Recording is still saved locally for retry."
+            ))
+        }
+    }
+}
+
+#[tauri::command]
+fn open_retained_recording(recording_id: String) -> Result<(), String> {
+    let directory = retained_recording_directory(&recording_id)?;
+    if !directory.exists() {
+        return Err("Retained recording was not found.".to_string());
+    }
+    open::that(directory).map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+fn delete_retained_recording(recording_id: String) -> Result<(), String> {
+    let directory = retained_recording_directory(&recording_id)?;
+    if !directory.exists() {
+        return Ok(());
+    }
+    fs::remove_dir_all(directory).map_err(|error| error.to_string())
 }
 
 #[tauri::command]
@@ -465,6 +641,10 @@ fn main() {
             get_recording_status,
             start_recording,
             stop_and_upload_recording,
+            list_retained_recordings,
+            retry_retained_recording,
+            open_retained_recording,
+            delete_retained_recording,
             get_upload_status,
             open_external_url,
             start_window_drag,
@@ -1048,10 +1228,7 @@ fn normalize_api_base_url(value: &str) -> Result<String, String> {
 }
 
 fn recording_directory() -> Result<PathBuf, String> {
-    let base = ProjectDirs::from("gg", "Chronote", "Chronote Desktop")
-        .map(|dirs| dirs.data_local_dir().to_path_buf())
-        .unwrap_or_else(|| std::env::temp_dir().join("chronote-desktop"));
-    Ok(base.join("recordings").join(Uuid::new_v4().to_string()))
+    Ok(recording_base_directory()?.join(Uuid::new_v4().to_string()))
 }
 
 fn source_file_name(path: &Path) -> Result<String, String> {
@@ -1059,6 +1236,142 @@ fn source_file_name(path: &Path) -> Result<String, String> {
         .and_then(|name| name.to_str())
         .map(ToString::to_string)
         .ok_or_else(|| "Recording file name could not be resolved.".to_string())
+}
+
+fn normalize_optional_title(title: Option<String>) -> Option<String> {
+    title
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn normalize_tags(tags: Vec<String>) -> Vec<String> {
+    tags.into_iter()
+        .map(|tag| tag.trim().to_string())
+        .filter(|tag| !tag.is_empty())
+        .take(20)
+        .collect()
+}
+
+fn recording_base_directory() -> Result<PathBuf, String> {
+    let base = ProjectDirs::from("gg", "Chronote", "Chronote Desktop")
+        .map(|dirs| dirs.data_local_dir().to_path_buf())
+        .unwrap_or_else(|| std::env::temp_dir().join("chronote-desktop"));
+    Ok(base.join("recordings"))
+}
+
+fn retained_recording_directory(recording_id: &str) -> Result<PathBuf, String> {
+    let recording_uuid =
+        Uuid::parse_str(recording_id).map_err(|_| "Invalid retained recording ID.".to_string())?;
+    Ok(recording_base_directory()?.join(recording_uuid.to_string()))
+}
+
+fn retained_manifest_path(directory: &Path) -> PathBuf {
+    directory.join(RETAINED_RECORDING_MANIFEST_FILE)
+}
+
+fn recording_id_from_directory(directory: &Path) -> Result<String, String> {
+    directory
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(ToString::to_string)
+        .ok_or_else(|| "Recording directory name could not be resolved.".to_string())
+}
+
+fn retained_source_from_captured_source(
+    source: &CapturedSourceFile,
+) -> Result<RetainedRecordingSource, String> {
+    Ok(RetainedRecordingSource {
+        source_id: source.source_id.clone(),
+        kind: source.kind.clone(),
+        label: source.label.clone(),
+        content_type: "audio/wav".to_string(),
+        file_name: source_file_name(&source.path)?,
+        file_size: source.file_size,
+    })
+}
+
+fn write_retained_recording_manifest(
+    directory: &Path,
+    started_at: &str,
+    sources: &[CapturedSourceFile],
+    title: Option<String>,
+    tags: Vec<String>,
+    error_message: &str,
+) -> Result<(), String> {
+    let now = now_iso();
+    let manifest = RetainedRecordingManifest {
+        version: RETAINED_RECORDING_MANIFEST_VERSION,
+        recording_id: recording_id_from_directory(directory)?,
+        started_at: started_at.to_string(),
+        stopped_at: now.clone(),
+        retained_at: now,
+        title,
+        tags,
+        status: RETAINED_RECORDING_STATUS_FAILED_UPLOAD.to_string(),
+        error_message: Some(error_message.to_string()),
+        sources: sources
+            .iter()
+            .map(retained_source_from_captured_source)
+            .collect::<Result<Vec<_>, _>>()?,
+    };
+    write_retained_recording_manifest_file(directory, &manifest)
+}
+
+fn write_retained_recording_manifest_file(
+    directory: &Path,
+    manifest: &RetainedRecordingManifest,
+) -> Result<(), String> {
+    fs::create_dir_all(directory).map_err(|error| error.to_string())?;
+    let body = serde_json::to_string_pretty(manifest).map_err(|error| error.to_string())?;
+    fs::write(retained_manifest_path(directory), body).map_err(|error| error.to_string())
+}
+
+fn read_retained_recording_manifest(directory: &Path) -> Result<RetainedRecordingManifest, String> {
+    let body =
+        fs::read_to_string(retained_manifest_path(directory)).map_err(|error| error.to_string())?;
+    let manifest: RetainedRecordingManifest =
+        serde_json::from_str(&body).map_err(|error| error.to_string())?;
+    if manifest.version != RETAINED_RECORDING_MANIFEST_VERSION {
+        return Err("Retained recording manifest version is unsupported.".to_string());
+    }
+    Ok(manifest)
+}
+
+fn retained_source_path(directory: &Path, file_name: &str) -> Result<PathBuf, String> {
+    let relative_path = Path::new(file_name);
+    if relative_path.components().count() != 1
+        || relative_path.file_name().and_then(|name| name.to_str()) != Some(file_name)
+    {
+        return Err("Retained recording source file name is invalid.".to_string());
+    }
+    Ok(directory.join(relative_path))
+}
+
+fn captured_sources_from_retained_manifest(
+    directory: &Path,
+    manifest: &RetainedRecordingManifest,
+) -> Result<Vec<CapturedSourceFile>, String> {
+    manifest
+        .sources
+        .iter()
+        .map(|source| {
+            let path = retained_source_path(directory, &source.file_name)?;
+            let metadata = fs::metadata(&path).map_err(|error| error.to_string())?;
+            if metadata.len() <= WAV_HEADER_BYTES {
+                return Err(format!(
+                    "Retained recording source {} was empty.",
+                    source.source_id
+                ));
+            }
+            Ok(CapturedSourceFile {
+                source_id: source.source_id.clone(),
+                kind: source.kind.clone(),
+                label: source.label.clone(),
+                path,
+                file_size: metadata.len(),
+            })
+        })
+        .collect()
 }
 
 fn random_url_token(byte_count: usize) -> String {
@@ -1084,4 +1397,86 @@ fn now_epoch_seconds() -> u64 {
 
 fn lock_error<T>(error: std::sync::PoisonError<T>) -> String {
     error.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retained_manifest_keeps_source_files_available_for_retry() {
+        let directory = std::env::temp_dir().join(format!(
+            "chronote-retained-recording-test-{}",
+            Uuid::new_v4()
+        ));
+        fs::create_dir_all(&directory).unwrap();
+        let source_path = directory.join("owner_mic.wav");
+        fs::write(&source_path, vec![0_u8; (WAV_HEADER_BYTES + 8) as usize]).unwrap();
+        let source = CapturedSourceFile {
+            source_id: "owner_mic".to_string(),
+            kind: "owner_mic".to_string(),
+            label: "Me".to_string(),
+            path: source_path.clone(),
+            file_size: WAV_HEADER_BYTES + 8,
+        };
+
+        write_retained_recording_manifest(
+            &directory,
+            "2026-06-15T00:00:00.000Z",
+            &[source],
+            Some("Planning".to_string()),
+            vec!["research".to_string()],
+            "upload failed",
+        )
+        .unwrap();
+
+        let manifest = read_retained_recording_manifest(&directory).unwrap();
+        let retry_sources = captured_sources_from_retained_manifest(&directory, &manifest).unwrap();
+
+        assert!(source_path.exists());
+        assert_eq!(manifest.status, RETAINED_RECORDING_STATUS_FAILED_UPLOAD);
+        assert_eq!(manifest.error_message.as_deref(), Some("upload failed"));
+        assert_eq!(retry_sources.len(), 1);
+        assert_eq!(retry_sources[0].source_id, "owner_mic");
+        assert_eq!(retry_sources[0].file_size, WAV_HEADER_BYTES + 8);
+
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn retained_manifest_rejects_nested_source_file_names() {
+        let directory = std::env::temp_dir().join(format!(
+            "chronote-retained-recording-test-{}",
+            Uuid::new_v4()
+        ));
+        fs::create_dir_all(&directory).unwrap();
+        let manifest = RetainedRecordingManifest {
+            version: RETAINED_RECORDING_MANIFEST_VERSION,
+            recording_id: "recording-1".to_string(),
+            started_at: "2026-06-15T00:00:00.000Z".to_string(),
+            stopped_at: "2026-06-15T00:01:00.000Z".to_string(),
+            retained_at: "2026-06-15T00:01:00.000Z".to_string(),
+            title: None,
+            tags: Vec::new(),
+            status: RETAINED_RECORDING_STATUS_FAILED_UPLOAD.to_string(),
+            error_message: None,
+            sources: vec![RetainedRecordingSource {
+                source_id: "owner_mic".to_string(),
+                kind: "owner_mic".to_string(),
+                label: "Me".to_string(),
+                content_type: "audio/wav".to_string(),
+                file_name: "../secret.wav".to_string(),
+                file_size: WAV_HEADER_BYTES + 8,
+            }],
+        };
+
+        let error = match captured_sources_from_retained_manifest(&directory, &manifest) {
+            Ok(_) => panic!("nested source file name should be rejected"),
+            Err(error) => error,
+        };
+
+        assert!(error.contains("file name is invalid"));
+
+        fs::remove_dir_all(directory).unwrap();
+    }
 }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -36,6 +36,7 @@ const WAV_HEADER_BYTES: u64 = 44;
 const RETAINED_RECORDING_MANIFEST_FILE: &str = "recording.json";
 const RETAINED_RECORDING_MANIFEST_VERSION: u32 = 1;
 const RETAINED_RECORDING_STATUS_FAILED_UPLOAD: &str = "failed_upload";
+const RETAINED_RECORDING_STATUS_UPLOADED_CLEANUP_FAILED: &str = "uploaded_cleanup_failed";
 
 #[derive(Default)]
 struct AppState {
@@ -526,6 +527,12 @@ async fn retry_retained_recording(
     let api_base_url = normalize_api_base_url(&api_base_url)?;
     let directory = retained_recording_directory(&recording_id)?;
     let mut manifest = read_retained_recording_manifest(&directory)?;
+    if manifest.status != RETAINED_RECORDING_STATUS_FAILED_UPLOAD {
+        return Err(
+            "This saved recording is no longer retryable. Open the folder or delete it."
+                .to_string(),
+        );
+    }
     let sources = captured_sources_from_retained_manifest(&directory, &manifest)?;
     let client = reqwest::Client::new();
     let upload_result = async {
@@ -546,7 +553,16 @@ async fn retry_retained_recording(
     .await;
     match upload_result {
         Ok(job) => {
-            let _ = fs::remove_dir_all(directory);
+            if let Err(error) = fs::remove_dir_all(&directory) {
+                let message = format!(
+                    "Upload completed, but Chronote could not delete local saved recording files: {error}"
+                );
+                manifest.retained_at = now_iso();
+                manifest.status = RETAINED_RECORDING_STATUS_UPLOADED_CLEANUP_FAILED.to_string();
+                manifest.error_message = Some(message.clone());
+                write_retained_recording_manifest_file(&directory, &manifest)?;
+                return Err(format!("{message}. Open the folder or delete it manually."));
+            }
             Ok(UploadResult { job })
         }
         Err(error) => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -730,6 +730,7 @@ export default function App() {
                       retainedAction?.recordingId === retained.recordingId
                         ? retainedAction.action
                         : null;
+                    const retryable = retained.status === "failed_upload";
                     return (
                       <article
                         className="retained-recording-card"
@@ -759,11 +760,18 @@ export default function App() {
                             onClick={() =>
                               void retryRetainedRecording(retained.recordingId)
                             }
-                            disabled={busy || recording.isRecording}
+                            disabled={
+                              busy ||
+                              recording.isRecording ||
+                              runningAction !== null ||
+                              !retryable
+                            }
                           >
                             {runningAction === "retry"
                               ? "Retrying..."
-                              : "Retry upload"}
+                              : retryable
+                                ? "Retry upload"
+                                : "Not retryable"}
                           </button>
                           <button
                             type="button"

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -71,6 +71,11 @@ type RetainedRecording = {
   sources: RetainedRecordingSource[];
 };
 
+type RetainedRecordingAction = {
+  recordingId: string;
+  action: "retry" | "open" | "delete";
+};
+
 const DEFAULT_API_BASE_URL =
   import.meta.env.VITE_DESKTOP_API_BASE_URL ||
   (import.meta.env.DEV ? "http://127.0.0.1:3001" : "https://api.chronote.gg");
@@ -216,7 +221,8 @@ export default function App() {
   const [retainedRecordings, setRetainedRecordings] = useState<
     RetainedRecording[]
   >([]);
-  const [retainedActionId, setRetainedActionId] = useState<string | null>(null);
+  const [retainedAction, setRetainedAction] =
+    useState<RetainedRecordingAction | null>(null);
   const [completeMissingLinkStartedAt, setCompleteMissingLinkStartedAt] =
     useState<number | null>(null);
   const [busy, setBusy] = useState(false);
@@ -465,7 +471,7 @@ export default function App() {
 
   async function retryRetainedRecording(recordingId: string) {
     setBusy(true);
-    setRetainedActionId(recordingId);
+    setRetainedAction({ recordingId, action: "retry" });
     setError(null);
     setMessage("Retrying saved recording upload...");
     try {
@@ -485,20 +491,20 @@ export default function App() {
       );
       await refreshRetainedRecordings();
     } finally {
-      setRetainedActionId(null);
+      setRetainedAction(null);
       setBusy(false);
     }
   }
 
   async function openRetainedRecording(recordingId: string) {
-    setRetainedActionId(recordingId);
+    setRetainedAction({ recordingId, action: "open" });
     setError(null);
     try {
       await invoke("open_retained_recording", { recordingId });
     } catch (err) {
       setError(formatError(err, "Failed to open saved recording folder."));
     } finally {
-      setRetainedActionId(null);
+      setRetainedAction(null);
     }
   }
 
@@ -506,7 +512,7 @@ export default function App() {
     if (!window.confirm("Delete this saved recording from this computer?")) {
       return;
     }
-    setRetainedActionId(recordingId);
+    setRetainedAction({ recordingId, action: "delete" });
     setError(null);
     try {
       await invoke("delete_retained_recording", { recordingId });
@@ -515,7 +521,7 @@ export default function App() {
     } catch (err) {
       setError(formatError(err, "Failed to delete saved recording."));
     } finally {
-      setRetainedActionId(null);
+      setRetainedAction(null);
     }
   }
 
@@ -720,8 +726,10 @@ export default function App() {
                     delete them.
                   </p>
                   {retainedRecordings.map((retained) => {
-                    const actionRunning =
-                      retainedActionId === retained.recordingId;
+                    const runningAction =
+                      retainedAction?.recordingId === retained.recordingId
+                        ? retainedAction.action
+                        : null;
                     return (
                       <article
                         className="retained-recording-card"
@@ -753,7 +761,9 @@ export default function App() {
                             }
                             disabled={busy || recording.isRecording}
                           >
-                            {actionRunning ? "Working..." : "Retry upload"}
+                            {runningAction === "retry"
+                              ? "Retrying..."
+                              : "Retry upload"}
                           </button>
                           <button
                             type="button"
@@ -761,9 +771,11 @@ export default function App() {
                             onClick={() =>
                               void openRetainedRecording(retained.recordingId)
                             }
-                            disabled={actionRunning}
+                            disabled={runningAction !== null}
                           >
-                            Open folder
+                            {runningAction === "open"
+                              ? "Opening..."
+                              : "Open folder"}
                           </button>
                           <button
                             type="button"
@@ -771,9 +783,15 @@ export default function App() {
                             onClick={() =>
                               void deleteRetainedRecording(retained.recordingId)
                             }
-                            disabled={busy || recording.isRecording}
+                            disabled={
+                              busy ||
+                              recording.isRecording ||
+                              runningAction !== null
+                            }
                           >
-                            Delete
+                            {runningAction === "delete"
+                              ? "Deleting..."
+                              : "Delete"}
                           </button>
                         </div>
                       </article>

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -49,6 +49,28 @@ type UploadResult = {
   job: UploadJob;
 };
 
+type RetainedRecordingSource = {
+  sourceId: string;
+  kind: string;
+  label: string;
+  contentType: string;
+  fileName: string;
+  fileSize: number;
+};
+
+type RetainedRecording = {
+  recordingId: string;
+  startedAt: string;
+  stoppedAt: string;
+  retainedAt: string;
+  title?: string | null;
+  tags: string[];
+  status: string;
+  errorMessage?: string | null;
+  localPath: string;
+  sources: RetainedRecordingSource[];
+};
+
 const DEFAULT_API_BASE_URL =
   import.meta.env.VITE_DESKTOP_API_BASE_URL ||
   (import.meta.env.DEV ? "http://127.0.0.1:3001" : "https://api.chronote.gg");
@@ -119,6 +141,18 @@ function openPortalUrl(portalBaseUrl: string) {
   return `${portalBaseUrl.replace(/\/$/, "")}/portal/meetings`;
 }
 
+function formatRetainedDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+function formatBytes(bytes: number) {
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${bytes} B`;
+}
+
 function getDeviceLabel(
   devices: AudioDevice[],
   selectedId: string,
@@ -179,6 +213,10 @@ export default function App() {
   const [title, setTitle] = useState("");
   const [tags, setTags] = useState("");
   const [job, setJob] = useState<UploadJob | null>(null);
+  const [retainedRecordings, setRetainedRecordings] = useState<
+    RetainedRecording[]
+  >([]);
+  const [retainedActionId, setRetainedActionId] = useState<string | null>(null);
   const [completeMissingLinkStartedAt, setCompleteMissingLinkStartedAt] =
     useState<number | null>(null);
   const [busy, setBusy] = useState(false);
@@ -248,6 +286,18 @@ export default function App() {
       .then(setRecording)
       .catch(() => undefined);
   }, [apiBaseUrl]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void invoke<RetainedRecording[]>("list_retained_recordings")
+      .then((recordings) => {
+        if (!cancelled) setRetainedRecordings(recordings);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     void invoke<AudioDevice[]>("list_audio_devices")
@@ -374,6 +424,16 @@ export default function App() {
     }
   }
 
+  async function refreshRetainedRecordings() {
+    try {
+      setRetainedRecordings(
+        await invoke<RetainedRecording[]>("list_retained_recordings"),
+      );
+    } catch {
+      // Retained recordings are a recovery affordance; keep the main recorder usable.
+    }
+  }
+
   async function stopAndUpload() {
     setBusy(true);
     setError(null);
@@ -388,9 +448,74 @@ export default function App() {
       setRecording({ isRecording: false });
       setMessage("Upload received.");
     } catch (err) {
-      setError(formatError(err, "Upload failed."));
+      setError(
+        formatError(
+          err,
+          "Upload failed. Your recording was saved locally for retry.",
+        ),
+      );
     } finally {
+      await invoke<RecordingStatus>("get_recording_status")
+        .then(setRecording)
+        .catch(() => undefined);
+      await refreshRetainedRecordings();
       setBusy(false);
+    }
+  }
+
+  async function retryRetainedRecording(recordingId: string) {
+    setBusy(true);
+    setRetainedActionId(recordingId);
+    setError(null);
+    setMessage("Retrying saved recording upload...");
+    try {
+      const result = await invoke<UploadResult>("retry_retained_recording", {
+        apiBaseUrl,
+        recordingId,
+      });
+      setJob(result.job);
+      setMessage("Upload received.");
+      await refreshRetainedRecordings();
+    } catch (err) {
+      setError(
+        formatError(
+          err,
+          "Retry failed. Your recording is still saved locally.",
+        ),
+      );
+      await refreshRetainedRecordings();
+    } finally {
+      setRetainedActionId(null);
+      setBusy(false);
+    }
+  }
+
+  async function openRetainedRecording(recordingId: string) {
+    setRetainedActionId(recordingId);
+    setError(null);
+    try {
+      await invoke("open_retained_recording", { recordingId });
+    } catch (err) {
+      setError(formatError(err, "Failed to open saved recording folder."));
+    } finally {
+      setRetainedActionId(null);
+    }
+  }
+
+  async function deleteRetainedRecording(recordingId: string) {
+    if (!window.confirm("Delete this saved recording from this computer?")) {
+      return;
+    }
+    setRetainedActionId(recordingId);
+    setError(null);
+    try {
+      await invoke("delete_retained_recording", { recordingId });
+      await refreshRetainedRecordings();
+      setMessage("Saved recording deleted.");
+    } catch (err) {
+      setError(formatError(err, "Failed to delete saved recording."));
+    } finally {
+      setRetainedActionId(null);
     }
   }
 
@@ -587,6 +712,75 @@ export default function App() {
                   </a>
                 </>
               )}
+              {retainedRecordings.length > 0 ? (
+                <div className="retained-recordings">
+                  <h3>Saved recordings</h3>
+                  <p>
+                    Uploads that fail stay on this computer until you retry or
+                    delete them.
+                  </p>
+                  {retainedRecordings.map((retained) => {
+                    const actionRunning =
+                      retainedActionId === retained.recordingId;
+                    return (
+                      <article
+                        className="retained-recording-card"
+                        key={retained.recordingId}
+                      >
+                        <strong>
+                          {retained.title || "Untitled recording"}
+                        </strong>
+                        <span>
+                          Saved {formatRetainedDate(retained.retainedAt)}
+                        </span>
+                        {retained.errorMessage ? (
+                          <p className="error">{retained.errorMessage}</p>
+                        ) : null}
+                        <p>
+                          {retained.sources
+                            .map(
+                              (source) =>
+                                `${source.label}: ${formatBytes(source.fileSize)}`,
+                            )
+                            .join(" | ")}
+                        </p>
+                        <code>{retained.localPath}</code>
+                        <div className="retained-actions">
+                          <button
+                            type="button"
+                            onClick={() =>
+                              void retryRetainedRecording(retained.recordingId)
+                            }
+                            disabled={busy || recording.isRecording}
+                          >
+                            {actionRunning ? "Working..." : "Retry upload"}
+                          </button>
+                          <button
+                            type="button"
+                            className="secondary-button"
+                            onClick={() =>
+                              void openRetainedRecording(retained.recordingId)
+                            }
+                            disabled={actionRunning}
+                          >
+                            Open folder
+                          </button>
+                          <button
+                            type="button"
+                            className="secondary-button"
+                            onClick={() =>
+                              void deleteRetainedRecording(retained.recordingId)
+                            }
+                            disabled={busy || recording.isRecording}
+                          >
+                            Delete
+                          </button>
+                        </div>
+                      </article>
+                    );
+                  })}
+                </div>
+              ) : null}
             </aside>
           </section>
         </>

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -215,6 +215,11 @@ h2 {
   font-size: 1.15rem;
 }
 
+h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
 .lede {
   margin: 0.45rem 0 0;
   color: #cbd5e1;
@@ -377,6 +382,49 @@ h2 {
   margin-top: 0.7rem;
   color: #7dd3fc;
   font-weight: 800;
+}
+
+.retained-recordings {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.retained-recording-card {
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 0.7rem;
+  background: rgba(15, 23, 42, 0.62);
+}
+
+.retained-recording-card strong {
+  color: #f8fbff;
+}
+
+.retained-recording-card span {
+  color: #93a4bc;
+  font-size: 0.78rem;
+}
+
+.retained-recording-card code {
+  overflow-wrap: anywhere;
+  user-select: text;
+  color: #c4b5fd;
+  font-size: 0.78rem;
+}
+
+.retained-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.retained-actions button {
+  padding: 0.52rem 0.72rem;
 }
 
 @media (max-width: 760px) {

--- a/apps/docs-site/docs/features/feature-overview.md
+++ b/apps/docs-site/docs/features/feature-overview.md
@@ -244,7 +244,7 @@ Chronote Desktop is currently available as a limited beta. Your account must hav
 4. Click **Start recording**.
 5. Click **Stop and upload** when the meeting ends.
 
-Desktop recordings use your Chronote account and do not require a Discord voice channel. Keep the app open until the upload is received. Processing continues in Chronote after the upload completes. Use **Open Chronote** in the desktop app to open **My Meetings** in the web portal.
+Desktop recordings use your Chronote account and do not require a Discord voice channel. Keep the app open until the upload is received. Processing continues in Chronote after the upload completes. If upload fails, Chronote Desktop keeps the local recording available in **Saved recordings** so you can retry the upload, open the local folder, or delete it when you no longer need it. Use **Open Chronote** in the desktop app to open **My Meetings** in the web portal.
 
 ## Context menu commands
 

--- a/src/commands/endMeeting.ts
+++ b/src/commands/endMeeting.ts
@@ -19,7 +19,10 @@ import { MeetingData } from "../types/meeting-data";
 import { saveMeetingHistoryToDatabase } from "./saveMeetingHistory";
 import { updateMeetingStatusService } from "../services/meetingHistoryService";
 import { renderChatEntryLine } from "../utils/chatLog";
-import { uploadMeetingArtifacts } from "../services/uploadService";
+import {
+  uploadMeetingArtifacts,
+  type UploadMeetingArtifactsResult,
+} from "../services/uploadService";
 import { buildUpgradeTextOnly } from "../utils/upgradePrompt";
 import { getGuildLimits } from "../services/subscriptionService";
 import { stopThinkingCueLoop } from "../audio/soundCues";
@@ -54,6 +57,8 @@ import { captionMeetingImages } from "../services/imageCaptionService";
 import {
   cleanupMeetingTempDir,
   ensureMeetingTempDir,
+  getMeetingTempDir,
+  retainMeetingTempDir,
 } from "../services/tempFileService";
 import { releaseMeetingLeaseForMeeting } from "../services/activeMeetingLeaseService";
 import { runTranscriptionFinalPass } from "../services/transcriptionFinalPassService";
@@ -61,6 +66,11 @@ import { runTranscriptionFinalPass } from "../services/transcriptionFinalPassSer
 type EndMeetingFlowOptions = {
   client: Client;
   meeting: MeetingData;
+};
+
+type LocalArtifactRetentionResult = {
+  preserveLocalArtifacts: boolean;
+  retainedTempDir?: string;
 };
 
 const DISMISSED_AUTO_RECORD_COMPLETE_MIN_DURATION_MS = 10 * 60 * 1000;
@@ -102,6 +112,33 @@ function shouldFinalizeDismissedAutoRecording(meeting: MeetingData): boolean {
     (entry) => entry.type === "message",
   ).length;
   return chatMessageCount >= DISMISSED_AUTO_RECORD_COMPLETE_MIN_CHAT_MESSAGES;
+}
+
+function shouldRetainLocalAudioArtifacts(
+  result: UploadMeetingArtifactsResult,
+): boolean {
+  return result.audioUploadExpected && !result.audioS3Key;
+}
+
+async function retainLocalMeetingArtifacts(
+  meeting: MeetingData,
+  reason: string,
+): Promise<LocalArtifactRetentionResult> {
+  const retainedTempDir = await retainMeetingTempDir(meeting, reason);
+  const localPath = retainedTempDir ?? getMeetingTempDir(meeting);
+  console.error(
+    "Meeting audio was not durably uploaded; retained local artifacts",
+    {
+      guildId: meeting.guildId,
+      meetingId: meeting.meetingId,
+      reason,
+      localPath,
+    },
+  );
+  return {
+    preserveLocalArtifacts: true,
+    retainedTempDir,
+  };
 }
 
 export async function handleEndMeetingButton(
@@ -236,6 +273,8 @@ async function runEndMeetingFlow(options: EndMeetingFlowOptions) {
   );
 
   const meetingTempDir = await ensureMeetingTempDir(meeting);
+  let preserveMeetingTempDir = false;
+  let retainedMeetingTempDir: string | undefined;
   try {
     const chatLogFilePath = path.join(meetingTempDir, "chat.txt");
     writeFileSync(
@@ -276,12 +315,18 @@ async function runEndMeetingFlow(options: EndMeetingFlowOptions) {
     }
 
     if (meeting.cancelled) {
-      await runMeetingEndStep(meeting, "auto-record-cancel-flow", () =>
-        handleAutoRecordCancellation(client, meeting, chatLogFilePath),
+      const retention = await runMeetingEndStep(
+        meeting,
+        "auto-record-cancel-flow",
+        () => handleAutoRecordCancellation(client, meeting, chatLogFilePath),
       );
-      await runMeetingEndStep(meeting, "cleanup-speaker-tracks", () =>
-        cleanupSpeakerTracks(meeting),
-      );
+      preserveMeetingTempDir = retention.preserveLocalArtifacts;
+      retainedMeetingTempDir = retention.retainedTempDir;
+      if (!preserveMeetingTempDir) {
+        await runMeetingEndStep(meeting, "cleanup-speaker-tracks", () =>
+          cleanupSpeakerTracks(meeting),
+        );
+      }
       return;
     }
 
@@ -300,12 +345,18 @@ async function runEndMeetingFlow(options: EndMeetingFlowOptions) {
         meeting.cancelled = true;
         meeting.cancellationReason = cancellationDecision.reason;
         meeting.endReason = MEETING_END_REASONS.AUTO_CANCELLED;
-        await runMeetingEndStep(meeting, "auto-record-cancel-flow", () =>
-          handleAutoRecordCancellation(client, meeting, chatLogFilePath),
+        const retention = await runMeetingEndStep(
+          meeting,
+          "auto-record-cancel-flow",
+          () => handleAutoRecordCancellation(client, meeting, chatLogFilePath),
         );
-        await runMeetingEndStep(meeting, "cleanup-speaker-tracks", () =>
-          cleanupSpeakerTracks(meeting),
-        );
+        preserveMeetingTempDir = retention.preserveLocalArtifacts;
+        retainedMeetingTempDir = retention.retainedTempDir;
+        if (!preserveMeetingTempDir) {
+          await runMeetingEndStep(meeting, "cleanup-speaker-tracks", () =>
+            cleanupSpeakerTracks(meeting),
+          );
+        }
         return;
       }
     }
@@ -398,27 +449,41 @@ async function runEndMeetingFlow(options: EndMeetingFlowOptions) {
     }
 
     // Upload artifacts after transcript generation (or audio/chat only)
-    await runMeetingEndStep(meeting, "upload-artifacts", () =>
-      uploadMeetingArtifacts(meeting, {
-        audioFilePath: outputAudioFile,
-        chatFilePath: chatLogFilePath,
-        transcriptText: transcriptForUpload,
-      }),
+    const uploadResult = await runMeetingEndStep(
+      meeting,
+      "upload-artifacts",
+      () =>
+        uploadMeetingArtifacts(meeting, {
+          audioFilePath: outputAudioFile,
+          chatFilePath: chatLogFilePath,
+          transcriptText: transcriptForUpload,
+        }),
     );
+    if (shouldRetainLocalAudioArtifacts(uploadResult)) {
+      const retention = await runMeetingEndStep(
+        meeting,
+        "retain-local-artifacts",
+        () => retainLocalMeetingArtifacts(meeting, "audio_upload_failed"),
+      );
+      preserveMeetingTempDir = retention.preserveLocalArtifacts;
+      retainedMeetingTempDir = retention.retainedTempDir;
+    }
 
     await runMeetingEndStep(meeting, "update-summary-message", () =>
       updateMeetingSummaryMessage(meeting),
     );
 
-    deleteIfExists(chatLogFilePath);
-    deleteIfExists(outputAudioFile);
-    if (outputAudioFile !== combinedAudioFile) {
-      // Only delete the combined file when a separate mixed file was used.
-      deleteIfExists(combinedAudioFile);
+    if (!preserveMeetingTempDir) {
+      deleteIfExists(chatLogFilePath);
+      deleteIfExists(outputAudioFile);
+      if (outputAudioFile !== combinedAudioFile) {
+        // Only delete the combined file when a separate mixed file was used.
+        deleteIfExists(combinedAudioFile);
+      }
+      await runMeetingEndStep(meeting, "cleanup-speaker-tracks", () =>
+        cleanupSpeakerTracks(meeting),
+      );
     }
-    await runMeetingEndStep(meeting, "cleanup-speaker-tracks", () =>
-      cleanupSpeakerTracks(meeting),
-    );
 
     // Save meeting history to database before cleanup
     await runMeetingEndStep(meeting, "save-meeting-history", () =>
@@ -447,7 +512,18 @@ async function runEndMeetingFlow(options: EndMeetingFlowOptions) {
         error,
       });
     }
-    await cleanupMeetingTempDir(meeting);
+    if (preserveMeetingTempDir) {
+      console.warn(
+        "Skipping meeting temp cleanup because local artifacts were retained",
+        {
+          guildId: meeting.guildId,
+          meetingId: meeting.meetingId,
+          localPath: retainedMeetingTempDir ?? meetingTempDir,
+        },
+      );
+    } else {
+      await cleanupMeetingTempDir(meeting);
+    }
   }
 }
 
@@ -482,26 +558,39 @@ async function handleAutoRecordCancellation(
   client: Client,
   meeting: MeetingData,
   chatLogFilePath: string,
-) {
+): Promise<LocalArtifactRetentionResult> {
   meetingsCancelled.inc();
-  await uploadCancelledMeetingArtifacts(client, meeting, chatLogFilePath);
+  const uploadResult = await uploadCancelledMeetingArtifacts(
+    client,
+    meeting,
+    chatLogFilePath,
+  );
+  const retention = shouldRetainLocalAudioArtifacts(uploadResult)
+    ? await retainLocalMeetingArtifacts(
+        meeting,
+        "cancelled_audio_upload_failed",
+      )
+    : { preserveLocalArtifacts: false };
   await updateAutoRecordCancelledMessage(meeting);
   await deleteTrackedMessages(meeting);
-  deleteIfExists(chatLogFilePath);
-  if (meeting.audioData.outputFileName) {
-    deleteIfExists(meeting.audioData.outputFileName);
+  if (!retention.preserveLocalArtifacts) {
+    deleteIfExists(chatLogFilePath);
+    if (meeting.audioData.outputFileName) {
+      deleteIfExists(meeting.audioData.outputFileName);
+    }
   }
   await saveMeetingHistoryToDatabase(meeting);
   meeting.setFinished();
   meeting.finished = true;
   deleteMeeting(meeting.guildId);
+  return retention;
 }
 
 async function uploadCancelledMeetingArtifacts(
   client: Client,
   meeting: MeetingData,
   chatLogFilePath: string,
-) {
+): Promise<UploadMeetingArtifactsResult> {
   let transcriptForUpload: string | undefined;
 
   if (meeting.transcribeMeeting) {
@@ -531,7 +620,7 @@ async function uploadCancelledMeetingArtifacts(
     transcriptForUpload = transcriptions;
   }
 
-  await runMeetingEndStep(meeting, "upload-cancelled-artifacts", () =>
+  return await runMeetingEndStep(meeting, "upload-cancelled-artifacts", () =>
     uploadMeetingArtifacts(meeting, {
       audioFilePath: meeting.audioData.outputFileName,
       chatFilePath: chatLogFilePath,

--- a/src/services/tempFileService.ts
+++ b/src/services/tempFileService.ts
@@ -4,6 +4,10 @@ import type { MeetingData } from "../types/meeting-data";
 import { config } from "./configService";
 
 const BASE_TEMP_DIR = path.resolve(config.paths.meetingTempDir);
+const RETAINED_TEMP_DIR = path.join(
+  path.dirname(BASE_TEMP_DIR),
+  "retained-meetings",
+);
 
 export function getTempBaseDir(): string {
   return BASE_TEMP_DIR;
@@ -16,6 +20,10 @@ export async function ensureTempBaseDir(): Promise<string> {
 
 export function getMeetingTempDir(meeting: MeetingData): string {
   return path.join(BASE_TEMP_DIR, "m", meeting.meetingId);
+}
+
+export function getRetainedMeetingTempDir(meeting: MeetingData): string {
+  return path.join(RETAINED_TEMP_DIR, meeting.meetingId);
 }
 
 export async function ensureMeetingTempDir(
@@ -48,4 +56,50 @@ export async function cleanupMeetingTempDir(
   meeting: MeetingData,
 ): Promise<void> {
   await safeRemove(getMeetingTempDir(meeting), "meeting");
+}
+
+export async function retainMeetingTempDir(
+  meeting: MeetingData,
+  reason: string,
+): Promise<string | undefined> {
+  const sourceDir = getMeetingTempDir(meeting);
+  const retainedDir = getRetainedMeetingTempDir(meeting);
+  try {
+    await fs.access(sourceDir);
+    await fs.mkdir(RETAINED_TEMP_DIR, { recursive: true });
+    await fs.rm(retainedDir, { recursive: true, force: true });
+    await fs.writeFile(
+      path.join(sourceDir, "retention.json"),
+      JSON.stringify(
+        {
+          retainedAt: new Date().toISOString(),
+          reason,
+          meetingId: meeting.meetingId,
+          guildId: meeting.guildId,
+          channelId: meeting.channelId,
+        },
+        null,
+        2,
+      ),
+    );
+    try {
+      await fs.rename(sourceDir, retainedDir);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EXDEV") {
+        throw error;
+      }
+      await fs.cp(sourceDir, retainedDir, { recursive: true });
+      await fs.rm(sourceDir, { recursive: true, force: true });
+    }
+    return retainedDir;
+  } catch (error) {
+    console.error("Failed to retain meeting temp directory", {
+      meetingId: meeting.meetingId,
+      sourceDir,
+      retainedDir,
+      reason,
+      error,
+    });
+    return undefined;
+  }
 }

--- a/src/services/uploadService.ts
+++ b/src/services/uploadService.ts
@@ -129,6 +129,8 @@ export async function uploadMeetingArtifacts(
   meeting: MeetingData,
   opts: UploadArtifactsOptions,
 ): Promise<UploadMeetingArtifactsResult> {
+  // Missing storage config still means captured audio was not durably persisted;
+  // callers use these flags to retain local artifacts instead of deleting them.
   const result: UploadMeetingArtifactsResult = {
     audioUploadExpected: Boolean(opts.audioFilePath),
     chatUploadExpected: Boolean(opts.chatFilePath),

--- a/src/services/uploadService.ts
+++ b/src/services/uploadService.ts
@@ -116,13 +116,28 @@ export interface UploadArtifactsOptions {
   transcriptText?: string;
 }
 
+export interface UploadMeetingArtifactsResult {
+  audioUploadExpected: boolean;
+  chatUploadExpected: boolean;
+  transcriptUploadExpected: boolean;
+  audioS3Key?: string;
+  chatS3Key?: string;
+  transcriptS3Key?: string;
+}
+
 export async function uploadMeetingArtifacts(
   meeting: MeetingData,
   opts: UploadArtifactsOptions,
-): Promise<void> {
+): Promise<UploadMeetingArtifactsResult> {
+  const result: UploadMeetingArtifactsResult = {
+    audioUploadExpected: Boolean(opts.audioFilePath),
+    chatUploadExpected: Boolean(opts.chatFilePath),
+    transcriptUploadExpected: Boolean(opts.transcriptText),
+  };
+
   if (!config.storage.transcriptBucket) {
     console.warn("TRANSCRIPTS_BUCKET not set; skipping uploads.");
-    return;
+    return result;
   }
 
   const folder = getMeetingFolder(meeting);
@@ -145,6 +160,7 @@ export async function uploadMeetingArtifacts(
       const uploaded = await uploadObjectToS3(key, audioBuffer, "audio/mpeg");
       if (uploaded) {
         meeting.audioS3Key = uploaded;
+        result.audioS3Key = uploaded;
       }
     } catch (error) {
       console.error("Failed to read/upload audio file", error);
@@ -163,14 +179,15 @@ export async function uploadMeetingArtifacts(
         chatText,
         "text/plain; charset=utf-8",
       );
-      await uploadObjectToS3(
+      const jsonUploaded = await uploadObjectToS3(
         chatJsonKey,
         JSON.stringify(chatEntriesToJson(meeting.chatLog), null, 2),
         "application/json",
       );
 
-      if (txtUploaded) {
-        meeting.chatS3Key = chatJsonKey; // point to structured file for lookups
+      if (txtUploaded && jsonUploaded) {
+        meeting.chatS3Key = jsonUploaded;
+        result.chatS3Key = jsonUploaded;
       }
     } catch (error) {
       console.error("Failed to upload chat artifacts", error);
@@ -179,18 +196,27 @@ export async function uploadMeetingArtifacts(
 
   // Transcript
   if (opts.transcriptText) {
-    const transcriptJsonKey = `${folder}transcript.json`;
+    try {
+      const transcriptJsonKey = `${folder}transcript.json`;
 
-    await uploadObjectToS3(
-      transcriptJsonKey,
-      JSON.stringify(
-        buildTranscriptJson(meeting, opts.transcriptText),
-        null,
-        2,
-      ),
-      "application/json",
-    );
+      const uploaded = await uploadObjectToS3(
+        transcriptJsonKey,
+        JSON.stringify(
+          buildTranscriptJson(meeting, opts.transcriptText),
+          null,
+          2,
+        ),
+        "application/json",
+      );
 
-    meeting.transcriptS3Key = transcriptJsonKey;
+      if (uploaded) {
+        meeting.transcriptS3Key = uploaded;
+        result.transcriptS3Key = uploaded;
+      }
+    } catch (error) {
+      console.error("Failed to upload transcript artifact", error);
+    }
   }
+
+  return result;
 }

--- a/test/commands/endMeeting.test.ts
+++ b/test/commands/endMeeting.test.ts
@@ -18,8 +18,13 @@ import {
 } from "../../src/audio";
 import { uploadMeetingArtifacts } from "../../src/services/uploadService";
 import { saveMeetingHistoryToDatabase } from "../../src/commands/saveMeetingHistory";
+import {
+  cleanupMeetingTempDir,
+  retainMeetingTempDir,
+} from "../../src/services/tempFileService";
 import { getGuildLimits } from "../../src/services/subscriptionService";
 import { updateMeetingStatusService } from "../../src/services/meetingHistoryService";
+import { deleteIfExists } from "../../src/util";
 import { deleteMeeting, getMeeting, hasMeeting } from "../../src/meetings";
 import { describeAutoRecordRule } from "../../src/utils/meetingLifecycle";
 import { MEETING_END_REASONS } from "../../src/types/meetingLifecycle";
@@ -42,6 +47,12 @@ jest.mock("../../src/embed", () => ({
 jest.mock("../../src/util", () => ({
   deleteDirectoryRecursively: jest.fn(),
   deleteIfExists: jest.fn(),
+}));
+jest.mock("../../src/services/tempFileService", () => ({
+  cleanupMeetingTempDir: jest.fn(),
+  ensureMeetingTempDir: jest.fn(async () => "tmp/meetings/meeting-1"),
+  getMeetingTempDir: jest.fn(() => "tmp/meetings/meeting-1"),
+  retainMeetingTempDir: jest.fn(async () => "tmp/retained-meetings/meeting-1"),
 }));
 jest.mock("../../src/services/meetingNotesService", () => ({
   ensureMeetingNotes: jest.fn(),
@@ -145,6 +156,14 @@ const mockedWaitForFinishProcessing =
   >;
 const mockedUploadMeetingArtifacts =
   uploadMeetingArtifacts as jest.MockedFunction<typeof uploadMeetingArtifacts>;
+const mockedCleanupMeetingTempDir =
+  cleanupMeetingTempDir as jest.MockedFunction<typeof cleanupMeetingTempDir>;
+const mockedRetainMeetingTempDir = retainMeetingTempDir as jest.MockedFunction<
+  typeof retainMeetingTempDir
+>;
+const mockedDeleteIfExists = deleteIfExists as jest.MockedFunction<
+  typeof deleteIfExists
+>;
 const mockedSaveMeetingHistoryToDatabase =
   saveMeetingHistoryToDatabase as jest.MockedFunction<
     typeof saveMeetingHistoryToDatabase
@@ -172,10 +191,22 @@ const mockedRunTranscriptionFinalPass =
     typeof runTranscriptionFinalPass
   >;
 
+const successfulArtifactUpload = {
+  audioUploadExpected: true,
+  chatUploadExpected: true,
+  transcriptUploadExpected: false,
+  audioS3Key: "audio/meeting-1.mp3",
+  chatS3Key: "chat/meeting-1.json",
+};
+
 describe("handleEndMeetingOther", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedCleanupSpeakerTracks.mockResolvedValue(undefined);
+    mockedUploadMeetingArtifacts.mockResolvedValue(successfulArtifactUpload);
+    mockedRetainMeetingTempDir.mockResolvedValue(
+      "tmp/retained-meetings/meeting-1",
+    );
     mockedRunTranscriptionFinalPass.mockResolvedValue({
       enabled: true,
       applied: false,
@@ -202,7 +233,6 @@ describe("handleEndMeetingOther", () => {
     mockedBuildMixedAudio.mockResolvedValue(undefined);
     mockedCloseOutputFile.mockResolvedValue(undefined);
     mockedWaitForAudioOnlyFinishProcessing.mockResolvedValue(undefined);
-    mockedUploadMeetingArtifacts.mockResolvedValue(undefined);
     mockedSaveMeetingHistoryToDatabase.mockResolvedValue(undefined);
     mockedGetGuildLimits.mockResolvedValue({ limits: {} } as never);
     mockedUpdateMeetingStatusService.mockResolvedValue(undefined);
@@ -283,7 +313,6 @@ describe("handleEndMeetingOther", () => {
     mockedWaitForFinishProcessing.mockResolvedValue(undefined);
     mockedBuildMixedAudio.mockResolvedValue(undefined);
     mockedCompileTranscriptions.mockResolvedValue("Recovered transcript");
-    mockedUploadMeetingArtifacts.mockResolvedValue(undefined);
     mockedGetGuildLimits.mockResolvedValue({ limits: {} } as never);
     mockedSaveMeetingHistoryToDatabase.mockResolvedValue(undefined);
 
@@ -432,7 +461,6 @@ describe("handleEndMeetingOther", () => {
     mockedBuildMixedAudio.mockResolvedValue(undefined);
     mockedCloseOutputFile.mockResolvedValue(undefined);
     mockedWaitForAudioOnlyFinishProcessing.mockResolvedValue(undefined);
-    mockedUploadMeetingArtifacts.mockResolvedValue(undefined);
     mockedSaveMeetingHistoryToDatabase.mockResolvedValue(undefined);
     mockedGetGuildLimits.mockResolvedValue({ limits: {} } as never);
     mockedUpdateMeetingStatusService.mockResolvedValue(undefined);
@@ -483,6 +511,64 @@ describe("handleEndMeetingOther", () => {
     });
   });
 
+  it("retains local artifacts when completed meeting audio upload is not durable", async () => {
+    mockedWithMeetingEndTrace.mockImplementation(async (_meeting, fn) => fn());
+    mockedEvaluateAutoRecordCancellation.mockResolvedValue({ cancel: false });
+    mockedBuildMixedAudio.mockResolvedValue(undefined);
+    mockedCloseOutputFile.mockResolvedValue(undefined);
+    mockedWaitForAudioOnlyFinishProcessing.mockResolvedValue(undefined);
+    mockedUploadMeetingArtifacts.mockResolvedValue({
+      audioUploadExpected: true,
+      chatUploadExpected: true,
+      transcriptUploadExpected: false,
+    });
+    mockedSaveMeetingHistoryToDatabase.mockResolvedValue(undefined);
+    mockedGetGuildLimits.mockResolvedValue({ limits: {} } as never);
+
+    const meeting = {
+      guildId: "guild-1",
+      channelId: "text-1",
+      meetingId: "meeting-1",
+      voiceChannel: { id: "voice-1", name: "Voice", members: new Collection() },
+      textChannel: {
+        id: "text-1",
+        send: jest.fn().mockResolvedValue(undefined),
+        messages: { fetch: jest.fn() },
+      },
+      connection: {
+        disconnect: jest.fn(),
+        destroy: jest.fn(),
+      },
+      chatLog: [],
+      audioData: {
+        audioFiles: [],
+        currentSnippets: new Map(),
+        outputFileName: "recording.mp3",
+      },
+      startTime: new Date("2025-01-01T00:00:00.000Z"),
+      endTime: undefined,
+      finishing: false,
+      finished: false,
+      transcribeMeeting: false,
+      generateNotes: false,
+      isAutoRecording: false,
+      creator: { id: "user-1" },
+      guild: { id: "guild-1", name: "Guild", members: { cache: new Map() } },
+      ttsQueue: { stopAndClear: jest.fn() },
+      setFinished: jest.fn(),
+    } as unknown as MeetingData;
+
+    await handleEndMeetingOther({} as Client, meeting);
+
+    expect(mockedRetainMeetingTempDir).toHaveBeenCalledWith(
+      meeting,
+      "audio_upload_failed",
+    );
+    expect(mockedDeleteIfExists).not.toHaveBeenCalledWith("recording.mp3");
+    expect(mockedCleanupSpeakerTracks).not.toHaveBeenCalled();
+    expect(mockedCleanupMeetingTempDir).not.toHaveBeenCalled();
+  });
+
   it("continues error cleanup when lease release fails", async () => {
     mockedWithMeetingEndTrace.mockRejectedValue(new Error("end flow failed"));
     mockedHasMeeting.mockReturnValue(true);
@@ -512,7 +598,6 @@ describe("handleEndMeetingOther", () => {
     mockedWaitForAudioOnlyFinishProcessing.mockResolvedValue(undefined);
     mockedCloseOutputFile.mockResolvedValue(undefined);
     mockedWaitForFinishProcessing.mockResolvedValue(undefined);
-    mockedUploadMeetingArtifacts.mockResolvedValue(undefined);
     mockedCompileTranscriptions.mockResolvedValueOnce(
       "Transcript without cues",
     );
@@ -575,6 +660,71 @@ describe("handleEndMeetingOther", () => {
     ).toBeLessThan(
       mockedSaveMeetingHistoryToDatabase.mock.invocationCallOrder[0],
     );
+  });
+
+  it("retains cancelled auto-record artifacts when audio upload is not durable", async () => {
+    mockedWithMeetingEndTrace.mockImplementation(async (_meeting, fn) => fn());
+    mockedWaitForAudioOnlyFinishProcessing.mockResolvedValue(undefined);
+    mockedCloseOutputFile.mockResolvedValue(undefined);
+    mockedUploadMeetingArtifacts.mockResolvedValue({
+      audioUploadExpected: true,
+      chatUploadExpected: true,
+      transcriptUploadExpected: false,
+    });
+    mockedDescribeAutoRecordRule.mockReturnValue(
+      "Auto-record rule: test-channel",
+    );
+    mockedSaveMeetingHistoryToDatabase.mockResolvedValue(undefined);
+
+    const meeting = {
+      guildId: "guild-1",
+      channelId: "text-1",
+      meetingId: "meeting-1",
+      voiceChannel: {
+        id: "voice-1",
+        name: "Voice",
+        members: new Collection(),
+      },
+      textChannel: {
+        send: jest.fn().mockResolvedValue(undefined),
+        messages: { fetch: jest.fn() },
+      },
+      connection: {
+        disconnect: jest.fn(),
+        destroy: jest.fn(),
+      },
+      chatLog: [],
+      audioData: {
+        audioFiles: [],
+        currentSnippets: new Map(),
+        outputFileName: "recording.mp3",
+      },
+      startTime: new Date("2025-01-01T00:00:00.000Z"),
+      endTime: undefined,
+      finishing: false,
+      finished: false,
+      transcribeMeeting: false,
+      generateNotes: false,
+      isAutoRecording: true,
+      cancelled: true,
+      cancellationReason: "Stopped by user",
+      endReason: MEETING_END_REASONS.AUTO_CANCELLED,
+      creator: { id: "bot-1" },
+      guild: { id: "guild-1", members: { cache: new Map() } },
+      ttsQueue: { stopAndClear: jest.fn() },
+      setFinished: jest.fn(),
+      participants: new Map(),
+    } as unknown as MeetingData;
+
+    await handleEndMeetingOther({} as Client, meeting);
+
+    expect(mockedRetainMeetingTempDir).toHaveBeenCalledWith(
+      meeting,
+      "cancelled_audio_upload_failed",
+    );
+    expect(mockedDeleteIfExists).not.toHaveBeenCalledWith("recording.mp3");
+    expect(mockedCleanupSpeakerTracks).not.toHaveBeenCalled();
+    expect(mockedCleanupMeetingTempDir).not.toHaveBeenCalled();
   });
 
   it("uses stopped messaging for short dismissed auto-record meetings", async () => {

--- a/test/e2e/desktop.visual.spec.ts
+++ b/test/e2e/desktop.visual.spec.ts
@@ -155,6 +155,9 @@ const installDesktopMock = async (page: Page): Promise<void> => {
             state.user = null;
             return null;
           }
+          if (command === "list_retained_recordings") {
+            return [];
+          }
           if (command === "start_recording") {
             state.recording = {
               isRecording: true,

--- a/test/services/tempFileService.test.ts
+++ b/test/services/tempFileService.test.ts
@@ -48,4 +48,42 @@ describe("tempFileService", () => {
     await service.cleanupTempBaseDir();
     expect(fs.existsSync(dir)).toBe(false);
   });
+
+  it("retains meeting temp directories outside the cleanup base", async () => {
+    const baseDir = path.join(os.tmpdir(), `chronote-test-${Date.now()}`);
+    const service = await loadService(baseDir);
+    const meeting = buildMeeting();
+    const dir = await service.ensureMeetingTempDir(meeting);
+    const recordingPath = path.join(dir, "recording.mp3");
+    await fs.promises.writeFile(recordingPath, Buffer.from([1, 2, 3]));
+
+    const retainedDir = await service.retainMeetingTempDir(
+      meeting,
+      "audio_upload_failed",
+    );
+
+    expect(retainedDir).toBe(service.getRetainedMeetingTempDir(meeting));
+    expect(fs.existsSync(dir)).toBe(false);
+    expect(fs.existsSync(path.join(retainedDir!, "recording.mp3"))).toBe(true);
+    await service.cleanupTempBaseDir();
+    expect(fs.existsSync(retainedDir!)).toBe(true);
+
+    const retention = JSON.parse(
+      await fs.promises.readFile(
+        path.join(retainedDir!, "retention.json"),
+        "utf8",
+      ),
+    ) as { reason: string; meetingId: string };
+    expect(retention).toEqual(
+      expect.objectContaining({
+        reason: "audio_upload_failed",
+        meetingId: meeting.meetingId,
+      }),
+    );
+
+    await fs.promises.rm(path.dirname(retainedDir!), {
+      recursive: true,
+      force: true,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Keep Chronote Desktop recording files after upload failures and add Saved recordings retry/open/delete actions.
- Retain Discord bot meeting artifacts outside startup-cleaned temp storage when audio was expected but not durably uploaded.
- Return artifact upload durability status and document desktop recovery behavior.

## Notes

Bot recovery is operator-visible via retained path/logs for this first slice.

Closes #256.
