### PR TITLE
Hold typescript at 6.x in the dependabot app group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,13 @@ updates:
     patterns:
       - "*"
     multi-ecosystem-group: "app"
+    # TypeScript 7 is the Go compiler rewrite. It ships no programmatic
+    # compiler API until 7.1, so typescript-eslint and ts-jest cannot consume
+    # it and both fail hard on a 7.x bump. Hold at 6.x so the app group stays
+    # mergeable, and treat the 7.x move as a deliberate migration.
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "uv"
     directory: "/"


### PR DESCRIPTION
[AGENT]

## Summary

Adds a dependabot ignore rule for `typescript` major-version updates in the `app` group.

TypeScript 7 is the Go compiler rewrite. It ships no programmatic compiler API until 7.1, so typescript-eslint and ts-jest cannot consume it. On #292 a `typescript` 6.0.3 -> 7.0.2 bump failed Lint, Unit Tests, Build, Docker Build, E2E, and Build Windows Desktop Artifacts, all from that single line:

- `typescript-eslint does not support TS 7.0.` (Lint)
- `The TypeScript compiler "typescript" (version 7.0.2) does not expose the JavaScript compiler API required by ts-jest.` (every Jest suite)

Without this rule the app group breaks every week and holds ~30 unrelated bumps hostage.

## Why not migrate instead

Measured against this repo's tsconfig with TS 7.0.2 installed:

| Config | Errors |
| --- | --- |
| current tsconfig | 1 (`moduleResolution=node10` has been removed) |
| `module`/`moduleResolution: node16` | ~44 (27 need explicit `.js` extensions, 10 CommonJS files importing ESM-only packages) |
| `moduleResolution: bundler` | ~6, but bundler resolution is wrong for the CommonJS backend and would typecheck imports Node cannot resolve at runtime |

typescript-eslint issue #10940 is open and blocked on both the missing 7.1 API and ESLint's lack of async parser support, so lint and tests stay on the TS 6 API regardless. The only gain from migrating today is build speed, against a ~44 error change that converts sync imports to async dynamic imports in the bot runtime. Worth doing deliberately, not as a dependency bump.

Follow-up after merge: `@dependabot recreate` on #292 so it returns without the TypeScript bump.