### PR TITLE
[AGENT] Require a host before accepting a TLS REDIS_URL

### DIFF
--- a/src/utils/__tests__/redisUrl.test.ts
+++ b/src/utils/__tests__/redisUrl.test.ts
@@ -43,4 +43,19 @@ describe("isUsableRedisUrl", () => {
     expect(isUsableRedisUrl("")).toBe(false);
     expect(isUsableRedisUrl("not-a-url")).toBe(false);
   });
+
+  it("rejects a TLS URL with no host", () => {
+    // A truncated secret parses as rediss: with an empty hostname, and ioredis
+    // would retry a connection that can never resolve. Scheme alone is not
+    // enough to accept a URL.
+    expect(isUsableRedisUrl("rediss://")).toBe(false);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("no host"));
+  });
+
+  it("matches local hosts regardless of case or IPv6 brackets", () => {
+    // redis: is not a special scheme, so the parser preserves host case and
+    // keeps IPv6 literals bracketed.
+    expect(isUsableRedisUrl("redis://LOCALHOST:6379")).toBe(true);
+    expect(isUsableRedisUrl("redis://[::1]:6379")).toBe(true);
+  });
 });

--- a/src/utils/redisUrl.ts
+++ b/src/utils/redisUrl.ts
@@ -2,6 +2,13 @@
 // redis:8-alpine with no TLS for local development.
 const LOCAL_CACHE_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "redis"]);
 
+// `redis:` and `rediss:` are not special schemes, so the WHATWG parser keeps the
+// host verbatim: it does not lowercase it, and it leaves IPv6 literals in their
+// brackets. Both would miss the allowlist above and quietly demote a working
+// local Redis to the memory cache.
+const normalizeHost = (hostname: string) =>
+  hostname.toLowerCase().replace(/^\[(.+)\]$/, "$1");
+
 /**
  * Managed Redis (Upstash, ElastiCache) accepts TLS only, and ioredis decides
  * whether to negotiate TLS from the URL scheme alone. A `redis://` URL pointed
@@ -25,8 +32,17 @@ export function isUsableRedisUrl(url: string): boolean {
     return false;
   }
 
+  // A truncated secret such as "rediss://" parses with an empty hostname, and
+  // ioredis would then retry a connection that can never resolve. That is the
+  // same loop this guard exists to prevent, so check the host before the scheme.
+  const hostname = normalizeHost(parsed.hostname);
+  if (!hostname) {
+    console.error("Cache disabled: REDIS_URL has no host.");
+    return false;
+  }
+
   if (parsed.protocol === "rediss:") return true;
-  if (LOCAL_CACHE_HOSTS.has(parsed.hostname)) return true;
+  if (LOCAL_CACHE_HOSTS.has(hostname)) return true;
 
   console.error(
     `Cache disabled: REDIS_URL uses ${parsed.protocol}// for remote host ${parsed.hostname}. ` +


### PR DESCRIPTION
[AGENT]

## Summary

Two edge cases raised in review of #309, both verified against the WHATWG parser rather than reasoned about:

| Input | `URL.hostname` | Before | After |
| --- | --- | --- | --- |
| `rediss://` | `""` | accepted | rejected |
| `redis://LOCALHOST:6379` | `"LOCALHOST"` | rejected | accepted |
| `redis://[::1]:6379` | `"[::1]"` | rejected | accepted |

**The first one is the important one.** A truncated or partially pasted secret parses as `rediss:` with an empty hostname, and the guard accepted it purely on its scheme. `cacheService` then built an ioredis client for a host that can never resolve, producing the same connection-retry loop that #309 exists to prevent, just reached by a different route. The host is now checked before the scheme.

The second is local-development only: `redis:` and `rediss:` are not special schemes, so the parser preserves host case and leaves IPv6 literals bracketed. Both forms missed the allowlist and silently demoted a working local Redis to the memory cache, which is the kind of thing that wastes an afternoon rather than breaking anything.

## Verification

Two tests added for exactly these cases. Full suite: 187 suites, 980 tests passing.

## Docs impact

- [ ] User-facing behavior changed and docs were updated in `apps/docs-site`
- [x] No user-facing behavior changed, this PR should be `docs-exempt`
- Docs notes (page links or exemption rationale): Internal cache configuration handling, no product surface affected. The behavior is already described in `AGENTS.md` and `_infra/README.md` from #309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
