### PR TITLE
Keep authenticated failures off the shared desktop IP bucket

### DIFF
--- a/src/api/desktop.ts
+++ b/src/api/desktop.ts
@@ -379,6 +379,10 @@ export function registerDesktopRoutes(app: Express) {
     windowMs: DESKTOP_RATE_LIMIT_WINDOW_MS,
     limit: DESKTOP_RATE_LIMIT_MAX,
     countFailuresOnly: true,
+    // requireDesktopAuth sets desktopAuth once a token checks out, so anything
+    // that failed later (wrong scope, bad payload) is an identified caller's
+    // problem and is left to their own token bucket.
+    wasAuthenticated: (req) => Boolean((req as DesktopRequest).desktopAuth),
   });
   const tokenRateLimiter = createAuthRateLimiter({
     enabled: true,

--- a/src/api/desktop.ts
+++ b/src/api/desktop.ts
@@ -332,20 +332,34 @@ const getBearerToken = (req: Request) => {
   return header.slice("Bearer ".length).trim() || undefined;
 };
 
-const requireDesktopAuth =
+// Split from the scope check on purpose. Identifying the caller is what lets
+// the rate limiters tell an unknown token apart from a known one, so it has to
+// happen before any later rejection: a scope failure raised while the request
+// still looked anonymous would be charged to the caller's IP and spend an
+// allowance shared with everybody at that address.
+const requireDesktopToken = async (
+  req: DesktopRequest,
+  res: Response,
+  next: () => void,
+) => {
+  const token = getBearerToken(req);
+  const auth = token ? await validateDesktopAccessToken(token) : undefined;
+  if (!auth) {
+    res.status(401).json({ error: "invalid_token" });
+    return;
+  }
+  req.desktopAuth = auth;
+  next();
+};
+
+const requireDesktopScopes =
   (requiredScopes: DesktopAuthScope[] = []) =>
-  async (req: DesktopRequest, res: Response, next: () => void) => {
-    const token = getBearerToken(req);
-    const auth = token ? await validateDesktopAccessToken(token) : undefined;
-    if (!auth) {
-      res.status(401).json({ error: "invalid_token" });
-      return;
-    }
-    if (!hasDesktopScopes(auth.scopes, requiredScopes)) {
+  (req: DesktopRequest, res: Response, next: () => void) => {
+    const auth = req.desktopAuth;
+    if (!auth || !hasDesktopScopes(auth.scopes, requiredScopes)) {
       res.status(403).json({ error: "insufficient_scope" });
       return;
     }
-    req.desktopAuth = auth;
     next();
   };
 
@@ -379,9 +393,9 @@ export function registerDesktopRoutes(app: Express) {
     windowMs: DESKTOP_RATE_LIMIT_WINDOW_MS,
     limit: DESKTOP_RATE_LIMIT_MAX,
     countFailuresOnly: true,
-    // requireDesktopAuth sets desktopAuth once a token checks out, so anything
-    // that failed later (wrong scope, bad payload) is an identified caller's
-    // problem and is left to their own token bucket.
+    // requireDesktopToken sets desktopAuth as soon as a token checks out, so
+    // anything rejected after that point (wrong scope, bad payload) belongs to
+    // an identified caller and is left to their own token bucket.
     wasAuthenticated: (req) => Boolean((req as DesktopRequest).desktopAuth),
   });
   const tokenRateLimiter = createAuthRateLimiter({
@@ -570,8 +584,9 @@ export function registerDesktopRoutes(app: Express) {
   app.get(
     "/api/desktop/me",
     rejectedRateLimiter,
-    requireDesktopAuth(REQUIRED_PROFILE_SCOPES),
+    requireDesktopToken,
     tokenRateLimiter,
+    requireDesktopScopes(REQUIRED_PROFILE_SCOPES),
     (req: DesktopRequest, res) => {
       const user = getDesktopUser(req);
       res.json({
@@ -586,8 +601,9 @@ export function registerDesktopRoutes(app: Express) {
   app.post(
     "/api/desktop/recordings/session",
     rejectedRateLimiter,
-    requireDesktopAuth(REQUIRED_UPLOAD_SCOPES),
+    requireDesktopToken,
     tokenRateLimiter,
+    requireDesktopScopes(REQUIRED_UPLOAD_SCOPES),
     async (req: DesktopRequest, res) => {
       try {
         const input = recordingSessionSchema.parse(req.body);
@@ -607,8 +623,9 @@ export function registerDesktopRoutes(app: Express) {
   app.post(
     "/api/desktop/recordings/segment-intent",
     rejectedRateLimiter,
-    requireDesktopAuth(REQUIRED_UPLOAD_SCOPES),
+    requireDesktopToken,
     tokenRateLimiter,
+    requireDesktopScopes(REQUIRED_UPLOAD_SCOPES),
     async (req: DesktopRequest, res) => {
       try {
         const input = recordingSegmentIntentSchema.parse(req.body);
@@ -628,8 +645,9 @@ export function registerDesktopRoutes(app: Express) {
   app.post(
     "/api/desktop/recordings/segment-complete",
     rejectedRateLimiter,
-    requireDesktopAuth(REQUIRED_UPLOAD_SCOPES),
+    requireDesktopToken,
     tokenRateLimiter,
+    requireDesktopScopes(REQUIRED_UPLOAD_SCOPES),
     async (req: DesktopRequest, res) => {
       try {
         const input = recordingSegmentCompleteSchema.parse(req.body);
@@ -649,8 +667,9 @@ export function registerDesktopRoutes(app: Express) {
   app.post(
     "/api/desktop/recordings/submit",
     rejectedRateLimiter,
-    requireDesktopAuth(REQUIRED_UPLOAD_SCOPES),
+    requireDesktopToken,
     tokenRateLimiter,
+    requireDesktopScopes(REQUIRED_UPLOAD_SCOPES),
     async (req: DesktopRequest, res) => {
       try {
         const input = recordingSubmitSchema.parse(req.body);
@@ -672,8 +691,9 @@ export function registerDesktopRoutes(app: Express) {
   app.get(
     "/api/desktop/recordings/:uploadId",
     rejectedRateLimiter,
-    requireDesktopAuth(REQUIRED_UPLOAD_SCOPES),
+    requireDesktopToken,
     tokenRateLimiter,
+    requireDesktopScopes(REQUIRED_UPLOAD_SCOPES),
     async (req: DesktopRequest, res) => {
       try {
         const user = getDesktopUser(req);

--- a/src/services/__tests__/authRateLimitService.test.ts
+++ b/src/services/__tests__/authRateLimitService.test.ts
@@ -1,0 +1,92 @@
+/** @jest-environment node */
+
+import { describe, expect, test } from "@jest/globals";
+import express from "express";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { createAuthRateLimiter } from "../authRateLimitService";
+
+const AUTHENTICATED_HEADER = "x-test-authenticated";
+
+// One window wide enough that nothing expires mid-test, and a limit small
+// enough to reach in three requests.
+const startServer = (options: { wasAuthenticated?: boolean }) => {
+  const app = express();
+  app.use(
+    createAuthRateLimiter({
+      enabled: true,
+      windowMs: 60_000,
+      limit: 2,
+      countFailuresOnly: true,
+      ...(options.wasAuthenticated === undefined
+        ? {}
+        : {
+            wasAuthenticated: (req) =>
+              req.headers[AUTHENTICATED_HEADER] === "yes",
+          }),
+    }),
+  );
+  app.get("/rejects", (_req, res) => {
+    res.status(400).json({ error: "invalid_request" });
+  });
+
+  const server = app.listen(0);
+  const { port } = server.address() as AddressInfo;
+  return { server, baseUrl: `http://127.0.0.1:${port}` };
+};
+
+const closeServer = async (server: http.Server) =>
+  new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+
+const statusesFor = async (baseUrl: string, authenticated: boolean) => {
+  const statuses: number[] = [];
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const response = await fetch(`${baseUrl}/rejects`, {
+      headers: authenticated ? { [AUTHENTICATED_HEADER]: "yes" } : {},
+    });
+    statuses.push(response.status);
+  }
+  return statuses;
+};
+
+describe("auth rate limiter", () => {
+  test("counts rejected requests when no authentication predicate is given", async () => {
+    const { server, baseUrl } = startServer({});
+
+    try {
+      await expect(statusesFor(baseUrl, false)).resolves.toEqual([
+        400, 400, 429,
+      ]);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  test("still counts rejections that never authenticated", async () => {
+    const { server, baseUrl } = startServer({ wasAuthenticated: true });
+
+    try {
+      await expect(statusesFor(baseUrl, false)).resolves.toEqual([
+        400, 400, 429,
+      ]);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  test("does not count rejections from an authenticated caller", async () => {
+    const { server, baseUrl } = startServer({ wasAuthenticated: true });
+
+    try {
+      // Without the predicate these would exhaust the bucket, taking the
+      // allowance away from every other caller sharing this key.
+      await expect(statusesFor(baseUrl, true)).resolves.toEqual([
+        400, 400, 400,
+      ]);
+    } finally {
+      await closeServer(server);
+    }
+  });
+});

--- a/src/services/authRateLimitService.ts
+++ b/src/services/authRateLimitService.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import type { RequestHandler } from "express";
+import type { Request, RequestHandler } from "express";
 import { ipKeyGenerator, rateLimit } from "express-rate-limit";
 
 type AuthRateLimitConfig = {
@@ -17,6 +17,12 @@ type AuthRateLimitConfig = {
   // an auth check: rejected calls are charged to the caller's address, while
   // authenticated traffic passes through to be counted per token instead.
   countFailuresOnly?: boolean;
+  // Narrows countFailuresOnly to failures that never got past authentication.
+  // A failure raised further along (wrong scope, bad payload) belongs to an
+  // identified caller and must not land on a shared IP bucket, or one signed-in
+  // account can spend the whole allowance for everyone behind an office, school
+  // or VPN address just by sending requests its token cannot satisfy.
+  wasAuthenticated?: (req: Request) => boolean;
 };
 
 const bearerTokenKey = (authorization?: string) => {
@@ -36,6 +42,7 @@ export const createAuthRateLimiter = ({
   limit,
   perBearerToken = false,
   countFailuresOnly = false,
+  wasAuthenticated,
 }: AuthRateLimitConfig): RequestHandler => {
   if (!enabled) {
     return passThrough;
@@ -48,6 +55,12 @@ export const createAuthRateLimiter = ({
     legacyHeaders: false,
     message: "Too many authentication attempts, please try again later.",
     skipSuccessfulRequests: countFailuresOnly,
+    ...(countFailuresOnly && wasAuthenticated
+      ? {
+          requestWasSuccessful: (req, res) =>
+            res.statusCode < 400 || wasAuthenticated(req),
+        }
+      : {}),
     ...(perBearerToken
       ? {
           keyGenerator: (req) =>

--- a/test/api/desktop.test.ts
+++ b/test/api/desktop.test.ts
@@ -133,7 +133,13 @@ const expectSuccess = async (response: Response) => {
 const createPkceChallenge = (codeVerifier: string) =>
   crypto.createHash("sha256").update(codeVerifier).digest("base64url");
 
-const buildAuthorizeUrl = (baseUrl: string, redirectUri: string) => {
+const ALL_DESKTOP_SCOPES = "profile:read personal_uploads:write meetings:read";
+
+const buildAuthorizeUrl = (
+  baseUrl: string,
+  redirectUri: string,
+  scope = ALL_DESKTOP_SCOPES,
+) => {
   const codeVerifier = "A".repeat(64);
   const authorizeUrl = new URL(`${baseUrl}/api/desktop/auth/authorize`);
   authorizeUrl.searchParams.set("response_type", "code");
@@ -143,10 +149,7 @@ const buildAuthorizeUrl = (baseUrl: string, redirectUri: string) => {
     createPkceChallenge(codeVerifier),
   );
   authorizeUrl.searchParams.set("code_challenge_method", "S256");
-  authorizeUrl.searchParams.set(
-    "scope",
-    "profile:read personal_uploads:write meetings:read",
-  );
+  authorizeUrl.searchParams.set("scope", scope);
   authorizeUrl.searchParams.set("state", "desktop-state");
   return { authorizeUrl, codeVerifier };
 };
@@ -159,10 +162,15 @@ const extractConsentToken = (html: string) => {
   return match[1];
 };
 
-const requestDesktopConsent = async (baseUrl: string, redirectUri: string) => {
+const requestDesktopConsent = async (
+  baseUrl: string,
+  redirectUri: string,
+  scope?: string,
+) => {
   const { authorizeUrl, codeVerifier } = buildAuthorizeUrl(
     baseUrl,
     redirectUri,
+    scope,
   );
   const response = await fetch(authorizeUrl, { redirect: "manual" });
   await expectSuccess(response);
@@ -184,11 +192,12 @@ const submitDesktopConsent = async (
     redirect: "manual",
   });
 
-const authorizeDesktopToken = async (baseUrl: string) => {
+const authorizeDesktopToken = async (baseUrl: string, scope?: string) => {
   const redirectUri = "http://127.0.0.1:49152/auth/callback";
   const { consentToken, codeVerifier } = await requestDesktopConsent(
     baseUrl,
     redirectUri,
+    scope,
   );
 
   const authorizeResponse = await submitDesktopConsent(
@@ -416,6 +425,36 @@ describe("desktop API", () => {
       }
 
       expect(limited).toBe(true);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  test("rejects an upload whose token lacks the scope", async () => {
+    const { server, baseUrl } = createServer();
+
+    try {
+      const token = await authorizeDesktopToken(baseUrl, "profile:read");
+      const response = await fetch(
+        `${baseUrl}/api/desktop/recordings/session`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token.access_token}`,
+          },
+          body: JSON.stringify({
+            sources: [
+              { sourceId: "owner_mic", kind: "owner_mic", label: "Me" },
+            ],
+          }),
+        },
+      );
+
+      expect(response.status).toBe(403);
+      await expect(readJson<{ error: string }>(response)).resolves.toEqual(
+        expect.objectContaining({ error: "insufficient_scope" }),
+      );
     } finally {
       await closeServer(server);
     }


### PR DESCRIPTION
[AGENT]

## Summary

- Follow-up to #333, addressing the last Codex P2 on it, which was still open when that PR merged.
- `countFailuresOnly` charged every 4xx to the caller's address rather than only the failures that never authenticated. A signed-in account sending requests its token cannot satisfy (wrong scope, bad payload) could spend the whole address allowance and lock out every other desktop user behind the same office, school or VPN address. That is the shared-IP problem the two-limiter split existed to remove, one layer further in.
- The IP limiter now treats a request that got past `requireDesktopAuth` as not counting, via `requestWasSuccessful`. Failures that never authenticated still count, so rotating bearer values stays bounded, and identified callers are bounded by their own token bucket.

## Testing note

Tested at the limiter rather than over HTTP, deliberately. The desktop routes share a 60 second window, so an HTTP-level test spends longer on setup (two consent flows plus 60+ requests) than the window lasts and ends up measuring a fresh bucket. My first attempt at an HTTP test passed with the fix reverted for exactly that reason. The unit test uses a limit of 2 and fails without the `requestWasSuccessful` wiring.

## Still open from #333

The desktop client cliff at the per-source duration cap is unaddressed and now in production: `upload_manifest_segments` aborts on the first rejected segment and never reaches `submit_recording_upload`, so a recording that passes the cap loses the valid audio before it too. The client has no maximum duration and no auto-stop, so it is reachable by anyone who leaves a recording running. Tracked on that thread, needs a decision on client fix versus server-side truncation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
