### PR TITLE
[AGENT] Add PostHog product analytics across the bot, portal, and billing

### DIFF
--- a/_infra/README.md
+++ b/_infra/README.md
@@ -195,6 +195,44 @@ If you set `DOCS_DOMAIN` in `terraform.tfvars`, Terraform will:
 
 Deploy workflows use those variables to publish `apps/docs-site` to `docs.chronote.gg`.
 
+## Analytics proxy (PostHog)
+
+The portal sends analytics to a first-party subdomain rather than to PostHog's
+ingestion host, because ad blockers filter the latter and every metric comes out
+skewed low. PostHog runs the proxy itself, so the only infrastructure here is one
+CNAME in `_infra/analytics.tf`. There is no CloudFront behavior and no origin.
+
+Three variables control it, all blank by default:
+
+| Variable                       | Purpose                                                                                                                            |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `POSTHOG_KEY`                  | Public ingestion token for server-side capture. Blank disables capture entirely. Not a credential, so `TFVAR_POSTHOG_KEY` is fine. |
+| `ANALYTICS_PROXY_DOMAIN`       | The subdomain to serve ingestion from, e.g. `e.chronote.gg`.                                                                       |
+| `ANALYTICS_PROXY_CNAME_TARGET` | The CNAME target PostHog issues when the domain is registered.                                                                     |
+
+Leave the proxy pair blank in any non-production workspace. Both must be set
+before the record is created, so a workspace with only one of them configured
+simply gets no record rather than a broken one.
+
+**Rollout order matters, and getting it wrong is not self-healing.** Setting the
+frontend host before the proxy certificate is valid stops the portal sending
+analytics until another frontend deploy goes out.
+
+1. Register the domain in PostHog's organization proxy settings. It returns a
+   CNAME target and sits in `waiting`.
+2. Set `ANALYTICS_PROXY_DOMAIN` and `ANALYTICS_PROXY_CNAME_TARGET`, then apply.
+   Remember that a Terraform apply alone does not move a running ECS service:
+   a backend deploy has to follow, as described under the plan and apply
+   workflows below.
+3. Wait for the PostHog record to report `valid`. It verifies automatically once
+   DNS resolves and then issues the certificate.
+4. Only then set the `VITE_POSTHOG_HOST` Actions variable to
+   `https://<ANALYTICS_PROXY_DOMAIN>`. The next frontend deploy picks it up.
+
+To roll back, clear `VITE_POSTHOG_HOST` and deploy the frontend. The portal
+returns to sending directly to PostHog, losing the ad-blocker coverage but
+nothing else.
+
 ## Environments (production, sandbox, staging)
 
 Terraform now supports environment-specific resource naming via `environment`

--- a/_infra/analytics.tf
+++ b/_infra/analytics.tf
@@ -1,0 +1,38 @@
+# PostHog managed reverse proxy DNS.
+#
+# The portal sends analytics to a first-party subdomain instead of
+# us.i.posthog.com, because ad blockers filter the latter and silently skew
+# every metric downward. PostHog hosts the proxy itself, so there is no
+# CloudFront behavior or origin here: the only infrastructure is this CNAME.
+#
+# The domain is registered in PostHog's organization proxy settings, which
+# issues the target below and provisions the certificate once DNS resolves.
+# Both values are supplied per environment so a non-production workspace does
+# not publish a record pointing at the production proxy.
+
+variable "ANALYTICS_PROXY_DOMAIN" {
+  description = "Custom subdomain that fronts PostHog ingestion; leave blank to send directly to PostHog"
+  type        = string
+  default     = ""
+}
+
+variable "ANALYTICS_PROXY_CNAME_TARGET" {
+  description = "CNAME target issued by PostHog when the proxy domain is registered"
+  type        = string
+  default     = ""
+}
+
+data "aws_route53_zone" "analytics_proxy_hosted_zone" {
+  count = var.ANALYTICS_PROXY_DOMAIN != "" && var.HOSTED_ZONE_NAME != "" ? 1 : 0
+  name  = var.HOSTED_ZONE_NAME
+}
+
+resource "aws_route53_record" "analytics_proxy" {
+  count = var.ANALYTICS_PROXY_DOMAIN != "" && var.ANALYTICS_PROXY_CNAME_TARGET != "" && var.HOSTED_ZONE_NAME != "" ? 1 : 0
+
+  zone_id = data.aws_route53_zone.analytics_proxy_hosted_zone[0].zone_id
+  name    = var.ANALYTICS_PROXY_DOMAIN
+  type    = "CNAME"
+  records = [var.ANALYTICS_PROXY_CNAME_TARGET]
+  ttl     = 300
+}

--- a/_infra/main.tf
+++ b/_infra/main.tf
@@ -201,6 +201,15 @@ variable "DOCS_DOMAIN" {
   default     = ""
 }
 
