### PR TITLE
Retry transient dependency installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           cache: "yarn"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Run ESLint
         run: yarn lint:check
@@ -42,7 +42,7 @@ jobs:
           cache: "yarn"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Run Prettier
         run: yarn prettier:check
@@ -61,7 +61,7 @@ jobs:
           cache: "yarn"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Run markdownlint
         run: yarn markdownlint:check
@@ -80,7 +80,7 @@ jobs:
           cache: "yarn"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Run Langfuse prompt check
         env:
@@ -109,7 +109,7 @@ jobs:
           cache: "yarn"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Run Langfuse LLM connection check
         env:
@@ -138,7 +138,7 @@ jobs:
           cache: "yarn"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Run Jest
         run: yarn test
@@ -157,7 +157,7 @@ jobs:
           cache: "yarn"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Build backend and frontend
         run: yarn build:all
@@ -198,7 +198,7 @@ jobs:
           cache: "yarn"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Build and validate docs
         run: yarn docs:check
@@ -217,7 +217,7 @@ jobs:
           cache: "yarn"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       # UI changes are expected to ship Storybook screenshots, so the build has
       # to stay green. A build is sufficient: a preview-level transform failure
@@ -254,7 +254,7 @@ jobs:
           cache: "yarn"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Get Playwright version
         id: pw-version
@@ -302,7 +302,7 @@ jobs:
           cache: "yarn"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile --ignore-scripts
+        run: bash scripts/ci-install-dependencies.sh --ignore-scripts
 
       - name: Get Playwright version
         id: pw-version-visual

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -28,7 +28,7 @@ jobs:
           cache-dependency-path: "yarn.lock"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Run linter
         run: yarn lint
@@ -48,7 +48,7 @@ jobs:
           cache-dependency-path: "yarn.lock"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Run markdownlint
         run: yarn markdownlint:check
@@ -68,7 +68,7 @@ jobs:
           cache-dependency-path: "yarn.lock"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Run tests
         id: run-tests
@@ -134,7 +134,7 @@ jobs:
           cache-dependency-path: "yarn.lock"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Build TypeScript
         run: yarn build
@@ -188,7 +188,7 @@ jobs:
           cache-dependency-path: "yarn.lock"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Build and validate docs
         run: yarn docs:check
@@ -210,7 +210,7 @@ jobs:
           cache-dependency-path: "yarn.lock"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Get Playwright version
         id: pw-version
@@ -625,7 +625,7 @@ jobs:
           cache-dependency-path: "yarn.lock"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Build frontend (Vite)
         run: yarn build:web
@@ -677,7 +677,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.docs-config.outputs.enabled == 'true'
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Build docs site
         if: steps.docs-config.outputs.enabled == 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
           cache-dependency-path: "yarn.lock"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Run ESLint
         run: yarn lint:check
@@ -50,7 +50,7 @@ jobs:
           cache-dependency-path: "yarn.lock"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Run Prettier
         run: yarn prettier:check
@@ -70,7 +70,7 @@ jobs:
           cache-dependency-path: "yarn.lock"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Run markdownlint
         run: yarn markdownlint:check
@@ -90,7 +90,7 @@ jobs:
           cache-dependency-path: "yarn.lock"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Run Jest
         run: yarn test
@@ -110,7 +110,7 @@ jobs:
           cache-dependency-path: "yarn.lock"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Build backend and frontend
         run: yarn build:all
@@ -164,7 +164,7 @@ jobs:
           cache-dependency-path: "yarn.lock"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Build and validate docs
         run: yarn docs:check
@@ -239,7 +239,7 @@ jobs:
           cache-dependency-path: "yarn.lock"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Get Playwright version
         id: pw-version
@@ -611,7 +611,7 @@ jobs:
           cache-dependency-path: "yarn.lock"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Build frontend (Vite)
         run: yarn build:web
@@ -675,7 +675,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.docs-config.outputs.enabled == 'true'
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Build docs site
         if: steps.docs-config.outputs.enabled == 'true'
@@ -740,7 +740,7 @@ jobs:
           cache-dependency-path: "yarn.lock"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: bash scripts/ci-install-dependencies.sh
 
       - name: Show pending prompt changes
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,14 @@ COPY package*.json ./
 COPY yarn.lock ./
 COPY patches ./patches
 
-# Install dependencies
-RUN npx yarn install --frozen-lockfile
+# Install dependencies. Package registries can return brief 5xx responses, so
+# keep image builds resilient without hiding persistent failures.
+RUN for attempt in 1 2 3; do \
+      npx yarn install --frozen-lockfile --network-timeout 600000 && exit 0; \
+      if [ "$attempt" -eq 3 ]; then exit 1; fi; \
+      echo "Dependency installation failed on attempt $attempt. Retrying in 15 seconds."; \
+      sleep 15; \
+    done
 
 # Copy the rest of the application code
 COPY . .

--- a/scripts/ci-install-dependencies.sh
+++ b/scripts/ci-install-dependencies.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MAX_ATTEMPTS=3
+RETRY_DELAY_SECONDS=15
+
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+  if yarn install --frozen-lockfile --network-timeout 600000 "$@"; then
+    exit 0
+  fi
+
+  if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
+    echo "::error::Dependency installation failed after $MAX_ATTEMPTS attempts."
+    exit 1
+  fi
+
+  echo "::warning::Dependency installation failed on attempt $attempt. Retrying in $RETRY_DELAY_SECONDS seconds."
+  sleep "$RETRY_DELAY_SECONDS"
+done


### PR DESCRIPTION
[AGENT]

## Summary

- retry frozen Yarn installs up to three times when the package registry returns a transient failure
- use the same helper across CI, production deploy, and staging deploy workflows
- give the Docker dependency layer the same bounded retry behavior

This unblocks the merged artifact-access release after repeated production attempts failed on varying registry tarball 502 responses before any deploy job ran.

## Validation

- shell syntax and retry/argument-forwarding behavior
- Prettier and `git diff --check`
- actionlint across all changed workflows

## Docs

No user-facing product behavior changes; this is deployment resilience only (`docs-exempt`).
