### PR TITLE
Fix desktop segment uploads for signed-in sessions

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -497,6 +497,7 @@ async fn start_recording(
             label: "System/Other".to_string(),
         },
     ];
+    let upload_session = get_cached_or_stored_session(&api_base_url, &state).unwrap_or(None);
     let manifest = Arc::new(Mutex::new(create_active_recording_manifest(
         &recording_id,
         &started_at,
@@ -511,6 +512,7 @@ async fn start_recording(
         directory.clone(),
         Arc::clone(&manifest),
         segment_rx,
+        upload_session,
     );
     let mic = match start_source_capture(
         "owner_mic",
@@ -1046,6 +1048,32 @@ async fn access_token_for_stored_session(
     Ok(refreshed.access_token)
 }
 
+async fn access_token_for_session_snapshot(
+    api_base_url: &str,
+    client: &reqwest::Client,
+    session: &mut Option<DesktopSession>,
+) -> Result<String, String> {
+    if session
+        .as_ref()
+        .is_some_and(|session| session.api_base_url != api_base_url)
+    {
+        *session = None;
+    }
+    if session.is_none() {
+        *session = load_stored_session()?.filter(|session| session.api_base_url == api_base_url);
+    }
+    let current = session
+        .clone()
+        .ok_or_else(|| "Sign in before uploading recordings.".to_string())?;
+    if current.expires_at > now_epoch_seconds() + TOKEN_REFRESH_SKEW_SECONDS {
+        return Ok(current.access_token);
+    }
+    let refreshed = refresh_session(api_base_url, client, &current.refresh_token).await?;
+    let _ = persist_session(&refreshed);
+    *session = Some(refreshed.clone());
+    Ok(refreshed.access_token)
+}
+
 async fn create_recording_upload_session(
     api_base_url: &str,
     access_token: &str,
@@ -1238,6 +1266,7 @@ fn spawn_segment_upload_worker(
     directory: PathBuf,
     manifest: SharedRecordingManifest,
     mut segment_rx: async_mpsc::UnboundedReceiver<SealedSegmentEvent>,
+    mut session: Option<DesktopSession>,
 ) -> tauri::async_runtime::JoinHandle<()> {
     tauri::async_runtime::spawn(async move {
         while let Some(event) = segment_rx.recv().await {
@@ -1252,8 +1281,15 @@ fn spawn_segment_upload_worker(
                 eprintln!("Failed to update recording manifest: {error}");
                 continue;
             }
-            if let Err(error) =
-                upload_segment_file(&api_base_url, &directory, &manifest, &upload_file, None).await
+            if let Err(error) = upload_segment_file(
+                &api_base_url,
+                &directory,
+                &manifest,
+                &upload_file,
+                None,
+                Some(&mut session),
+            )
+            .await
             {
                 let _ = mark_segment_failed(&directory, &manifest, &upload_file, &error);
             }
@@ -1289,6 +1325,7 @@ async fn upload_manifest_segments(
             manifest,
             &upload_file,
             access_token,
+            None,
         )
         .await?;
     }
@@ -1301,11 +1338,17 @@ async fn upload_segment_file(
     manifest: &SharedRecordingManifest,
     segment: &SegmentUploadFile,
     access_token: Option<&str>,
+    session: Option<&mut Option<DesktopSession>>,
 ) -> Result<(), String> {
     let client = reqwest::Client::new();
     let access_token = match access_token {
         Some(access_token) => access_token.to_string(),
-        None => access_token_for_stored_session(api_base_url, &client).await?,
+        None => match session {
+            Some(session) => {
+                access_token_for_session_snapshot(api_base_url, &client, session).await?
+            }
+            None => access_token_for_stored_session(api_base_url, &client).await?,
+        },
     };
     let upload_id =
         ensure_recording_upload_session(api_base_url, &access_token, &client, directory, manifest)

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -22,7 +22,7 @@ use rand::{rngs::OsRng, RngCore};
 use reqwest::multipart::{Form, Part};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use tauri::{Emitter, State};
+use tauri::{Emitter, Manager, State};
 use tokio::sync::mpsc as async_mpsc;
 use url::Url;
 use uuid::Uuid;
@@ -497,7 +497,7 @@ async fn start_recording(
             label: "System/Other".to_string(),
         },
     ];
-    let upload_session = get_cached_or_stored_session(&api_base_url, &state).unwrap_or(None);
+    let upload_session = get_cached_or_stored_session(&api_base_url, &state)?;
     let manifest = Arc::new(Mutex::new(create_active_recording_manifest(
         &recording_id,
         &started_at,
@@ -508,6 +508,7 @@ async fn start_recording(
     write_shared_recording_manifest(&directory, &manifest)?;
     let (segment_tx, segment_rx) = async_mpsc::unbounded_channel();
     let upload_task = spawn_segment_upload_worker(
+        app.clone(),
         api_base_url.clone(),
         directory.clone(),
         Arc::clone(&manifest),
@@ -1051,6 +1052,7 @@ async fn access_token_for_stored_session(
 async fn access_token_for_session_snapshot(
     api_base_url: &str,
     client: &reqwest::Client,
+    app: &tauri::AppHandle,
     session: &mut Option<DesktopSession>,
 ) -> Result<String, String> {
     if session
@@ -1070,6 +1072,8 @@ async fn access_token_for_session_snapshot(
     }
     let refreshed = refresh_session(api_base_url, client, &current.refresh_token).await?;
     let _ = persist_session(&refreshed);
+    let state = app.state::<AppState>();
+    set_cached_session(&state, Some(refreshed.clone()))?;
     *session = Some(refreshed.clone());
     Ok(refreshed.access_token)
 }
@@ -1262,6 +1266,7 @@ async fn parse_api_response<T: DeserializeOwned>(response: reqwest::Response) ->
 }
 
 fn spawn_segment_upload_worker(
+    app: tauri::AppHandle,
     api_base_url: String,
     directory: PathBuf,
     manifest: SharedRecordingManifest,
@@ -1282,6 +1287,7 @@ fn spawn_segment_upload_worker(
                 continue;
             }
             if let Err(error) = upload_segment_file(
+                Some(&app),
                 &api_base_url,
                 &directory,
                 &manifest,
@@ -1320,6 +1326,7 @@ async fn upload_manifest_segments(
     for segment in segments {
         let upload_file = segment_upload_file_from_manifest(directory, &segment)?;
         upload_segment_file(
+            None,
             api_base_url,
             directory,
             manifest,
@@ -1333,6 +1340,7 @@ async fn upload_manifest_segments(
 }
 
 async fn upload_segment_file(
+    app: Option<&tauri::AppHandle>,
     api_base_url: &str,
     directory: &Path,
     manifest: &SharedRecordingManifest,
@@ -1345,7 +1353,15 @@ async fn upload_segment_file(
         Some(access_token) => access_token.to_string(),
         None => match session {
             Some(session) => {
-                access_token_for_session_snapshot(api_base_url, &client, session).await?
+                access_token_for_session_snapshot(
+                    api_base_url,
+                    &client,
+                    app.ok_or_else(|| {
+                        "Recording upload worker state was unavailable.".to_string()
+                    })?,
+                    session,
+                )
+                .await?
             }
             None => access_token_for_stored_session(api_base_url, &client).await?,
         },


### PR DESCRIPTION
## Summary
- Use the current cached desktop session when starting live segment uploads.
- Keep stored-session fallback for retained retries and token refresh.

## Validation
Local Rust fmt/tests and desktop typecheck pass.