### PR TITLE
[AGENT] Return 200 for docs subpaths instead of 404

### DIFF
--- a/_infra/functions/__tests__/docs-index-rewrite.test.ts
+++ b/_infra/functions/__tests__/docs-index-rewrite.test.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+
+type CloudFrontRequest = { uri: string };
+
+// Evaluated from the same file Terraform uploads, so this cannot drift from
+// what is actually deployed. CloudFront Functions declare a global `handler`
+// rather than exporting one, hence the vm rather than an import.
+const source = fs.readFileSync(
+  path.join(__dirname, "..", "docs-index-rewrite.js"),
+  "utf8",
+);
+const handler = vm.runInNewContext(`${source}\nhandler;`) as (event: {
+  request: CloudFrontRequest;
+}) => CloudFrontRequest;
+
+const rewrite = (uri: string) => handler({ request: { uri } }).uri;
+
+describe("docs index rewrite", () => {
+  it("appends index.html to trailing-slash URLs", () => {
+    // Docusaurus sets trailingSlash: true, so every sitemap URL looks like this.
+    expect(rewrite("/integrations/remote-mcp/")).toBe(
+      "/integrations/remote-mcp/index.html",
+    );
+    expect(rewrite("/")).toBe("/index.html");
+  });
+
+  it("appends /index.html to extensionless URLs", () => {
+    expect(rewrite("/integrations/remote-mcp")).toBe(
+      "/integrations/remote-mcp/index.html",
+    );
+  });
+
+  it("leaves real files alone", () => {
+    for (const uri of [
+      "/sitemap.xml",
+      "/robots.txt",
+      "/index.html",
+      "/img/chronote-mark.png",
+      "/assets/css/styles.2015c20e.css",
+    ]) {
+      expect(rewrite(uri)).toBe(uri);
+    }
+  });
+
+  it("only treats the last segment as a filename", () => {
+    // A dot earlier in the path is a directory name, not an extension.
+    expect(rewrite("/v1.2/guide")).toBe("/v1.2/guide/index.html");
+  });
+});

--- a/_infra/functions/docs-index-rewrite.js
+++ b/_infra/functions/docs-index-rewrite.js
@@ -1,0 +1,34 @@
+// Maps directory-style docs URLs onto the objects that actually exist in S3.
+//
+// The docs origin is an S3 bucket behind OAC, not an S3 website endpoint, so it
+// has no directory-index behaviour: a request for /integrations/remote-mcp/
+// finds no such key, S3 answers 403, and the distribution's custom error
+// response serves /404.html. Docusaurus then routes client-side, so a person
+// sees the right page while the response carries a 404 status. That is
+// invisible in a browser and fatal to crawlers, which believe the status.
+//
+// Rewriting the URI here means the correct object is fetched and a 200 is
+// returned. Genuine misses still fall through to the 404 response, because the
+// rewritten key does not exist either.
+
+// CloudFront invokes a global named `handler`; there is no module system and
+// nothing imports this, so it reads as unused to eslint.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+
+  if (uri.charAt(uri.length - 1) === "/") {
+    request.uri = uri + "index.html";
+    return request;
+  }
+
+  // Only the last segment decides whether this looks like a file, so a path
+  // such as /v1.2/guide is treated as a directory rather than an asset.
+  var lastSegment = uri.substring(uri.lastIndexOf("/") + 1);
+  if (lastSegment.indexOf(".") === -1) {
+    request.uri = uri + "/index.html";
+  }
+
+  return request;
+}

--- a/_infra/main.tf
+++ b/_infra/main.tf
@@ -1148,6 +1148,14 @@ resource "aws_cloudfront_distribution" "frontend" {
   aliases = var.FRONTEND_DOMAIN != "" ? [var.FRONTEND_DOMAIN] : []
 }
 
+resource "aws_cloudfront_function" "docs_index_rewrite" {
+  name    = "${local.name_prefix}-docs-index-rewrite"
+  runtime = "cloudfront-js-2.0"
+  comment = "Appends index.html to directory-style docs URLs so they return 200 instead of 404"
+  publish = true
+  code    = file("${path.module}/functions/docs-index-rewrite.js")
+}
+
 resource "aws_cloudfront_distribution" "docs" {
   #checkov:skip=CKV_AWS_86 reason: Access logging not enabled yet; will add if/when audit requirements demand it.
   #checkov:skip=CKV_AWS_310 reason: Origin failover not configured; single-origin setup is acceptable for now.
@@ -1171,6 +1179,11 @@ resource "aws_cloudfront_distribution" "docs" {
     allowed_methods        = ["GET", "HEAD"]
     cached_methods         = ["GET", "HEAD"]
 
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.docs_index_rewrite.arn
+    }
+
     forwarded_values {
       query_string = false
       cookies {
@@ -1184,6 +1197,8 @@ resource "aws_cloudfront_distribution" "docs" {
     max_ttl     = 3600
   }
 
+  # /assets/* is intentionally left without the rewrite: those requests always
+  # carry a file extension, so the function would be a no-op on the hottest path.
   ordered_cache_behavior {
     path_pattern           = "/assets/*"
     target_origin_id       = "docs-s3"


### PR DESCRIPTION
[AGENT]

## The problem

Every deep link on `docs.chronote.gg` returns **404 while rendering the correct page**.

The docs origin is an S3 bucket behind OAC rather than an S3 website endpoint, so it has no directory-index behaviour. A request for `/integrations/remote-mcp/` finds no such key, S3 answers 403, and the distribution's `custom_error_response` serves `/404.html`. Docusaurus then routes client-side, so a person sees the right page while the response carries a 404.

That is invisible in a browser and fatal to crawlers, which believe the status. Measured against production:

| Request | Status |
| --- | --- |
| `/integrations/remote-mcp/` | 404 |
| `/integrations/remote-mcp/index.html` | 200 |
| `/whats-new/` | 404 |

**16 of the 17 URLs in the docs sitemap return non-200**, so the sitemap added in #320 is currently advertising pages that read as missing. Only the homepage resolves.

## The fix

A CloudFront Function on `viewer-request` rewrites directory-style URIs onto the `index.html` that exists, so the correct object is fetched and a 200 returned. Genuine misses still reach the 404 response, because the rewritten key does not exist either.

Two deliberate details:

- **Only the last path segment decides whether a URI looks like a file**, so a path such as `/v1.2/guide` is treated as a directory rather than an asset. Checking the whole URI for a dot would break it.
- **`/assets/*` gets no function association.** Those requests always carry an extension, so the function would be a no-op on the hottest path.

## Verification

`terraform validate` passes and `terraform fmt -check` reports no drift in the touched file. Checkov is clean at 379 passed, 0 failed. The unit test evaluates the same `.js` file Terraform uploads, via `vm`, so it cannot drift from what is deployed.

Note that `yarn lint:check` only covers `src test`, but lint-staged lints staged files anywhere, and it flags the global `handler` as unused. That is CloudFront's contract rather than a mistake, so it carries a scoped disable with the reason.

## Applying

This needs `terraform plan` and a gated apply, unlike everything else in this series. Nothing takes effect on merge. After apply, a docs CloudFront invalidation clears cached 404s; the docs deploy workflow already invalidates, so the next docs deploy handles it, or run one manually.
