### PR TITLE
[AGENT] Allow single-source desktop recordings

### DIFF
--- a/src/services/__tests__/personalMediaUploadProcessingService.test.ts
+++ b/src/services/__tests__/personalMediaUploadProcessingService.test.ts
@@ -328,6 +328,39 @@ describe("personalMediaUploadProcessingService", () => {
     );
   });
 
+  it("skips desktop sources that did not produce segments", async () => {
+    recordingSegments = [buildSegment(0)];
+    const job = {
+      ...buildDesktopJob(),
+      sourceManifest: [
+        { sourceId: "owner_mic", kind: "owner_mic", label: "Me" },
+        {
+          sourceId: "system_output",
+          kind: "system_output",
+          label: "System/Other",
+        },
+      ],
+    } satisfies PersonalMediaUploadJobRecord;
+
+    await processPersonalMediaUpload(job, "instance-1");
+
+    expect(mockTranscribe).toHaveBeenCalledTimes(1);
+    expect(markPersonalRecordingUploadSegmentProcessed).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(recordingSegments).toEqual([
+      expect.objectContaining({ sourceId: "owner_mic", status: "processed" }),
+    ]);
+    expect(updateClaimedPersonalMediaUploadJobRecord).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        status: "complete",
+        segmentCount: 1,
+        processedSegmentCount: 1,
+      }),
+      "instance-1",
+    );
+  });
+
   it("reuses processed segment transcript artifacts on retry", async () => {
     const processedSegment = {
       ...buildSegment(0, "processed"),

--- a/src/services/__tests__/personalMediaUploadService.test.ts
+++ b/src/services/__tests__/personalMediaUploadService.test.ts
@@ -488,45 +488,62 @@ describe("personalMediaUploadService", () => {
     );
   });
 
-  it("rejects desktop recording submission unless every source has a segment", async () => {
-    const session = await createPersonalRecordingUploadSession({
-      userId: "user-1",
-      sources: [
-        { sourceId: "owner_mic", kind: "owner_mic" },
-        { sourceId: "system_output", kind: "system_output" },
-      ],
-    });
-    uploadRepository.get.mockResolvedValue(getWrittenJob());
-    const ownerIntent = await createPersonalRecordingSegmentUploadIntent(
-      segmentInput({
-        uploadId: session.uploadId,
-        sourceId: "owner_mic",
-        fileSize: 1000,
-      }),
-    );
-    jest.mocked(getStoredObjectMetadata).mockResolvedValue({
-      contentLength: 1000,
-      contentType: "audio/wav",
-    });
-    await markPersonalRecordingSegmentUploadComplete({
-      uploadId: session.uploadId,
-      userId: "user-1",
-      sourceId: "owner_mic",
-      sequence: 0,
-      key: ownerIntent.segment.sourceS3Key,
-      uploadToken: ownerIntent.uploadToken!,
-    });
-
-    await expect(
-      submitPersonalRecordingUpload({
+  it.each([
+    { sourceId: "owner_mic", kind: "owner_mic", size: 1000 },
+    { sourceId: "system_output", kind: "system_output", size: 2000 },
+  ] as const)(
+    "submits a desktop recording when only $sourceId has audio",
+    async ({ sourceId, size }) => {
+      const session = await createPersonalRecordingUploadSession({
+        userId: "user-1",
+        sources: [
+          { sourceId: "owner_mic", kind: "owner_mic" },
+          { sourceId: "system_output", kind: "system_output" },
+        ],
+      });
+      uploadRepository.get.mockResolvedValue(getWrittenJob());
+      const intent = await createPersonalRecordingSegmentUploadIntent(
+        segmentInput({
+          uploadId: session.uploadId,
+          sourceId,
+          fileSize: size,
+        }),
+      );
+      jest.mocked(getStoredObjectMetadata).mockResolvedValue({
+        contentLength: size,
+        contentType: "audio/wav",
+      });
+      await markPersonalRecordingSegmentUploadComplete({
         uploadId: session.uploadId,
         userId: "user-1",
-      }),
-    ).rejects.toMatchObject<Partial<PersonalMediaUploadError>>({
-      code: "invalid_state",
-    });
-    expect(uploadRepository.update).not.toHaveBeenCalled();
-  });
+        sourceId,
+        sequence: 0,
+        key: intent.segment.sourceS3Key,
+        uploadToken: intent.uploadToken!,
+      });
+
+      const completed = await submitPersonalRecordingUpload({
+        uploadId: session.uploadId,
+        userId: "user-1",
+      });
+
+      expect(completed).toMatchObject({
+        uploadId: session.uploadId,
+        status: "queued",
+        fileSize: size,
+        segmentCount: 1,
+        uploadedSegmentCount: 1,
+      });
+      expect(uploadRepository.update).toHaveBeenCalledWith(completed);
+      await expect(
+        segmentRepository.listByUpload(session.uploadId),
+      ).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ sourceId, status: "submitted" }),
+        ]),
+      );
+    },
+  );
 
   it("rejects upload completion with the wrong key", async () => {
     const intent = await createPersonalMediaUploadIntent({

--- a/src/services/personalMediaUploadProcessingService.ts
+++ b/src/services/personalMediaUploadProcessingService.ts
@@ -624,6 +624,9 @@ const processPersonalRecordingContent = async (
     const sourceSegments = submittedSegments
       .filter((segment) => segment.sourceId === source.sourceId)
       .sort((left, right) => left.sequence - right.sequence);
+    if (sourceSegments.length === 0 && !source.sourceS3Key) {
+      continue;
+    }
     processedSources.push(
       sourceSegments.length > 0
         ? await processPersonalRecordingSegmentSource(
@@ -635,6 +638,9 @@ const processPersonalRecordingContent = async (
           )
         : await processPersonalRecordingSource(job, source, workDir),
     );
+  }
+  if (processedSources.length === 0) {
+    throw new Error("No recording segments were available to assemble.");
   }
 
   const audioPath = path.join(workDir, "audio.mp3");

--- a/src/services/personalMediaUploadService.ts
+++ b/src/services/personalMediaUploadService.ts
@@ -679,18 +679,6 @@ export async function submitPersonalRecordingUpload(options: {
       "invalid_state",
     );
   }
-  const sourcesWithSegments = new Set(
-    segments.map((segment) => segment.sourceId),
-  );
-  const missingSource = job.sourceManifest?.find(
-    (source) => !sourcesWithSegments.has(source.sourceId),
-  );
-  if (missingSource) {
-    throw new PersonalMediaUploadError(
-      "Every recording source must include at least one uploaded segment.",
-      "invalid_state",
-    );
-  }
   const notUploaded = segments.find(
     (segment) =>
       !["uploaded", "submitted", "processed"].includes(segment.status),

--- a/test/api/desktop.test.ts
+++ b/test/api/desktop.test.ts
@@ -527,6 +527,118 @@ describe("desktop API", () => {
     }
   });
 
+  test("submits a desktop recording when one registered source has no segments", async () => {
+    const { server, baseUrl } = createServer();
+    Object.defineProperty(config.mcp, "publicBaseUrl", {
+      get: () => baseUrl,
+      configurable: true,
+    });
+
+    try {
+      const token = await authorizeDesktopToken(baseUrl);
+      const sessionResponse = await fetch(
+        `${baseUrl}/api/desktop/recordings/session`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token.access_token}`,
+          },
+          body: JSON.stringify({
+            sources: [
+              {
+                sourceId: "owner_mic",
+                kind: "owner_mic",
+                label: "Me",
+              },
+              {
+                sourceId: "system_output",
+                kind: "system_output",
+                label: "System/Other",
+              },
+            ],
+          }),
+        },
+      );
+      await expectSuccess(sessionResponse);
+      const session = await readJson<RecordingSessionResponse>(sessionResponse);
+
+      const ownerBody = Buffer.from([0, 1, 2, 3]);
+      const ownerIntentResponse = await fetch(
+        `${baseUrl}/api/desktop/recordings/segment-intent`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token.access_token}`,
+          },
+          body: JSON.stringify({
+            uploadId: session.uploadId,
+            sourceId: "owner_mic",
+            sequence: 0,
+            contentType: "audio/wav",
+            fileSize: ownerBody.byteLength,
+            checksumSha256: checksumSha256(ownerBody),
+            durationMillis: 1000,
+            startedAt: "2026-06-15T00:00:00.000Z",
+            endedAt: "2026-06-15T00:00:01.000Z",
+            originalFileName: "owner_mic.wav",
+          }),
+        },
+      );
+      await expectSuccess(ownerIntentResponse);
+      const ownerIntent =
+        await readJson<RecordingSegmentIntentResponse>(ownerIntentResponse);
+      await uploadSegment(ownerIntent, ownerBody);
+
+      const completeResponse = await fetch(
+        `${baseUrl}/api/desktop/recordings/segment-complete`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token.access_token}`,
+          },
+          body: JSON.stringify({
+            uploadId: session.uploadId,
+            sourceId: ownerIntent.segment.sourceId,
+            sequence: ownerIntent.segment.sequence,
+            key: ownerIntent.segment.sourceS3Key,
+            uploadToken: ownerIntent.uploadToken,
+          }),
+        },
+      );
+      await expectSuccess(completeResponse);
+
+      const submitResponse = await fetch(
+        `${baseUrl}/api/desktop/recordings/submit`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token.access_token}`,
+          },
+          body: JSON.stringify({ uploadId: session.uploadId }),
+        },
+      );
+      await expectSuccess(submitResponse);
+      const completed = await readJson<RecordingJobResponse>(submitResponse);
+      expect(completed.job).toEqual(
+        expect.objectContaining({
+          uploadId: session.uploadId,
+          status: "queued",
+          uploadOrigin: "desktop_recording",
+          segmentCount: 1,
+          uploadedSegmentCount: 1,
+          processedSegmentCount: 0,
+        }),
+      );
+      expect(completed.job.sourceManifest).toHaveLength(2);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
   test("rejects duplicate source IDs when creating a desktop recording session", async () => {
     const { server, baseUrl } = createServer();
     Object.defineProperty(config.mcp, "publicBaseUrl", {


### PR DESCRIPTION
[AGENT]

## Summary
- Allow desktop recordings to submit when only one registered source produced uploaded segments.
- Skip segmentless desktop sources during processing unless they have a legacy whole-source object.
- Add service, processing, and desktop API regressions for single-source recordings.

## Notes
- Docs-exempt: bug fix to existing desktop recording behavior, no new user-facing workflow.
- Server-side only; existing desktop builds should be able to retry retained recordings after backend deploy.
- Validated with focused upload tests, TypeScript build, and lint on touched files.