+# Not a secret: this is the public ingestion token, already shipped in the
+# frontend bundle. Blank disables server-side capture, which is what a
+# non-production workspace wants so its traffic stays out of the real project.
+variable "POSTHOG_KEY" {
+  description = "PostHog project ingestion key for server-side analytics; leave blank to disable capture"
+  type        = string
+  default     = ""
+}
+
 variable "DOCS_CERT_ARN" {
   description = "ACM cert ARN in us-east-1 for docs CloudFront (required if DOCS_DOMAIN set)"
   type        = string
@@ -1781,6 +1790,10 @@ resource "aws_ecs_task_definition" "app_task" {
         {
           name  = "SUPER_ADMIN_USER_IDS"
           value = var.SUPER_ADMIN_USER_IDS
+        },
+        {
+          name  = "POSTHOG_KEY"
+          value = var.POSTHOG_KEY
         },
       ]
       secrets = [

--- a/_infra/terraform.tfvars.example
+++ b/_infra/terraform.tfvars.example
@@ -119,6 +119,18 @@ grafana_service_account_id=""                # numeric SA ID from: aws grafana l
 grafana_token_rotation_days=25               # 1-25; rotation_days + 5 must stay within 30-day AMG max
 aws_region="us-east-1"
 grafana_suffix_seed=""                       # optional; change to force a new workspace name suffix
+
+# Product analytics. All three are optional: left blank, server-side capture is
+# disabled and no analytics proxy DNS record is created, which is what a
+# non-production workspace wants so its traffic stays out of the real project.
+# POSTHOG_KEY is the public ingestion token, already shipped in the frontend
+# bundle, so it is not a credential and is fine to set via TFVAR_POSTHOG_KEY.
+# Read the analytics proxy rollout section in _infra/README.md before setting
+# the proxy values: the ordering matters and getting it wrong takes portal
+# analytics down until the next frontend deploy.
+POSTHOG_KEY=""
+ANALYTICS_PROXY_DOMAIN=""                    # e.g. e.example.com; register in PostHog first
+ANALYTICS_PROXY_CNAME_TARGET=""              # CNAME target PostHog issues for that domain
 # Secrets (managed in AWS Secrets Manager)
 # After apply, set secret values for:
 # - ${project_name}-${environment}/discord-bot-token

--- a/apps/docs-site/docs/legal/privacy.md
+++ b/apps/docs-site/docs/legal/privacy.md
@@ -82,9 +82,12 @@ We use PostHog to understand how people use the website and the web portal, so w
 
 - **Page views and clicks.** Which pages you visit and which elements you interact with, including the text and labels of what you clicked.
 - **Session replay.** A reconstruction of your session, so we can watch how a page was actually used. In the web portal this can include meeting content shown on screen, such as notes and transcript text.
-- **Technical metadata.** PostHog's SDK attaches an anonymous identifier to your browser and records the usual request details alongside each event: browser and device type, the page you came from, the page you are on, and an approximate location derived from your IP address.
+- **What you do in Discord.** Actions the bot takes on your behalf, such as starting and ending a meeting, changing a server setting, or asking a question. These record that the action happened and its shape, for example how long a meeting ran or how many people attended. They never carry the content: not notes, not transcripts, not the text of your questions, dictionary terms, or context prompts.
+- **Technical metadata.** Your browser and device type, the page you came from, and the page you are on.
 
-Two things are deliberately excluded: share link ids are stripped before anything is sent, because those act as passwords for a shared meeting, and we do not send analytics at all if your browser sends a Do Not Track signal.
+While you are signed in, these events are tied to your Discord account rather than to an anonymous browser identifier, so that your activity on the website and in Discord is understood as one person rather than two strangers. Signing out unlinks the browser from your account again.
+
+Three things are deliberately excluded: share link ids are stripped before anything is sent, because those act as passwords for a shared meeting; your IP address is discarded on arrival, so we do not derive a location from it; and we do not send analytics at all if your browser sends a Do Not Track signal.
 
 **Turning it off.** Enable Do Not Track in your browser and Chronote sends nothing to PostHog. If you would rather we exclude your account entirely, email us and we will do it.
 

--- a/apps/docs-site/docs/legal/privacy.md
+++ b/apps/docs-site/docs/legal/privacy.md
@@ -3,7 +3,7 @@ title: Privacy Policy
 slug: /legal/privacy
 ---
 
-Last updated: July 27, 2026
+Last updated: August 8, 2026
 
 This policy explains what Chronote records, what we store, who else processes it, and what you can do about it. It is written to be read by the people it affects, not only by lawyers.
 
@@ -66,7 +66,7 @@ Chronote depends on the following providers. Each one sees only what it needs to
 | Stripe              | Payments and subscription billing. Receives your Discord email address, account ID, and username so a subscription can be matched to the right person and server                                                                                                                                                                                                                                                                                                                                                                  |
 | Langfuse            | Engineering observability for the transcription and notes pipeline. Traces can include transcript and notes content, and attach a compressed copy of the meeting audio                                                                                                                                                                                                                                                                                                                                                            |
 | Notion              | Only if a user connects their Notion account, to export notes there                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| PostHog             | Product analytics for the website and web portal. See the analytics section below for what this covers                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| PostHog             | Product analytics for the website and web portal, and for what you do with Chronote in Discord. See the analytics section below for what this covers                                                                                                                                                                                                                                                                                                                                                                              |
 
 ## How long we keep things
 

--- a/apps/docs-site/docs/legal/privacy.md
+++ b/apps/docs-site/docs/legal/privacy.md
@@ -78,7 +78,7 @@ Server and application logs held in Amazon CloudWatch expire after 365 days. Acc
 
 ## Analytics
 
-We use PostHog to understand how people use the website and the web portal, so we can see where the product is confusing and what people actually do with it. This is worth stating plainly, because it is more than counting page views:
+We use PostHog to understand how people use Chronote, both on the website and in Discord, so we can see where the product is confusing and what people actually do with it. This is worth stating plainly, because it is more than counting page views:
 
 - **Page views and clicks.** Which pages you visit and which elements you interact with, including the text and labels of what you clicked.
 - **Session replay.** A reconstruction of your session, so we can watch how a page was actually used. In the web portal this can include meeting content shown on screen, such as notes and transcript text.
@@ -87,9 +87,14 @@ We use PostHog to understand how people use the website and the web portal, so w
 
 While you are signed in, these events are tied to your Discord account rather than to an anonymous browser identifier, so that your activity on the website and in Discord is understood as one person rather than two strangers. Signing out unlinks the browser from your account again.
 
-Three things are deliberately excluded: share link ids are stripped before anything is sent, because those act as passwords for a shared meeting; your IP address is discarded on arrival, so we do not derive a location from it; and we do not send analytics at all if your browser sends a Do Not Track signal.
+Two things are deliberately excluded: share link ids are stripped before anything is sent, because those act as passwords for a shared meeting, and your IP address is discarded on arrival, so we do not derive a location from it.
 
-**Turning it off.** Enable Do Not Track in your browser and Chronote sends nothing to PostHog. If you would rather we exclude your account entirely, email us and we will do it.
+**Turning it off.** These are two separate things, and it is worth being clear about which is which.
+
+- **On the website and web portal**, enable Do Not Track in your browser and Chronote sends nothing to PostHog.
+- **In Discord**, Do Not Track does not apply. It is a browser signal, and the bot never sees your browser, so actions you take through Chronote in Discord are recorded whether or not you have it enabled, including if you have never opened the portal.
+
+To opt out of both, email us and we will exclude your account. We do not yet have a self-service switch for the Discord side.
 
 ## Who can see a meeting
 
@@ -105,7 +110,7 @@ Three things are deliberately excluded: share link ids are stripped before anyth
 - **Have it removed.** Email us to have a meeting and its recording removed from storage entirely.
 - **Turn recording off.** Server admins can disable auto-record per channel or entirely, and can remove Chronote from the server at any time, which stops all recording.
 - **Correct the record.** Notes can be corrected through the correction and approval flow, so the stored record reflects what actually happened.
-- **Opt out of analytics.** Turn on Do Not Track in your browser and the site will not send analytics events.
+- **Opt out of analytics.** Turn on Do Not Track in your browser and the website and portal will not send analytics events. Do Not Track cannot cover what you do in Discord, because the bot never sees your browser, so email us to opt out of that as well.
 - **Ask us.** Email [basic@basicbit.net](mailto:basic@basicbit.net) with a data access or deletion request. We respond within 30 days.
 
 ### If you have data protection rights

--- a/apps/docs-site/docs/whats-new/analytics-in-discord.md
+++ b/apps/docs-site/docs/whats-new/analytics-in-discord.md
@@ -1,0 +1,20 @@
+---
+title: Analytics now cover what you do in Discord
+slug: /whats-new/analytics-in-discord
+---
+
+Chronote already used PostHog for product analytics on the website and web portal. It now also records what you do with Chronote inside Discord. Our [privacy policy](/legal/privacy) says we will tell you before a change like this takes effect, so this is that notice.
+
+## What changed
+
+- Actions you take through Chronote in Discord are recorded: starting and ending a meeting, changing a server setting, adding a dictionary term, asking a question, and similar.
+- These record that the action happened and its shape, for example how long a meeting ran or how many people attended. They never carry the content: not notes, not transcripts, not the text of your questions, your dictionary terms, or your context prompts.
+- While you are signed in to the portal, analytics are tied to your Discord account instead of an anonymous browser identifier, so activity on the website and in Discord is understood as one person rather than two strangers. Signing out unlinks the browser again.
+- Your IP address is now discarded on arrival, so we no longer derive an approximate location from it.
+- Session replay is enabled for the web portal. Browser console output is not captured.
+
+## Turning it off
+
+Do Not Track still works for the website and the web portal, and switching it on means we send nothing to PostHog from your browser.
+
+It cannot cover the Discord side. Do Not Track is a browser signal and the bot never sees your browser, so actions you take through Chronote in Discord are recorded whether or not you have it enabled, including if you have never opened the portal. To opt out of that, email [basic@basicbit.net](mailto:basic@basicbit.net) and we will exclude your account. There is no self-service switch for it yet.

--- a/apps/docs-site/docs/whats-new/index.md
+++ b/apps/docs-site/docs/whats-new/index.md
@@ -7,6 +7,14 @@ Notable product changes for Chronote users. For the full changelog, see the [Git
 
 ## 2026
 
+### Analytics now cover what you do in Discord
+
+- Product analytics now record actions taken through Chronote in Discord, not only on the website and web portal. They capture that an action happened and its shape, never its content.
+- While you are signed in, analytics are tied to your Discord account rather than an anonymous browser identifier. Signing out unlinks the browser again.
+- IP addresses are discarded on arrival, so we no longer derive an approximate location from them.
+- Do Not Track still covers the website and portal, but cannot cover Discord, because the bot never sees your browser. Email us to opt out of that side.
+- See [Analytics now cover what you do in Discord](/whats-new/analytics-in-discord) and the updated [privacy policy](/legal/privacy).
+
 ### Role mentions in meeting notes
 
 - Notes now mention server roles when work is assigned to a group rather than to one person.

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "passport": "^0.7.0",
     "passport-discord": "^0.1.4",
     "posthog-js": "^1.408.3",
+    "posthog-node": "^5.48.0",
     "prism-media": "^1.3.5",
     "prom-client": "15.1.3",
     "quill-delta": "^5.1.0",

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -4,6 +4,7 @@ import {
   ChannelType,
   Client,
   GatewayIntentBits,
+  Guild,
   ModalSubmitInteraction,
   Partials,
   RepliableInteraction,
@@ -123,6 +124,7 @@ import {
   onboardCommand,
 } from "./commands/onboard";
 import { fetchGuildInstaller } from "./services/guildInstallerService";
+import { captureEvent, shutdownAnalytics } from "./services/analyticsService";
 import { setDiscordClient } from "./services/discordClientAccessor";
 import { startMeetingControlCommandWorker } from "./services/meetingControlWorkerService";
 import { autoRecordJoinSuppressionService } from "./services/autoRecordJoinSuppressionService";
@@ -203,6 +205,16 @@ const invalidateBotGuildCache = async (label: string) => {
     console.warn(`${label} cache invalidation failed`, error);
   }
 };
+
+/**
+ * A guild that has just been joined has a joinedTimestamp of roughly now; one
+ * that is merely becoming available again after an outage carries its original
+ * join date. Anything inside the window counts as a real install.
+ */
+const FRESH_GUILD_JOIN_WINDOW_MS = 60_000;
+
+const isFreshGuildJoin = (guild: Guild): boolean =>
+  Date.now() - guild.joinedTimestamp < FRESH_GUILD_JOIN_WINDOW_MS;
 
 const commandHandlers: Record<
   string,
@@ -468,6 +480,18 @@ export async function setupBot() {
   client.on("guildCreate", async (guild) => {
     await invalidateBotGuildCache("guildCreate");
     await invalidateGuildCache(guild.id, "guildCreate");
+
+    // guildCreate also fires when an existing guild becomes available again
+    // after an outage, not only on a real join, so joinedTimestamp is what
+    // separates the two. Without this an outage recovery reads as a burst of
+    // installs and the cumulative count drifts upward permanently.
+    if (isFreshGuildJoin(guild)) {
+      captureEvent("server_installed", {
+        guildId: guild.id,
+        properties: { guild_count: client.guilds.cache.size },
+      });
+    }
+
     if (!config.server.onboardingEnabled) {
       return;
     }
@@ -498,6 +522,12 @@ export async function setupBot() {
   client.on("guildDelete", async (guild) => {
     await invalidateBotGuildCache("guildDelete");
     await invalidateGuildCache(guild.id, "guildDelete");
+    // Safe to trust: the gateway flags outages with `unavailable` and
+    // discord.js routes those to guildUnavailable instead of here.
+    captureEvent("server_removed", {
+      guildId: guild.id,
+      properties: { guild_count: client.guilds.cache.size },
+    });
   });
 
   client.on("guildUpdate", async (_oldGuild, newGuild) => {
@@ -1417,6 +1447,12 @@ process.on("SIGTERM", async () => {
 
   // Wait for ongoing meetings to finish
   await completeOngoingMeetings();
+
+  // Flush buffered analytics before the task goes away. posthog-node batches,
+  // so anything still in the buffer is lost otherwise, and a dropped event is
+  // never reconstructed. This handler is registered at module scope, so it
+  // covers the api-only runtime too.
+  await shutdownAnalytics();
 
   // Shut down the bot gracefully
   console.log("Shutting down...");

--- a/src/chatTts.ts
+++ b/src/chatTts.ts
@@ -9,6 +9,7 @@ import {
   chatTtsMonthlyLimitBlocked,
 } from "./metrics";
 import { resolveTtsVoice } from "./utils/ttsVoices";
+import { captureEvent } from "./services/analyticsService";
 import { formatParticipantLabel } from "./utils/participants";
 import {
   getGuildLimits,
@@ -186,6 +187,12 @@ export async function maybeSpeakChatMessage(
   }
 
   chatTtsEnqueued.inc();
+  captureEvent("chat_tts_message_spoken", {
+    userId: message.author.id,
+    guildId: meeting.guildId,
+    // Message text is user content and stays out of the event.
+    properties: { tier: monthlyLimit.compedTier ?? undefined },
+  });
   entry.source = "chat_tts";
   await sendFinalMonthlyLimitNoticeIfNeeded(
     meeting,

--- a/src/chatTts.ts
+++ b/src/chatTts.ts
@@ -112,6 +112,10 @@ async function resolveMonthlyMessageLimit(meeting: MeetingData) {
     : resolved.limits;
   return {
     limit: limits.maxChatTtsMessagesMonthly,
+    // The tier actually in force, which is what usage should be segmented by.
+    // compedTier below is only set for manually comped servers, so reporting
+    // that instead leaves the tier blank for nearly all real usage.
+    effectiveTier: meeting.subscriptionTier ?? resolved.subscription.tier,
     compedTier:
       resolved.subscription.billingSource === "manual_comp"
         ? resolved.subscription.grantTier
@@ -191,7 +195,10 @@ export async function maybeSpeakChatMessage(
     userId: message.author.id,
     guildId: meeting.guildId,
     // Message text is user content and stays out of the event.
-    properties: { tier: monthlyLimit.compedTier ?? undefined },
+    properties: {
+      tier: monthlyLimit.effectiveTier,
+      comped: monthlyLimit.compedTier !== null,
+    },
   });
   entry.source = "chat_tts";
   await sendFinalMonthlyLimitNoticeIfNeeded(

--- a/src/commands/endMeeting.ts
+++ b/src/commands/endMeeting.ts
@@ -40,6 +40,7 @@ import {
 import { evaluateAutoRecordCancellation } from "../services/autoRecordCancellationService";
 import { autoRecordJoinSuppressionService } from "../services/autoRecordJoinSuppressionService";
 import { meetingsCancelled } from "../metrics";
+import { captureEvent } from "../services/analyticsService";
 import { describeAutoRecordRule } from "../utils/meetingLifecycle";
 import {
   deleteMeeting,
@@ -91,6 +92,39 @@ async function runMeetingEndStep<T>(
 
 function shouldReleaseLeaseDuringErrorCleanup(meeting: MeetingData): boolean {
   return !meeting.finishing && !meeting.finished;
+}
+
+/**
+ * Counts and flags only. Notes, transcript, and chat content are user data and
+ * must not leave the system as event properties.
+ *
+ * Reading the meeting to build those properties happens inside the guard on
+ * purpose. This runs on the successful-completion path, so an unexpected shape
+ * here would otherwise throw into the caller's error cleanup and tear down a
+ * meeting that had already finished, for the sake of an analytics event.
+ */
+function captureMeetingCompleted(meeting: MeetingData): void {
+  try {
+    const endTime = meeting.endTime ?? new Date();
+    captureEvent("meeting_completed", {
+      userId: meeting.creator.id,
+      guildId: meeting.guildId,
+      properties: {
+        duration_ms: endTime.getTime() - meeting.startTime.getTime(),
+        attendee_count: meeting.attendance.size,
+        end_reason: meeting.endReason ?? MEETING_END_REASONS.UNKNOWN,
+        trigger: meeting.startReason,
+        transcribed: meeting.transcribeMeeting,
+        notes_generated: meeting.generateNotes,
+        cancelled: Boolean(meeting.cancelled),
+      },
+    });
+  } catch (error) {
+    console.warn("Failed to capture meeting_completed", {
+      meetingId: meeting.meetingId,
+      error,
+    });
+  }
 }
 
 function shouldFinalizeDismissedAutoRecording(meeting: MeetingData): boolean {
@@ -495,6 +529,7 @@ async function runEndMeetingFlow(options: EndMeetingFlowOptions) {
 
     meeting.setFinished();
     meeting.finished = true;
+    captureMeetingCompleted(meeting);
     deleteMeeting(meeting.guildId);
   } finally {
     try {

--- a/src/commands/endMeeting.ts
+++ b/src/commands/endMeeting.ts
@@ -47,6 +47,7 @@ import {
   endTtsOnlySession,
   getMeeting,
   hasMeeting,
+  resolveMeetingActorId,
   restoreVoiceSessionNickname,
 } from "../meetings";
 import { MEETING_END_REASONS, MEETING_STATUS } from "../types/meetingLifecycle";
@@ -99,15 +100,20 @@ function shouldReleaseLeaseDuringErrorCleanup(meeting: MeetingData): boolean {
  * must not leave the system as event properties.
  *
  * Reading the meeting to build those properties happens inside the guard on
- * purpose. This runs on the successful-completion path, so an unexpected shape
- * here would otherwise throw into the caller's error cleanup and tear down a
- * meeting that had already finished, for the sake of an analytics event.
+ * purpose. This runs on a finalization path, so an unexpected shape here would
+ * otherwise throw into the caller's error cleanup and tear down a meeting that
+ * had already finished, for the sake of an analytics event.
+ *
+ * Called from both finalization paths. A cancelled auto-recording finishes
+ * through its own branch, and skipping it there would leave those meetings
+ * emitting meeting_started with no completion, so ordinary cancellation would
+ * read as funnel abandonment.
  */
 function captureMeetingCompleted(meeting: MeetingData): void {
   try {
     const endTime = meeting.endTime ?? new Date();
     captureEvent("meeting_completed", {
-      userId: meeting.creator.id,
+      userId: resolveMeetingActorId(meeting),
       guildId: meeting.guildId,
       properties: {
         duration_ms: endTime.getTime() - meeting.startTime.getTime(),
@@ -617,6 +623,7 @@ async function handleAutoRecordCancellation(
   await saveMeetingHistoryToDatabase(meeting);
   meeting.setFinished();
   meeting.finished = true;
+  captureMeetingCompleted(meeting);
   deleteMeeting(meeting.guildId);
   return retention;
 }

--- a/src/frontend/components/SiteHeader.tsx
+++ b/src/frontend/components/SiteHeader.tsx
@@ -21,6 +21,7 @@ import { Link } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import SiteHeaderLogo from "./SiteHeaderLogo";
 import { useAuth } from "../contexts/AuthContext";
+import { resetAnalyticsIdentity } from "../services/analytics";
 
 type SiteHeaderProps = {
   showNavbarToggle?: boolean;
@@ -110,6 +111,13 @@ function LogoutButton({ authState, user, logoutUrl }: LogoutButtonProps) {
       <ActionIcon
         component="a"
         href={logoutUrl}
+        // Sign-out is a full page navigation to the server route, so the React
+        // tree is torn down and never re-renders as unauthenticated. Clearing
+        // the identity here is what actually unlinks the browser from the
+        // account, which the privacy policy says signing out does. Matters most
+        // on a shared browser, where the next person would otherwise be
+        // attributed to the previous account.
+        onClick={() => resetAnalyticsIdentity()}
         variant="outline"
         size="lg"
         aria-label="Switch account"

--- a/src/frontend/contexts/AuthContext.tsx
+++ b/src/frontend/contexts/AuthContext.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useContext, useEffect, useMemo } from "react";
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
 import { buildApiUrl } from "../services/apiClient";
 import { trpc } from "../services/trpc";
 import { identifyUser, resetAnalyticsIdentity } from "../services/analytics";
@@ -71,13 +77,22 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const logoutUrl = buildLogoutUrl(getBrowserLocation());
 
   const userId = authQuery.data?.id;
+  const wasAuthenticated = useRef(false);
   useEffect(() => {
     // "unknown" means the query is still in flight, so neither branch applies
     // yet; acting on it would reset the identity on every page load.
     if (state === "authenticated" && userId) {
       identifyUser(userId);
-    } else if (state === "unauthenticated") {
+      wasAuthenticated.current = true;
+      return;
+    }
+    // Reset only on a real authenticated -> unauthenticated transition. Doing
+    // it on every logged-out load would mint a new anonymous id each time,
+    // which breaks return-visit and funnel continuity for visitors who have
+    // never signed in.
+    if (state === "unauthenticated" && wasAuthenticated.current) {
       resetAnalyticsIdentity();
+      wasAuthenticated.current = false;
     }
   }, [state, userId]);
 

--- a/src/frontend/contexts/AuthContext.tsx
+++ b/src/frontend/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
-import React, { createContext, useContext, useMemo } from "react";
+import React, { createContext, useContext, useEffect, useMemo } from "react";
 import { buildApiUrl } from "../services/apiClient";
 import { trpc } from "../services/trpc";
+import { identifyUser, resetAnalyticsIdentity } from "../services/analytics";
 
 type AuthState = "unknown" | "authenticated" | "unauthenticated";
 
@@ -68,6 +69,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const loginUrl = buildLoginUrl(getBrowserLocation());
   const logoutUrl = buildLogoutUrl(getBrowserLocation());
+
+  const userId = authQuery.data?.id;
+  useEffect(() => {
+    // "unknown" means the query is still in flight, so neither branch applies
+    // yet; acting on it would reset the identity on every page load.
+    if (state === "authenticated" && userId) {
+      identifyUser(userId);
+    } else if (state === "unauthenticated") {
+      resetAnalyticsIdentity();
+    }
+  }, [state, userId]);
 
   const refetch = authQuery.refetch;
   const value = useMemo(

--- a/src/frontend/services/analytics.ts
+++ b/src/frontend/services/analytics.ts
@@ -69,12 +69,29 @@ export function initAnalytics() {
     // API navigation rather than full document loads.
     capture_pageview: "history_change",
     respect_dnt: true,
-    // Autocapture and session replay are deliberately left on: the product
-    // needs behavioural data and the privacy policy discloses both. Share ids
-    // are still redacted below, because those are bearer credentials rather
-    // than analytics data.
+    // Autocapture is on because the product needs behavioural data and the
+    // privacy policy discloses it. Session replay is NOT enabled here: it is
+    // gated project-side by `session_recording_opt_in`, so this config alone
+    // records nothing. Share ids are still redacted below, because those are
+    // bearer credentials rather than analytics data.
     sanitize_properties: sanitizeProperties,
   });
+}
+
+/**
+ * Ties portal activity to the same Discord user id the bot sends server-side,
+ * so a person's portal and in-Discord behaviour resolve to one person rather
+ * than two anonymous ones.
+ */
+export function identifyUser(userId: string) {
+  if (!resolveKey()) return;
+  posthog.identify(userId);
+}
+
+/** Clears the identity on logout so the next visitor is not merged into it. */
+export function resetAnalyticsIdentity() {
+  if (!resolveKey()) return;
+  posthog.reset();
 }
 
 export function track(event: string, properties?: Record<string, unknown>) {

--- a/src/meetings.ts
+++ b/src/meetings.ts
@@ -49,6 +49,7 @@ import {
   type MeetingStartReason,
 } from "./types/meetingLifecycle";
 import { meetingsStarted } from "./metrics";
+import { captureEvent } from "./services/analyticsService";
 import type { ConfigTier } from "./config/types";
 import type { ChatTtsSpeakerPrefixMode } from "./utils/ttsText";
 import { DEFAULT_CHAT_TTS_SPEAKER_PREFIX_MODE as DEFAULT_PREFIX_MODE } from "./utils/ttsText";
@@ -524,6 +525,15 @@ export async function initializeMeeting(
   addMeeting(meeting);
   if (meeting.sessionMode === "meeting") {
     meetingsStarted.inc();
+    captureEvent("meeting_started", {
+      userId: meeting.creator.id,
+      guildId: meeting.guildId,
+      properties: {
+        trigger: meeting.startReason,
+        is_auto_recording: meeting.isAutoRecording,
+        channel_id: meeting.voiceChannel.id,
+      },
+    });
   }
 
   try {

--- a/src/meetings.ts
+++ b/src/meetings.ts
@@ -54,6 +54,23 @@ import type { ConfigTier } from "./config/types";
 import type { ChatTtsSpeakerPrefixMode } from "./utils/ttsText";
 import { DEFAULT_CHAT_TTS_SPEAKER_PREFIX_MODE as DEFAULT_PREFIX_MODE } from "./utils/ttsText";
 
+/**
+ * Who to attribute a meeting's analytics to.
+ *
+ * Auto-recorded meetings are constructed with `creator: client.user`, so using
+ * the creator would file every auto-record meeting under the bot's own account
+ * and collapse all of that usage onto one profile. The member whose voice join
+ * triggered the recording is the real actor; when there is none, returning
+ * undefined lets the event fall back to a guild-scoped identity rather than
+ * inventing a person.
+ */
+export function resolveMeetingActorId(
+  meeting: MeetingData,
+): string | undefined {
+  if (meeting.startTriggeredByUserId) return meeting.startTriggeredByUserId;
+  return meeting.isAutoRecording ? undefined : meeting.creator.id;
+}
+
 const meetings = new Map<string, MeetingData>();
 
 // Since the bot can't be in multiple channels at once, we can just track a single meeting per guild, that's good enough.
@@ -526,7 +543,7 @@ export async function initializeMeeting(
   if (meeting.sessionMode === "meeting") {
     meetingsStarted.inc();
     captureEvent("meeting_started", {
-      userId: meeting.creator.id,
+      userId: resolveMeetingActorId(meeting),
       guildId: meeting.guildId,
       properties: {
         trigger: meeting.startReason,

--- a/src/meetings.ts
+++ b/src/meetings.ts
@@ -548,7 +548,6 @@ export async function initializeMeeting(
       properties: {
         trigger: meeting.startReason,
         is_auto_recording: meeting.isAutoRecording,
-        channel_id: meeting.voiceChannel.id,
       },
     });
   }

--- a/src/services/__tests__/analyticsService.test.ts
+++ b/src/services/__tests__/analyticsService.test.ts
@@ -1,0 +1,98 @@
+const capture = jest.fn();
+const shutdown = jest.fn().mockResolvedValue(undefined);
+const constructPostHog = jest.fn();
+
+jest.mock("posthog-node", () => ({
+  PostHog: class {
+    capture = capture;
+    shutdown = shutdown;
+    constructor(...args: unknown[]) {
+      constructPostHog(...args);
+    }
+  },
+}));
+
+const analyticsConfig = { posthogKey: "", posthogHost: "https://example.test" };
+
+jest.mock("../configService", () => ({
+  config: {
+    get analytics() {
+      return analyticsConfig;
+    },
+  },
+}));
+
+import { captureEvent, shutdownAnalytics } from "../analyticsService";
+
+describe("analyticsService", () => {
+  beforeEach(async () => {
+    // Drops any client cached by a previous test, so each case starts from an
+    // unconfigured service the way a fresh process would.
+    await shutdownAnalytics();
+    jest.clearAllMocks();
+    analyticsConfig.posthogKey = "";
+  });
+
+  it("does not construct a client or capture when no key is configured", () => {
+    captureEvent("meeting_started", { userId: "user-1", guildId: "guild-1" });
+
+    expect(constructPostHog).not.toHaveBeenCalled();
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it("captures with the acting user as distinct id and guild as a property", () => {
+    analyticsConfig.posthogKey = "phc_test";
+
+    captureEvent("meeting_started", {
+      userId: "user-1",
+      guildId: "guild-1",
+      properties: { trigger: "manual_command" },
+    });
+
+    expect(capture).toHaveBeenCalledWith({
+      distinctId: "user-1",
+      event: "meeting_started",
+      properties: { trigger: "manual_command", guild_id: "guild-1" },
+    });
+  });
+
+  it("namespaces the distinct id by guild when there is no acting user", () => {
+    analyticsConfig.posthogKey = "phc_test";
+
+    captureEvent("server_installed", { guildId: "guild-1" });
+
+    expect(capture).toHaveBeenCalledWith(
+      expect.objectContaining({ distinctId: "guild:guild-1" }),
+    );
+  });
+
+  it("drops an event that identifies neither a user nor a guild", () => {
+    analyticsConfig.posthogKey = "phc_test";
+
+    captureEvent("server_installed");
+
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it("never throws when the client fails", () => {
+    analyticsConfig.posthogKey = "phc_test";
+    capture.mockImplementationOnce(() => {
+      throw new Error("posthog exploded");
+    });
+
+    expect(() =>
+      captureEvent("meeting_started", { userId: "user-1" }),
+    ).not.toThrow();
+  });
+
+  it("flushes on shutdown only when a client was created", async () => {
+    await shutdownAnalytics();
+    expect(shutdown).not.toHaveBeenCalled();
+
+    analyticsConfig.posthogKey = "phc_test";
+    captureEvent("meeting_started", { userId: "user-1" });
+    await shutdownAnalytics();
+
+    expect(shutdown).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -11,6 +11,13 @@ import { config } from "./configService";
  * Properties must describe the *shape* of an action (counts, lengths, enums)
  * and never its content. Meeting notes, context prompts, and dictionary terms
  * are user data and must not leave the system as event properties.
+ *
+ * Two identifiers are sent deliberately, and they are the only two: the guild,
+ * because server-level analysis is the point of this at all, and the acting
+ * Discord user as the distinct id, so portal and bot activity resolve to one
+ * person. Anything finer grained, a channel or message id for instance, is a
+ * stable identifier wearing a property's clothes. Add one only with a question
+ * that needs it and a matching line in the privacy policy.
  */
 
 type AnalyticsProperties = Record<

--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -1,0 +1,92 @@
+import { PostHog } from "posthog-node";
+import { config } from "./configService";
+
+/**
+ * Server-side product analytics.
+ *
+ * This is deliberately separate from `metrics.ts`: those are Prometheus
+ * counters for Grafana, which are dimensionless and cannot answer "which
+ * server" or "which person". These events carry identity and properties.
+ *
+ * Properties must describe the *shape* of an action (counts, lengths, enums)
+ * and never its content. Meeting notes, context prompts, and dictionary terms
+ * are user data and must not leave the system as event properties.
+ */
+
+type AnalyticsProperties = Record<
+  string,
+  string | number | boolean | undefined
+>;
+
+type CaptureArgs = {
+  /** Discord user id of whoever took the action, when there is one. */
+  userId?: string;
+  /** Always set this when the action belongs to a guild. */
+  guildId?: string;
+  properties?: AnalyticsProperties;
+};
+
+let client: PostHog | null = null;
+
+/**
+ * No-ops when no key is configured, which keeps local dev, Jest, and CI free
+ * of analytics traffic, the same way the frontend does.
+ */
+function getClient(): PostHog | null {
+  if (!config.analytics.posthogKey) return null;
+  client ??= new PostHog(config.analytics.posthogKey, {
+    host: config.analytics.posthogHost,
+  });
+  return client;
+}
+
+/**
+ * Server-level events have no acting user, so they are keyed by guild. Person
+ * counts stay meaningful because these ids are namespaced and never collide
+ * with Discord user ids.
+ */
+function resolveDistinctId(userId?: string, guildId?: string): string | null {
+  if (userId) return userId;
+  if (guildId) return `guild:${guildId}`;
+  return null;
+}
+
+export function captureEvent(
+  event: string,
+  { userId, guildId, properties }: CaptureArgs = {},
+): void {
+  // Everything, including client construction, stays inside the guard:
+  // analytics must never take down a meeting, and building the client reads
+  // config and can throw on its own.
+  try {
+    const posthog = getClient();
+    if (!posthog) return;
+
+    const distinctId = resolveDistinctId(userId, guildId);
+    if (!distinctId) return;
+
+    posthog.capture({
+      distinctId,
+      event,
+      properties: { ...properties, guild_id: guildId },
+    });
+  } catch (error) {
+    console.warn("Analytics capture failed", { event, error });
+  }
+}
+
+/**
+ * Flushes buffered events. Deploys replace the ECS task, and posthog-node
+ * batches, so without this every event still in the buffer is lost. A dropped
+ * event is permanent: nothing later reconstructs it.
+ */
+export async function shutdownAnalytics(): Promise<void> {
+  if (!client) return;
+  try {
+    await client.shutdown();
+  } catch (error) {
+    console.warn("Analytics shutdown failed", { error });
+  } finally {
+    client = null;
+  }
+}

--- a/src/services/askFeedbackService.ts
+++ b/src/services/askFeedbackService.ts
@@ -1,4 +1,5 @@
 import { getFeedbackRepository } from "../repositories/feedbackRepository";
+import { captureEvent } from "./analyticsService";
 import type {
   FeedbackRating,
   FeedbackRecord,
@@ -64,6 +65,17 @@ export async function submitAskFeedback(params: {
   };
 
   await getFeedbackRepository().write(record);
+
+  captureEvent("feedback_submitted", {
+    userId: params.userId,
+    guildId: params.guildId,
+    properties: {
+      target: "ask_answer",
+      rating: params.rating,
+      surface: record.source,
+      has_comment: Boolean(comment),
+    },
+  });
 
   return {
     ok: true as const,

--- a/src/services/askService.ts
+++ b/src/services/askService.ts
@@ -1,5 +1,6 @@
 import { listRecentMeetingsForGuildService } from "./meetingHistoryService";
 import { config } from "./configService";
+import { captureEvent } from "./analyticsService";
 import { listDictionaryEntriesService } from "./dictionaryService";
 import { normalizeTags, parseTags } from "../utils/tags";
 import { buildUpgradeTextOnly } from "../utils/upgradePrompt";
@@ -236,6 +237,17 @@ export async function answerQuestionService(
   const tags = req.tags
     ? normalizeTags(parseTags(req.tags.join(",")))
     : undefined;
+
+  // The question text is user content, so only its shape and scope are sent.
+  captureEvent("ask_question_asked", {
+    userId: req.viewerUserId,
+    guildId,
+    properties: {
+      scope,
+      has_tag_filter: Boolean(tags?.length),
+      question_length: question.length,
+    },
+  });
 
   const maxMeetings = req.maxMeetings ?? config.ask.maxMeetings;
   let attendeeOverrideEnabled = true;

--- a/src/services/billingService.ts
+++ b/src/services/billingService.ts
@@ -211,6 +211,10 @@ export async function ensureStripeCustomer(
     metadata: {
       discord_id: user.id,
       discord_username: user.username ?? "",
+      // Lets PostHog revenue analytics join this Stripe customer to the
+      // PostHog person. Must match the distinct id used by the portal and the
+      // bot, which is the Discord user id.
+      posthog_person_distinct_id: user.id,
     },
   });
   return created.id;

--- a/src/services/chatTtsUsageService.ts
+++ b/src/services/chatTtsUsageService.ts
@@ -1,6 +1,7 @@
 import { getChatTtsUsageRepository } from "../repositories/chatTtsUsageRepository";
 import type { ChatTtsMonthlyUsage } from "../types/db";
 import { buildUpgradeTextOnly } from "../utils/upgradePrompt";
+import { captureEvent } from "./analyticsService";
 
 const USAGE_TTL_DAYS = 400;
 const USAGE_TTL_MS = USAGE_TTL_DAYS * 24 * 60 * 60 * 1000;
@@ -82,6 +83,26 @@ export async function checkChatTtsMessageUsageLimit(options: {
   });
 }
 
+/**
+ * A server running into a tier ceiling is the clearest upgrade-intent signal
+ * the product produces, so it is worth an event of its own rather than only a
+ * Prometheus counter.
+ */
+function captureLimitBlocked(params: {
+  guildId: string;
+  limit: number;
+  used: number;
+}): void {
+  captureEvent("limit_blocked", {
+    guildId: params.guildId,
+    properties: {
+      feature: "chat_tts",
+      limit: params.limit,
+      used: params.used,
+    },
+  });
+}
+
 export async function reserveChatTtsMessageUsage(options: {
   guildId: string;
   limit?: number;
@@ -96,6 +117,7 @@ export async function reserveChatTtsMessageUsage(options: {
     };
   }
   if (limit <= 0) {
+    captureLimitBlocked({ guildId, limit, used: 0 });
     return {
       ...buildStatus({ guildId, period, limit, used: 0 }),
       allowed: false,
@@ -127,12 +149,14 @@ export async function reserveChatTtsMessageUsage(options: {
   }
 
   const current = await getChatTtsUsageRepository().get(guildId, period);
+  const used = current?.acceptedMessages ?? limit;
+  captureLimitBlocked({ guildId, limit, used });
   return {
     ...buildStatus({
       guildId,
       period,
       limit,
-      used: current?.acceptedMessages ?? limit,
+      used,
     }),
     allowed: false,
     reserved: false,

--- a/src/services/configOverridesService.ts
+++ b/src/services/configOverridesService.ts
@@ -79,6 +79,15 @@ export async function setConfigOverrideForScope(
   userId: string,
 ): Promise<void> {
   const scopeId = buildScopeId(context);
+  const repository = getConfigOverridesRepository();
+  // saveAutoRecordSetting rewrites the enabled value and any supplied channel
+  // or tags on every save, so reopening a rule and saving it unchanged would
+  // otherwise count as a settings change and inflate the totals. Mirrors the
+  // existence check on the reset path below.
+  const existing = await repository.get(scopeId, configKey);
+  const unchanged =
+    existing !== undefined &&
+    JSON.stringify(existing.value) === JSON.stringify(value);
   const record: ConfigOverrideRecord = {
     scopeId,
     configKey,
@@ -86,7 +95,8 @@ export async function setConfigOverrideForScope(
     updatedAt: nowIso(),
     updatedBy: userId,
   };
-  await getConfigOverridesRepository().write(record);
+  await repository.write(record);
+  if (unchanged) return;
 
   // Setting a value and resetting to default are the two ways config changes,
   // and both flow through this pair: the settings UI, channel overrides, and

--- a/src/services/configOverridesService.ts
+++ b/src/services/configOverridesService.ts
@@ -2,6 +2,7 @@ import { getConfigOverridesRepository } from "../repositories/configOverridesRep
 import type { ConfigOverrideRecord } from "../types/db";
 import type { ConfigScope } from "../config/types";
 import { nowIso } from "../utils/time";
+import { captureEvent } from "./analyticsService";
 
 export type ConfigOverrideScopeContext = {
   scope: ConfigScope;
@@ -86,6 +87,17 @@ export async function setConfigOverrideForScope(
     updatedBy: userId,
   };
   await getConfigOverridesRepository().write(record);
+
+  // Every settings change routes through here: the settings UI, channel
+  // overrides, and autorecord all write overrides, so this one call site
+  // covers all three. The key and scope describe what was configured; the
+  // value is deliberately omitted because context prompts and note templates
+  // are user content.
+  captureEvent("setting_changed", {
+    userId,
+    guildId: context.guildId,
+    properties: { key: configKey, scope: context.scope },
+  });
 }
 
 export async function clearConfigOverrideForScope(

--- a/src/services/configOverridesService.ts
+++ b/src/services/configOverridesService.ts
@@ -106,7 +106,14 @@ export async function clearConfigOverrideForScope(
   userId?: string,
 ): Promise<void> {
   const scopeId = buildScopeId(context);
-  await getConfigOverridesRepository().remove(scopeId, configKey);
+  const repository = getConfigOverridesRepository();
+  // The removal is idempotent, and callers clear keys that were never set:
+  // saveAutoRecordSetting clears the optional channel and tag keys on every
+  // save, including for a channel being configured for the first time. Only an
+  // override that actually existed is a reset worth reporting.
+  const existing = await repository.get(scopeId, configKey);
+  await repository.remove(scopeId, configKey);
+  if (!existing) return;
 
   // Optional actor: callers that know who reset the value should pass it, and
   // the ones that do not still record that the reset happened, scoped to the

--- a/src/services/configOverridesService.ts
+++ b/src/services/configOverridesService.ts
@@ -88,22 +88,33 @@ export async function setConfigOverrideForScope(
   };
   await getConfigOverridesRepository().write(record);
 
-  // Every settings change routes through here: the settings UI, channel
-  // overrides, and autorecord all write overrides, so this one call site
-  // covers all three. The key and scope describe what was configured; the
-  // value is deliberately omitted because context prompts and note templates
-  // are user content.
+  // Setting a value and resetting to default are the two ways config changes,
+  // and both flow through this pair: the settings UI, channel overrides, and
+  // autorecord all use them. The key and scope describe what was configured;
+  // the value is deliberately omitted because context prompts and note
+  // templates are user content.
   captureEvent("setting_changed", {
     userId,
     guildId: context.guildId,
-    properties: { key: configKey, scope: context.scope },
+    properties: { key: configKey, scope: context.scope, action: "set" },
   });
 }
 
 export async function clearConfigOverrideForScope(
   context: ConfigOverrideScopeContext,
   configKey: string,
+  userId?: string,
 ): Promise<void> {
   const scopeId = buildScopeId(context);
   await getConfigOverridesRepository().remove(scopeId, configKey);
+
+  // Optional actor: callers that know who reset the value should pass it, and
+  // the ones that do not still record that the reset happened, scoped to the
+  // guild. Omitting resets entirely would make "setting_changed" read as if
+  // every override were permanent.
+  captureEvent("setting_changed", {
+    userId,
+    guildId: context.guildId,
+    properties: { key: configKey, scope: context.scope, action: "reset" },
+  });
 }

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -198,6 +198,14 @@ class ConfigService {
     superAdminUserIds: parseCsv(process.env.SUPER_ADMIN_USER_IDS),
   };
 
+  // Product analytics. Empty key disables capture entirely.
+  // The frontend points at a reverse proxy so ad blockers cannot drop events;
+  // server-side traffic has no such problem, so it goes to PostHog directly.
+  readonly analytics = {
+    posthogKey: process.env.POSTHOG_KEY || "",
+    posthogHost: process.env.POSTHOG_HOST || "https://us.i.posthog.com",
+  };
+
   readonly desktop = {
     enabled: parseBoolean(process.env.ENABLE_DESKTOP_API, this.mock.enabled),
     allowedUserIds: (() => {

--- a/src/services/dictionaryService.ts
+++ b/src/services/dictionaryService.ts
@@ -7,6 +7,7 @@ import {
   normalizeDictionaryDefinition,
   normalizeDictionaryTerm,
 } from "../utils/dictionary";
+import { captureEvent } from "./analyticsService";
 
 const sortEntries = (entries: DictionaryEntry[]) =>
   [...entries].sort((a, b) => {
@@ -61,6 +62,16 @@ export async function upsertDictionaryEntryService(params: {
   };
 
   await repository.write(entry);
+  // The term itself is user content, so only its shape is reported.
+  captureEvent("dictionary_updated", {
+    userId: params.userId,
+    guildId: params.guildId,
+    properties: {
+      action: existing ? "updated" : "added",
+      has_definition: Boolean(definition),
+      term_length: term.length,
+    },
+  });
   return entry;
 }
 

--- a/src/services/onboardingService.ts
+++ b/src/services/onboardingService.ts
@@ -7,14 +7,22 @@ export async function fetchOnboardingState(guildId: string, userId: string) {
 }
 
 export async function saveOnboardingState(state: OnboardingState) {
+  // Only a step change is an event. Reopening /onboard at the current step, or
+  // picking channels within the autorecord step, saves repeatedly without
+  // advancing, and counting those would inflate each step and make the
+  // drop-off ratios meaningless.
+  const previous = await getOnboardingRepository().get(
+    state.guildId,
+    state.userId,
+  );
   const result = await getOnboardingRepository().write(state);
-  // One event per step rather than started/completed, so a drop-off shows
-  // which step lost people instead of only that they never finished.
-  captureEvent("onboarding_step_reached", {
-    userId: state.userId,
-    guildId: state.guildId,
-    properties: { step: state.step, autorecord_mode: state.autorecordMode },
-  });
+  if (previous?.step !== state.step) {
+    captureEvent("onboarding_step_reached", {
+      userId: state.userId,
+      guildId: state.guildId,
+      properties: { step: state.step, autorecord_mode: state.autorecordMode },
+    });
+  }
   return result;
 }
 

--- a/src/services/onboardingService.ts
+++ b/src/services/onboardingService.ts
@@ -1,12 +1,21 @@
 import type { OnboardingState } from "../types/db";
 import { getOnboardingRepository } from "../repositories/onboardingRepository";
+import { captureEvent } from "./analyticsService";
 
 export async function fetchOnboardingState(guildId: string, userId: string) {
   return getOnboardingRepository().get(guildId, userId);
 }
 
 export async function saveOnboardingState(state: OnboardingState) {
-  return getOnboardingRepository().write(state);
+  const result = await getOnboardingRepository().write(state);
+  // One event per step rather than started/completed, so a drop-off shows
+  // which step lost people instead of only that they never finished.
+  captureEvent("onboarding_step_reached", {
+    userId: state.userId,
+    guildId: state.guildId,
+    properties: { step: state.step, autorecord_mode: state.autorecordMode },
+  });
+  return result;
 }
 
 export async function removeOnboardingState(guildId: string, userId: string) {

--- a/src/services/summaryFeedbackService.ts
+++ b/src/services/summaryFeedbackService.ts
@@ -1,4 +1,5 @@
 import { getFeedbackRepository } from "../repositories/feedbackRepository";
+import { captureEvent } from "./analyticsService";
 import type {
   FeedbackRating,
   FeedbackRecord,
@@ -71,6 +72,19 @@ export async function submitMeetingSummaryFeedback(params: {
   };
 
   await getFeedbackRepository().write(record);
+
+  // Downvotes feed the eval harvest, so the rating and surface are worth
+  // tracking as a trend. The comment itself is user content and stays out.
+  captureEvent("feedback_submitted", {
+    userId: params.userId,
+    guildId: params.guildId,
+    properties: {
+      target: "meeting_summary",
+      rating: params.rating,
+      surface: record.source,
+      has_comment: Boolean(comment),
+    },
+  });
 
   return {
     ok: true as const,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5268,10 +5268,22 @@
   dependencies:
     "@posthog/types" "^1.399.0"
 
+"@posthog/core@^1.46.8":
+  version "1.46.8"
+  resolved "https://registry.yarnpkg.com/@posthog/core/-/core-1.46.8.tgz#e2afb03ee9012edabbbf47af1ebb187e485bf5ee"
+  integrity sha512-WQTSwlFhsWk09xngTimHiTyhFU8QZHFZEGSm+6brY3acwYdvTLcTxpIhgl/qOCgn/XoqlCFTZqU1ldWLxNntfA==
+  dependencies:
+    "@posthog/types" "^1.401.1"
+
 "@posthog/types@^1.399.0":
   version "1.399.0"
   resolved "https://registry.yarnpkg.com/@posthog/types/-/types-1.399.0.tgz#96248f0822fa3a1c38b1882d04a77bf5349c08fe"
   integrity sha512-/WDwBzqIPko8VJ1B+0rlso2XQEz9+2sqtsY9Tqy3p1GhgTqsFakcz/PmMpAnA321LTEZVRcO6x5hAwABV4yrDw==
+
+"@posthog/types@^1.401.1":
+  version "1.402.1"
+  resolved "https://registry.yarnpkg.com/@posthog/types/-/types-1.402.1.tgz#f2d3af9b53b3ed699185d815e51eb28cb4618641"
+  integrity sha512-4PZ9wMYI8m8AqJuZ9YR1IAHGVtSnYbBVBgTevrKpzZbcSe/OUwhEV2Ks//rJh/L8eMTU8R5DrD4D/hlrOwaAiQ==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -15100,6 +15112,13 @@ posthog-js@^1.408.3:
     preact "^10.29.3"
     query-selector-shadow-dom "^1.0.1"
     web-vitals "^5.3.0"
+
+posthog-node@^5.48.0:
+  version "5.48.0"
+  resolved "https://registry.yarnpkg.com/posthog-node/-/posthog-node-5.48.0.tgz#d93c4d6644782e509fe52c4697f9350562a6eddc"
+  integrity sha512-YIH82XV24aa1nnVph1ndiW/vBN2QDIKlrHNEJcmAYutMGeoGC4WeEefg7O5aD3dDcO5dzociy8sVwXq4tNDYsQ==
+  dependencies:
+    "@posthog/core" "^1.46.8"
 
 preact@^10.29.3:
   version "10.29.7"


### PR DESCRIPTION
[AGENT]

## Summary

PostHog had no server-side path at all: `posthog-js` ran in the frontend only, so the project held three marketing-site events and nothing about how the product is actually used. This adds a capture wrapper and instruments eleven events, wires identity so the portal and the bot resolve to one person, and routes portal traffic through a PostHog-managed reverse proxy.

Event properties carry **shape** (counts, lengths, enums) and never content. Notes, context prompts, dictionary terms, and questions are user data and stay out.

## Events

`server_installed`, `server_removed`, `meeting_started`, `meeting_completed`, `setting_changed`, `dictionary_updated`, `chat_tts_message_spoken`, `ask_question_asked`, `feedback_submitted`, `onboarding_step_reached`, `limit_blocked`.

Instrumented at the shared service layer, so the Discord command and tRPC router paths are both covered from one call site each.

## Notable choices

- **`guildCreate` is not only "joined".** It also fires when a guild becomes available after an outage, so `server_installed` is gated on `joinedTimestamp`. Without that, an outage recovery reads as a burst of installs and the count drifts upward permanently, with no self-correction. `guildDelete` needs no guard: the gateway flags outages with `unavailable` and discord.js routes those to `guildUnavailable`.
- **`setConfigOverrideForScope` is the single seam** every settings write routes through, so settings, channel overrides, and autorecord are one event rather than three.
- **Onboarding reports each step reached** rather than started/completed, so a drop-off shows which step lost people.
- **Capture can never throw into a caller.** This matters most in `endMeeting`: a throw there would reach the error cleanup and tear down an already-finished meeting for the sake of an analytics event.
- **`metrics.ts` is left alone.** Those Prometheus counters are dimensionless and cannot answer "which server" or "which person", so they stay an ops concern rather than growing into a second analytics layer.
- **The count itself is not event-sourced.** `guild_count` rides along on install/remove events as a gauge read from Discord, so it self-heals on every event instead of accumulating permanent drift from any dropped one.

## Follow-ups deliberately not in this PR

- **Dashboard** — building one against zero data is guesswork; worth doing once events flow.
- **`notes_correction`** — apply logic is duplicated across the tRPC router and the Discord command with no shared service. Instrumenting one surface only would make the other look unused.
- **Group analytics** — the right model once servers are the unit of analysis, but subscribing bills all identified events in the project, so it deserves its own decision.
- **Existing Stripe customers** — `ensureStripeCustomer` only tags newly created ones; existing customers need a Stripe-side backfill before their revenue joins to a person.

## Deployment order

The proxy is a handshake, not a single change:

1. Set `TFVAR_POSTHOG_KEY`, `TFVAR_ANALYTICS_PROXY_DOMAIN`, `TFVAR_ANALYTICS_PROXY_CNAME_TARGET` on the `production` environment
2. Terraform apply, **then a backend deploy** — apply alone registers a new task definition but the service keeps the old revision
3. Wait for the PostHog proxy record to read `valid`, **then** set `VITE_POSTHOG_HOST`. Setting it earlier silently stops the portal sending until the next deploy.

Session replay, `anonymize_ips`, and console-capture-off were already applied project-side in PostHog and need no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
