### PR TITLE
chore(deps): bump stripe to 22.4.0, adopt API version 2026-07-29.dahlia

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "react-markdown": "^10.1.0",
     "react-quill-new": "^3.8.3",
     "remark-gfm": "^4.0.1",
-    "stripe": "22.3.2",
+    "stripe": "22.4.0",
     "syllable": "^5.0.1",
     "uuid": "^14.0.1",
     "web-vitals": "^6.0.1",

--- a/src/services/stripeClient.ts
+++ b/src/services/stripeClient.ts
@@ -9,7 +9,7 @@ export function getStripeClient(): StripeClient | null {
     return stripeClient;
   }
   stripeClient = config.stripe.secretKey
-    ? new Stripe(config.stripe.secretKey, { apiVersion: "2026-06-24.dahlia" })
+    ? new Stripe(config.stripe.secretKey, { apiVersion: "2026-07-29.dahlia" })
     : null;
   return stripeClient;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17055,10 +17055,10 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
-stripe@22.3.2:
-  version "22.3.2"
-  resolved "https://registry.yarnpkg.com/stripe/-/stripe-22.3.2.tgz#0799b3a2ef799758432349208590ac78cc577d5d"
-  integrity sha512-O13QOvgEIQvDlTy6Ubb5kB980wpbhmoZNsgCXKILjCMZS67f+bW+6w99k3gnSi/N1lkryoj1WYdpGT5Wc5edjg==
+stripe@22.4.0:
+  version "22.4.0"
+  resolved "https://registry.yarnpkg.com/stripe/-/stripe-22.4.0.tgz#f82873c14743927f2b70fcc30f548a9eaacb843f"
+  integrity sha512-LVJ+tcSYeqOSnXr3i+Kz2tZ7y0crLLdP2uwD/4wccrmEVyn0g/Heo0pF7as7rxS/sOjJzrb1lxgZY0Y0Dx1pSA==
 
 strnum@^2.2.3:
   version "2.3.0"


### PR DESCRIPTION
[AGENT]

## Summary

Clears the `stripe` bump held back in #300. Two lines: the dependency, and the `apiVersion` literal that has to move with it.

The SDK pins the Stripe API version in its types, so the two are coupled. Confirmed by unpacking both tarballs rather than trusting the error message:

| SDK | `ApiVersion` | `ApiMajorVersion` |
| --- | --- | --- |
| 22.3.2 | `2026-06-24.dahlia` | `dahlia` |
| 22.4.0 | `2026-07-29.dahlia` | `dahlia` |

22.4.0 is the latest stable (22.5.0 is beta only).

## Kept the explicit literal on purpose

`Stripe.ApiVersion` is exported and would make this never break again, but that is the wrong trade here. The build break is what forces an API version change to get looked at. Removing it would mean every future SDK bump silently moves live billing to a new API version. Keeping the literal keeps the review gate.

## Risk notes

Stripe API surface used here is narrow and stable: `checkout.sessions`, `billingPortal.sessions`, `customers.create`/`list`, `prices.list`, `promotionCodes.list`, `subscriptions.retrieve`, `webhooks.constructEvent`.

Webhook payload shape is not affected by this change. The constructor `apiVersion` governs outbound calls; inbound webhook versioning comes from the endpoint/account setting.

Two things worth knowing before merging:

1. `2026-07-29` is one day old at time of writing, and its entry is not yet in the public changelog, so the change list could not be reviewed directly.
2. Versions sharing a release name are not guaranteed compatible. Stripe marks breaking changes between dated versions within the same train, so `dahlia` to `dahlia` is not by itself a safety guarantee.

## Verification

- `yarn build` (tsc) passes
- `yarn lint:check` passes
- `yarn test` passes, 948 tests across 182 suites

Limit worth stating plainly: no test constructs a real Stripe client. `test/api/billing.test.ts` mocks `StripeClient` outright, so the suite proves the types line up and the mocked flows still work, not that API version `2026-07-29` behaves identically against Stripe.

Revert is `git revert` of this commit, restoring `22.3.2` and the previous literal together.