### PR TITLE
[AGENT] Stop gating the ALB security group; a dropped inline rule is not removed

### DIFF
--- a/_infra/README.md
+++ b/_infra/README.md
@@ -318,10 +318,16 @@ The DynamoDB tables are on-demand, and S3, CloudFront, ACM and ECR are free whil
 unused, so there is no reason to destroy the whole workspace to stop paying for
 it. Three variables park it instead:
 
-- `ENABLE_API_ALB=false` removes the load balancer, its listeners, target group,
-  security group and alias record. A bot-only environment does not need inbound
-  traffic at all, because the Discord gateway connection is outbound. You do lose
-  the portal, OAuth callbacks and Stripe webhooks until it is flipped back.
+- `ENABLE_API_ALB=false` removes the load balancer, its listeners, target group
+  and alias record. A bot-only environment does not need inbound traffic at all,
+  because the Discord gateway connection is outbound. You do lose the portal,
+  OAuth callbacks and Stripe webhooks until it is flipped back.
+  The ALB **security group is deliberately kept**, along with the ECS service's
+  ingress rule referencing it. Security groups are free, and the alternative does
+  not work: the AWS provider treats an absent inline rule attribute as unmanaged
+  rather than empty, so a rule that stops being emitted is left in place and then
+  blocks the group's own deletion with a `DependencyViolation`. Expect an
+  unattached security group in a parked environment; it is not leftover cruft.
 - `ECS_DESIRED_COUNT=0` stops the task without touching the service definition.
   Terraform stops it immediately, without the `ActiveMeetingTable` lease wait that
   `deploy.yml` and `deploy-staging.yml` run before replacing a task, so parking an

--- a/_infra/api.tf
+++ b/_infra/api.tf
@@ -56,8 +56,12 @@ resource "aws_acm_certificate_validation" "api_cert" {
 }
 
 resource "aws_security_group" "api_alb_sg" {
-  #checkov:skip=CKV2_AWS_5: Attached to aws_lb.api_alb via a count-indexed reference, which checkov's graph does not resolve.
-  count       = var.ENABLE_API_ALB ? 1 : 0
+  #checkov:skip=CKV2_AWS_5: Attached to aws_lb.api_alb via a count-indexed reference, which checkov's graph does not resolve. Unattached while the ALB is parked.
+  # Deliberately not gated on ENABLE_API_ALB. Security groups are free, and the
+  # ECS service SG holds an inline ingress rule referencing this one: an inline
+  # rule block that stops being emitted is treated by the AWS provider as
+  # unmanaged rather than removed, so the reference would survive and block this
+  # group's deletion with a DependencyViolation. Only the billable ALB is gated.
   name_prefix = "${local.name_prefix}-api-alb-"
   description = "ALB SG for ${local.name_prefix} API"
   vpc_id      = aws_vpc.app_vpc.id
@@ -95,7 +99,7 @@ resource "aws_lb" "api_alb" {
   name                       = "${local.name_prefix}-api"
   internal                   = false
   load_balancer_type         = "application"
-  security_groups            = [aws_security_group.api_alb_sg[0].id]
+  security_groups            = [aws_security_group.api_alb_sg.id]
   subnets                    = [aws_subnet.app_public_subnet_1.id, aws_subnet.app_public_subnet_2.id]
   drop_invalid_header_fields = true
   enable_deletion_protection = var.ENABLE_API_ALB_DELETION_PROTECTION

--- a/_infra/main.tf
+++ b/_infra/main.tf
@@ -725,16 +725,16 @@ resource "aws_security_group" "ecs_service_sg" {
   description = "ECS service SG for ${local.name_prefix}-bot"
   vpc_id      = aws_vpc.app_vpc.id
 
-  # Only meaningful when the ALB exists; a parked environment has no inbound path.
-  dynamic "ingress" {
-    for_each = aws_security_group.api_alb_sg
-    content {
-      description     = "Allow app traffic from the ALB to port 3001"
-      from_port       = 3001
-      to_port         = 3001
-      protocol        = "tcp"
-      security_groups = [ingress.value.id]
-    }
+  # Kept unconditional. A dynamic block that emits nothing leaves the rule in
+  # place rather than removing it, because the AWS provider treats an absent
+  # inline rule attribute as unmanaged, so gating this on the ALB blocked the
+  # ALB security group's deletion instead of tidying up after it.
+  ingress {
+    description     = "Allow app traffic from the ALB to port 3001"
+    from_port       = 3001
+    to_port         = 3001
+    protocol        = "tcp"
+    security_groups = [aws_security_group.api_alb_sg.id]
   }
 
   # Outbound HTTPS for Discord/OpenAI/AWS APIs

--- a/_infra/moved.tf
+++ b/_infra/moved.tf
@@ -1,0 +1,18 @@
+# State address migration.
+#
+# aws_security_group.api_alb_sg briefly carried a count and has been returned to
+# a singleton, so any workspace that applied the counted version holds it at
+# [0]. Terraform migrates a singleton to [0] on its own, but not the reverse, and
+# without this it would destroy and recreate the group. The destroy would then
+# fail with a DependencyViolation, because the ECS service security group holds
+# an inline ingress rule referencing it.
+#
+# A from address absent from state is skipped, so this is a no-op for any
+# workspace that never applied the counted version.
+#
+# Can be deleted once every workspace has applied once past this change.
+
+moved {
+  from = aws_security_group.api_alb_sg[0]
+  to   = aws_security_group.api_alb_sg
+}


### PR DESCRIPTION
[AGENT]

## Summary

- Parking sandbox failed at apply: `DependencyViolation: resource sg-... has a dependent object` when destroying the ALB security group. Found while applying #307, not in review.
- Root cause: the AWS provider treats an **absent** inline `ingress` attribute as *unmanaged*, not as *empty*. The `dynamic "ingress"` block on `aws_security_group.ecs_service_sg` iterates the ALB security group collection, so when the ALB is parked it emits nothing, and the existing rule referencing the ALB security group is silently left in place instead of removed. That reference then blocks the group's deletion forever.
- Two consecutive plans confirmed it: neither planned any change to `aws_security_group.ecs_service_sg`, while the port 3001 rule was plainly present in both state and AWS.

## Fix

`aws_security_group.api_alb_sg` is no longer gated on `ENABLE_API_ALB`. Security groups are free, only the load balancer is billable, and an unattached group in a parked environment costs nothing. The ECS ingress rule becomes unconditional again and the dynamic block goes away, so this is a **smaller** configuration than the one it replaces.

The alternatives were worse for the gain: the `ingress = [...]` attribute form requires every field spelled out and is easy to get wrong, and splitting the rule into `aws_vpc_security_group_ingress_rule` would mix rule resources with the inline `egress` blocks still on that group and need an import for the rule that already exists.

A `moved` block returns the group from `[0]` to the singleton address. Terraform migrates a singleton to `[0]` automatically but not the reverse, and a destroy-and-recreate would hit the same `DependencyViolation`. It is a no-op for any workspace that never applied the counted version.

## Blast radius

Production is unaffected. `ENABLE_API_ALB` defaults to true, so the rule was always emitted there and prod has not applied the counted version of this group at all. Sandbox is currently mid-park with its ALB already deleted and this group orphaned; this change is what lets it settle.

## Docs impact

- [ ] User-facing behavior changed and docs were updated in `apps/docs-site`
- [x] No user-facing behavior changed, this PR should be `docs-exempt`
- Docs notes (page links or exemption rationale): Terraform configuration only, no product surface affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
