### PR TITLE
Account for Chronote AI costs in Langfuse

### DIFF
--- a/.codex/skills/chronote-product-analytics/SKILL.md
+++ b/.codex/skills/chronote-product-analytics/SKILL.md
@@ -20,6 +20,11 @@ visitors, authenticated product users, guilds, and AI generations distinct.
   of aggregate completion, not a proven one-to-one pairing.
 - Use the `langfuse-metrics` skill for aggregate model volume, cost, and
   latency. Do not treat healthy telemetry as output-quality evidence.
+- For the daily operating view, run its `cost-report` command over the same UTC
+  window as PostHog. Supply completed meetings and transcribed minutes as
+  denominators, and report fully-unpriced model groups alongside attributed
+  cost. This is operational cost accounting, not an OpenAI invoice
+  reconciliation.
 - Do not retrieve questions, answers, notes, transcripts, or identities when
   aggregate evidence answers the request.
 

--- a/.codex/skills/chronote-product-analytics/SKILL.md
+++ b/.codex/skills/chronote-product-analytics/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: chronote-product-analytics
+description: Analyze Chronote product adoption with PostHog and Langfuse, including active users, meetings, feature usage, AI telemetry, and privacy-safe resolution of active Discord guild IDs to live server names.
+---
+
+# Chronote Product Analytics
+
+Use PostHog for product behavior and Langfuse for model telemetry. Keep website
+visitors, authenticated product users, guilds, and AI generations distinct.
+
+## Product metrics
+
+- Confirm the active PostHog project is `Chronote` before querying.
+- Read the live event schema before relying on event or property names.
+- Unless the user chooses another definition, count a product-active user as a
+  unique person who emitted `meeting_started`, `meeting_completed`, or
+  `ask_question_asked`. Report anonymous website visitors separately.
+- Use bounded UTC ranges. State whether the current day is partial.
+- Report meeting starts and completions separately. Equal totals are evidence
+  of aggregate completion, not a proven one-to-one pairing.
+- Use the `langfuse-metrics` skill for aggregate model volume, cost, and
+  latency. Do not treat healthy telemetry as output-quality evidence.
+- Do not retrieve questions, answers, notes, transcripts, or identities when
+  aggregate evidence answers the request.
+
+## Resolve active guild names
+
+PostHog intentionally stores `guild_id`, not the mutable guild name. Group the
+requested product events by `guild_id` first, including only the counts and
+time bounds needed for the question.
+
+Resolve names in this order:
+
+1. Match IDs visible in the signed-in Chronote server picker when the operator
+   already has access.
+2. For remaining IDs, run
+   [`scripts/resolve-production-guilds.mjs`](scripts/resolve-production-guilds.mjs)
+   with authorized production AWS access:
+
+   ```text
+   node .codex/skills/chronote-product-analytics/scripts/resolve-production-guilds.mjs --guild-id <id> --guild-id <id>
+   ```
+
+   The helper reads `meeting-notes-prod/discord-bot-token` from Secrets Manager
+   in `us-east-1`, verifies that Discord identifies it as the Chronote bot, and
+   prints only the requested IDs and names. Override `--secret-id`, `--region`,
+   or `--expected-bot-id` only when the target environment is explicitly
+   different.
+
+3. If AWS authentication is unavailable, stop and request the appropriate
+   read-only login. Do not substitute an unrelated local bot token, dispatch a
+   workflow, expose a secret, or persist guild names into analytics.
+
+Treat an ID absent from the bot guild list as unresolved; it may represent a
+removed installation or the wrong environment. Report that distinction rather
+than guessing a server name.
+
+This skill is read-only. It does not authorize production configuration,
+analytics instrumentation, billing, deployment, or Discord mutations.

--- a/.codex/skills/chronote-product-analytics/agents/openai.yaml
+++ b/.codex/skills/chronote-product-analytics/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Chronote Product Analytics"
+  short_description: "Analyze adoption and resolve active guilds"

--- a/.codex/skills/chronote-product-analytics/scripts/resolve-production-guilds.mjs
+++ b/.codex/skills/chronote-product-analytics/scripts/resolve-production-guilds.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+import {
+  GetSecretValueCommand,
+  SecretsManagerClient,
+} from "@aws-sdk/client-secrets-manager";
+
+const DEFAULT_REGION = "us-east-1";
+const DEFAULT_SECRET_ID = "meeting-notes-prod/discord-bot-token";
+const CHRONOTE_BOT_ID = "1278729036528619633";
+const SNOWFLAKE_PATTERN = /^\d{17,20}$/;
+
+const fail = (message) => {
+  throw new Error(message);
+};
+
+const parseArgs = (argv) => {
+  const options = { guildIds: [] };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--guild-id") {
+      const value = argv[index + 1];
+      if (!value) fail("Missing value for --guild-id");
+      options.guildIds.push(value);
+      index += 1;
+      continue;
+    }
+    if (
+      ["--region", "--secret-id", "--expected-bot-id", "--token-env"].includes(
+        argument,
+      )
+    ) {
+      const value = argv[index + 1];
+      if (!value) fail(`Missing value for ${argument}`);
+      options[argument.slice(2)] = value;
+      index += 1;
+      continue;
+    }
+    fail(`Unexpected argument: ${argument}`);
+  }
+  if (options.guildIds.length === 0) fail("Provide at least one --guild-id");
+  options.guildIds = [...new Set(options.guildIds)];
+  for (const guildId of options.guildIds) {
+    if (!SNOWFLAKE_PATTERN.test(guildId))
+      fail(`Invalid Discord guild ID: ${guildId}`);
+  }
+  return options;
+};
+
+const extractToken = (secretString) => {
+  const trimmed = secretString?.trim();
+  if (!trimmed) fail("The Discord bot token secret is empty");
+  if (!trimmed.startsWith("{")) return trimmed;
+  try {
+    const parsed = JSON.parse(trimmed);
+    const token = parsed.token ?? parsed.DISCORD_BOT_TOKEN;
+    if (typeof token === "string" && token.trim()) return token.trim();
+  } catch {
+    // Fall through to the non-sensitive error below.
+  }
+  fail("The Discord bot token secret has an unsupported JSON shape");
+};
+
+const readToken = async (options) => {
+  if (options["token-env"]) {
+    const token = process.env[options["token-env"]];
+    if (!token) fail(`Environment variable ${options["token-env"]} is not set`);
+    return token;
+  }
+  const client = new SecretsManagerClient({
+    region: options.region ?? DEFAULT_REGION,
+  });
+  let response;
+  try {
+    response = await client.send(
+      new GetSecretValueCommand({
+        SecretId: options["secret-id"] ?? DEFAULT_SECRET_ID,
+      }),
+    );
+  } finally {
+    client.destroy();
+  }
+  if (response.SecretString) return extractToken(response.SecretString);
+  if (response.SecretBinary) {
+    return extractToken(Buffer.from(response.SecretBinary).toString("utf8"));
+  }
+  fail("The Discord bot token secret has no value");
+};
+
+const discordGet = async (token, path) => {
+  const response = await fetch(`https://discord.com/api/v10${path}`, {
+    headers: { Authorization: `Bot ${token}` },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!response.ok) {
+    fail(`Discord HTTP ${response.status} while reading ${path.split("?")[0]}`);
+  }
+  return response.json();
+};
+
+const listGuilds = async (token) => {
+  const guilds = [];
+  let after;
+  while (true) {
+    const query = new URLSearchParams({ limit: "200" });
+    if (after) query.set("after", after);
+    const page = await discordGet(token, `/users/@me/guilds?${query}`);
+    if (!Array.isArray(page)) fail("Discord returned an invalid guild list");
+    guilds.push(...page);
+    if (page.length < 200) return guilds;
+    after = page.at(-1)?.id;
+    if (!after) fail("Discord guild pagination did not provide a cursor");
+  }
+};
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  const token = await readToken(options);
+  const bot = await discordGet(token, "/users/@me");
+  const expectedBotId = options["expected-bot-id"] ?? CHRONOTE_BOT_ID;
+  if (bot.id !== expectedBotId) {
+    fail(
+      `Refusing lookup: credential belongs to bot ${bot.id}, expected ${expectedBotId}`,
+    );
+  }
+
+  const guilds = await listGuilds(token);
+  const namesById = new Map(guilds.map((guild) => [guild.id, guild.name]));
+  const results = options.guildIds.map((guildId) => ({
+    guildId,
+    name: namesById.get(guildId) ?? null,
+    installed: namesById.has(guildId),
+  }));
+
+  console.log(
+    JSON.stringify(
+      {
+        bot: { id: bot.id, username: bot.username },
+        requestedGuildCount: options.guildIds.length,
+        matchedGuildCount: results.filter((result) => result.installed).length,
+        results,
+      },
+      null,
+      2,
+    ),
+  );
+} catch (error) {
+  console.error(error instanceof Error ? error.message : "Guild lookup failed");
+  process.exitCode = 1;
+}

--- a/.codex/skills/langfuse-metrics/SKILL.md
+++ b/.codex/skills/langfuse-metrics/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: langfuse-metrics
+description: Query aggregate Langfuse cost, volume, latency, and model telemetry efficiently with Metrics API v2. Use for dashboards, rollout checks, usage summaries, and cost or latency comparisons; use Observations API v2 instead when individual rows are actually required.
+---
+
+# Langfuse Metrics
+
+Prefer one bounded `GET /api/public/v2/metrics` query over downloading and
+aggregating observations. Metrics queries return aggregates and avoid exposing
+prompt or output content.
+
+Use [`scripts/query-metrics-v2.mjs`](scripts/query-metrics-v2.mjs):
+
+```text
+node .codex/skills/langfuse-metrics/scripts/query-metrics-v2.mjs summary --from 2026-08-26T00:00:00Z --model-prefix gpt-5.6-
+node .codex/skills/langfuse-metrics/scripts/query-metrics-v2.mjs query --file query.json
+```
+
+The helper reads `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and optional
+`LANGFUSE_BASE_URL` (Chronote defaults to the US cloud host). `summary` makes a
+single request grouped by provided model and observation name, returning count,
+total cost, average latency, and p95 latency. Use `--dry-run` to inspect the
+query without sending it.
+
+Keep queries bounded with explicit UTC `fromTimestamp` and `toTimestamp`.
+Start with the dimensions and metrics needed to answer the question; do not add
+time buckets or high row limits speculatively. Metrics API v2 supports at most
+1,000 rows and does not permit grouping by high-cardinality identifiers such as
+trace, session, or user IDs.
+
+Before interpreting an empty result as no traffic, check ingestion freshness.
+Data from Langfuse Python SDK versions before 4.7 or JS/TS versions before 5.4
+can appear in v2 endpoints up to 15 minutes late.
+
+If row-level investigation is necessary, use `GET /api/public/v2/observations`
+with bounded `fromStartTime` and `toStartTime`, selective `fields`, and cursor
+pagination. Do not use deprecated `/api/public/observations` or page-based
+pagination. Omit the `io` field group unless the task genuinely requires user
+content and that access is authorized.
+
+On HTTP 429, honor `Retry-After`. The helper retries once only when the wait is
+60 seconds or less; otherwise it stops and reports the wait. Do not work around
+an organization-wide quota by rotating project keys. Langfuse applies rate
+limits to organization-level resource buckets shared by its projects and keys.
+
+Aggregate health does not prove output quality. Report routing/configuration,
+traffic, latency, cost, and error evidence separately from representative
+workload or human quality validation. This skill is read-only and does not
+authorize prompt, model-routing, evaluator, or production configuration writes.
+
+Current official references:
+
+- https://langfuse.com/docs/metrics/features/metrics-api
+- https://langfuse.com/guides/cookbook/example_metrics_api_v2
+- https://langfuse.com/docs/api-and-data-platform/features/observations-api

--- a/.codex/skills/langfuse-metrics/SKILL.md
+++ b/.codex/skills/langfuse-metrics/SKILL.md
@@ -21,7 +21,8 @@ The helper reads `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and optional
 `LANGFUSE_BASE_URL` (Chronote defaults to the US cloud host). `summary` makes a
 single request grouped by provided model and observation name, returning count,
 total cost, average latency, and p95 latency. Use `--dry-run` to inspect the
-query without sending it.
+query without sending it. `--model-prefix` is sent as a Metrics v2 `starts
+with` filter so matching happens before the server's 1,000-row limit.
 
 `cost-report` uses that same single aggregate query to return attributed cost,
 cost by model and feature, known fully-unpriced model groups, and group-based

--- a/.codex/skills/langfuse-metrics/SKILL.md
+++ b/.codex/skills/langfuse-metrics/SKILL.md
@@ -13,6 +13,7 @@ Use [`scripts/query-metrics-v2.mjs`](scripts/query-metrics-v2.mjs):
 
 ```text
 node .codex/skills/langfuse-metrics/scripts/query-metrics-v2.mjs summary --from 2026-08-26T00:00:00Z --model-prefix gpt-5.6-
+node .codex/skills/langfuse-metrics/scripts/query-metrics-v2.mjs cost-report --from 2026-08-26T00:00:00Z --to 2026-08-27T00:00:00Z --completed-meetings 12 --transcribed-minutes 347
 node .codex/skills/langfuse-metrics/scripts/query-metrics-v2.mjs query --file query.json
 ```
 
@@ -21,6 +22,14 @@ The helper reads `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and optional
 single request grouped by provided model and observation name, returning count,
 total cost, average latency, and p95 latency. Use `--dry-run` to inspect the
 query without sending it.
+
+`cost-report` uses that same single aggregate query to return attributed cost,
+cost by model and feature, known fully-unpriced model groups, and group-based
+cost coverage. Pass PostHog's completed-meeting count and the application's
+transcribed-minute denominator when available to add unit costs. Do not call
+the coverage ratio exact: a group with some cost may still contain individual
+unpriced observations. Keep any unpriced TTS, image, or provider activity
+visible rather than estimating dollars from unrelated units.
 
 Keep queries bounded with explicit UTC `fromTimestamp` and `toTimestamp`.
 Start with the dimensions and metrics needed to answer the question; do not add

--- a/.codex/skills/langfuse-metrics/agents/openai.yaml
+++ b/.codex/skills/langfuse-metrics/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Langfuse Metrics"
+  short_description: "Query aggregate Langfuse Metrics API v2 efficiently"
+  default_prompt: "Use Langfuse Metrics API v2 to answer this aggregate telemetry question with the fewest requests."

--- a/.codex/skills/langfuse-metrics/scripts/query-metrics-v2.mjs
+++ b/.codex/skills/langfuse-metrics/scripts/query-metrics-v2.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+const DEFAULT_BASE_URL = "https://us.cloud.langfuse.com";
+const MAX_RETRY_AFTER_SECONDS = 60;
+
+const fail = (message) => {
+  console.error(message);
+  process.exit(1);
+};
+
+const parseArgs = (argv) => {
+  const options = { command: argv[0] || "summary" };
+  for (let index = 1; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (!argument.startsWith("--")) fail(`Unexpected argument: ${argument}`);
+    const key = argument.slice(2);
+    if (["dry-run", "compact"].includes(key)) {
+      options[key] = true;
+      continue;
+    }
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) fail(`Missing value for --${key}`);
+    options[key] = value;
+    index += 1;
+  }
+  return options;
+};
+
+const parseTimestamp = (value, label) => {
+  const parsed = new Date(value);
+  if (!value || Number.isNaN(parsed.getTime())) fail(`Invalid ${label}: ${value}`);
+  return parsed.toISOString();
+};
+
+const buildSummaryQuery = (options) => {
+  const toTimestamp = parseTimestamp(options.to || new Date().toISOString(), "--to");
+  const defaultFrom = new Date(new Date(toTimestamp).getTime() - 24 * 60 * 60 * 1000);
+  const fromTimestamp = parseTimestamp(options.from || defaultFrom.toISOString(), "--from");
+  if (new Date(fromTimestamp) >= new Date(toTimestamp)) {
+    fail("--from must be earlier than --to");
+  }
+
+  const query = {
+    view: "observations",
+    metrics: [
+      { measure: "count", aggregation: "count" },
+      { measure: "totalCost", aggregation: "sum" },
+      { measure: "latency", aggregation: "avg" },
+      { measure: "latency", aggregation: "p95" },
+    ],
+    dimensions: [
+      { field: "providedModelName" },
+      { field: "name" },
+    ],
+    filters: [],
+    fromTimestamp,
+    toTimestamp,
+    orderBy: [{ field: "count_count", direction: "desc" }],
+    config: { row_limit: 1000 },
+  };
+
+  if (options.granularity) {
+    if (!["hour", "day", "week", "month"].includes(options.granularity)) {
+      fail("--granularity must be hour, day, week, or month");
+    }
+    query.timeDimension = { granularity: options.granularity };
+  }
+  return query;
+};
+
+const loadQuery = (options) => {
+  if (options.command === "summary") return buildSummaryQuery(options);
+  if (options.command !== "query") fail("Command must be summary or query");
+  if (!options.file) fail("query requires --file <path>");
+  const parsed = JSON.parse(fs.readFileSync(options.file, "utf8"));
+  if (!parsed.fromTimestamp || !parsed.toTimestamp) {
+    fail("Custom queries require fromTimestamp and toTimestamp");
+  }
+  return parsed;
+};
+
+const normalizeNumbers = (row) =>
+  Object.fromEntries(
+    Object.entries(row).map(([key, value]) => {
+      if (/^(count|sum|avg|p\d+|min|max)_/.test(key) && value !== null && value !== "") {
+        const number = Number(value);
+        if (Number.isFinite(number)) return [key, number];
+      }
+      return [key, value];
+    }),
+  );
+
+const sleep = (milliseconds) =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+const requestMetrics = async ({ baseUrl, auth, query }, attempt = 0) => {
+  const url = new URL("/api/public/v2/metrics", baseUrl);
+  url.searchParams.set("query", JSON.stringify(query));
+  const response = await fetch(url, {
+    headers: { Authorization: `Basic ${auth}` },
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  if (response.status === 429) {
+    const retryAfter = Number(response.headers.get("retry-after"));
+    if (attempt === 0 && Number.isFinite(retryAfter) && retryAfter <= MAX_RETRY_AFTER_SECONDS) {
+      console.error(`Rate limited; retrying once after ${retryAfter}s.`);
+      await sleep(retryAfter * 1000);
+      return requestMetrics({ baseUrl, auth, query }, 1);
+    }
+    fail(
+      `Langfuse rate limit reached.${Number.isFinite(retryAfter) ? ` Retry after ${retryAfter}s.` : ""}`,
+    );
+  }
+
+  if (!response.ok) {
+    const body = (await response.text()).slice(0, 1000);
+    fail(`Langfuse HTTP ${response.status}: ${body}`);
+  }
+  return response.json();
+};
+
+const options = parseArgs(process.argv.slice(2));
+const query = loadQuery(options);
+
+if (options["dry-run"]) {
+  console.log(JSON.stringify(query, null, options.compact ? 0 : 2));
+  process.exit(0);
+}
+
+const publicKey = process.env.LANGFUSE_PUBLIC_KEY;
+const secretKey = process.env.LANGFUSE_SECRET_KEY;
+if (!publicKey || !secretKey) {
+  fail("LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY are required");
+}
+
+const baseUrl = (process.env.LANGFUSE_BASE_URL || DEFAULT_BASE_URL).replace(/\/$/, "");
+const auth = Buffer.from(`${publicKey}:${secretKey}`).toString("base64");
+const payload = await requestMetrics({ baseUrl, auth, query });
+let data = Array.isArray(payload.data) ? payload.data.map(normalizeNumbers) : [];
+
+if (options["model-prefix"]) {
+  data = data.filter((row) =>
+    String(row.providedModelName || "").startsWith(options["model-prefix"]),
+  );
+}
+
+console.log(
+  JSON.stringify(
+    { query, rowCount: data.length, data },
+    null,
+    options.compact ? 0 : 2,
+  ),
+);

--- a/.codex/skills/langfuse-metrics/scripts/query-metrics-v2.mjs
+++ b/.codex/skills/langfuse-metrics/scripts/query-metrics-v2.mjs
@@ -135,7 +135,7 @@ const buildCostReport = (rows, options) => {
     (total, row) => total + Number(row.sum_totalCost || 0),
     0,
   );
-  const billableObservationCount = modelRows.reduce(
+  const modelObservationCount = modelRows.reduce(
     (total, row) => total + Number(row.count_count || 0),
     0,
   );
@@ -177,13 +177,13 @@ const buildCostReport = (rows, options) => {
       toTimestamp: options.to,
     },
     totalAttributedCost: totalCost,
-    billableObservationCount,
+    modelObservationCount,
     observationsInPricedGroups,
     observationsInUnpricedGroups,
     pricedGroupObservationRatio:
-      billableObservationCount === 0
+      modelObservationCount === 0
         ? null
-        : observationsInPricedGroups / billableObservationCount,
+        : observationsInPricedGroups / modelObservationCount,
     unitCosts: {
       ...(completedMeetings !== undefined
         ? {

--- a/.codex/skills/langfuse-metrics/scripts/query-metrics-v2.mjs
+++ b/.codex/skills/langfuse-metrics/scripts/query-metrics-v2.mjs
@@ -30,14 +30,23 @@ const parseArgs = (argv) => {
 
 const parseTimestamp = (value, label) => {
   const parsed = new Date(value);
-  if (!value || Number.isNaN(parsed.getTime())) fail(`Invalid ${label}: ${value}`);
+  if (!value || Number.isNaN(parsed.getTime()))
+    fail(`Invalid ${label}: ${value}`);
   return parsed.toISOString();
 };
 
 const buildSummaryQuery = (options) => {
-  const toTimestamp = parseTimestamp(options.to || new Date().toISOString(), "--to");
-  const defaultFrom = new Date(new Date(toTimestamp).getTime() - 24 * 60 * 60 * 1000);
-  const fromTimestamp = parseTimestamp(options.from || defaultFrom.toISOString(), "--from");
+  const toTimestamp = parseTimestamp(
+    options.to || new Date().toISOString(),
+    "--to",
+  );
+  const defaultFrom = new Date(
+    new Date(toTimestamp).getTime() - 24 * 60 * 60 * 1000,
+  );
+  const fromTimestamp = parseTimestamp(
+    options.from || defaultFrom.toISOString(),
+    "--from",
+  );
   if (new Date(fromTimestamp) >= new Date(toTimestamp)) {
     fail("--from must be earlier than --to");
   }
@@ -50,10 +59,7 @@ const buildSummaryQuery = (options) => {
       { measure: "latency", aggregation: "avg" },
       { measure: "latency", aggregation: "p95" },
     ],
-    dimensions: [
-      { field: "providedModelName" },
-      { field: "name" },
-    ],
+    dimensions: [{ field: "providedModelName" }, { field: "name" }],
     filters: [],
     fromTimestamp,
     toTimestamp,
@@ -71,8 +77,12 @@ const buildSummaryQuery = (options) => {
 };
 
 const loadQuery = (options) => {
-  if (options.command === "summary") return buildSummaryQuery(options);
-  if (options.command !== "query") fail("Command must be summary or query");
+  if (["summary", "cost-report"].includes(options.command)) {
+    return buildSummaryQuery(options);
+  }
+  if (options.command !== "query") {
+    fail("Command must be summary, cost-report, or query");
+  }
   if (!options.file) fail("query requires --file <path>");
   const parsed = JSON.parse(fs.readFileSync(options.file, "utf8"));
   if (!parsed.fromTimestamp || !parsed.toTimestamp) {
@@ -84,13 +94,117 @@ const loadQuery = (options) => {
 const normalizeNumbers = (row) =>
   Object.fromEntries(
     Object.entries(row).map(([key, value]) => {
-      if (/^(count|sum|avg|p\d+|min|max)_/.test(key) && value !== null && value !== "") {
+      if (
+        /^(count|sum|avg|p\d+|min|max)_/.test(key) &&
+        value !== null &&
+        value !== ""
+      ) {
         const number = Number(value);
         if (Number.isFinite(number)) return [key, number];
       }
       return [key, value];
     }),
   );
+
+const nonnegativeNumberOption = (value, label) => {
+  if (value === undefined) return undefined;
+  const number = Number(value);
+  if (!Number.isFinite(number) || number < 0) {
+    fail(`${label} must be a nonnegative number`);
+  }
+  return number;
+};
+
+const sumBy = (rows, key) => {
+  const totals = new Map();
+  for (const row of rows) {
+    const label = String(row[key] || "unknown");
+    totals.set(
+      label,
+      (totals.get(label) || 0) + Number(row.sum_totalCost || 0),
+    );
+  }
+  return [...totals.entries()]
+    .map(([label, totalCost]) => ({ [key]: label, totalCost }))
+    .sort((left, right) => right.totalCost - left.totalCost);
+};
+
+const buildCostReport = (rows, options) => {
+  const modelRows = rows.filter((row) => Boolean(row.providedModelName));
+  const totalCost = modelRows.reduce(
+    (total, row) => total + Number(row.sum_totalCost || 0),
+    0,
+  );
+  const billableObservationCount = modelRows.reduce(
+    (total, row) => total + Number(row.count_count || 0),
+    0,
+  );
+  const pricedGroupRows = modelRows.filter(
+    (row) => Number(row.sum_totalCost || 0) > 0,
+  );
+  const observationsInPricedGroups = pricedGroupRows.reduce(
+    (total, row) => total + Number(row.count_count || 0),
+    0,
+  );
+  const unpricedGroups = modelRows
+    .filter(
+      (row) =>
+        Number(row.count_count || 0) > 0 &&
+        Number(row.sum_totalCost || 0) === 0,
+    )
+    .map((row) => ({
+      providedModelName: row.providedModelName,
+      name: row.name,
+      observationCount: Number(row.count_count || 0),
+    }))
+    .sort((left, right) => right.observationCount - left.observationCount);
+  const observationsInUnpricedGroups = unpricedGroups.reduce(
+    (total, row) => total + row.observationCount,
+    0,
+  );
+  const completedMeetings = nonnegativeNumberOption(
+    options["completed-meetings"],
+    "--completed-meetings",
+  );
+  const transcribedMinutes = nonnegativeNumberOption(
+    options["transcribed-minutes"],
+    "--transcribed-minutes",
+  );
+
+  return {
+    window: {
+      fromTimestamp: options.from,
+      toTimestamp: options.to,
+    },
+    totalAttributedCost: totalCost,
+    billableObservationCount,
+    observationsInPricedGroups,
+    observationsInUnpricedGroups,
+    pricedGroupObservationRatio:
+      billableObservationCount === 0
+        ? null
+        : observationsInPricedGroups / billableObservationCount,
+    unitCosts: {
+      ...(completedMeetings !== undefined
+        ? {
+            costPerCompletedMeeting:
+              completedMeetings === 0 ? null : totalCost / completedMeetings,
+          }
+        : {}),
+      ...(transcribedMinutes !== undefined
+        ? {
+            costPerTranscribedMinute:
+              transcribedMinutes === 0 ? null : totalCost / transcribedMinutes,
+          }
+        : {}),
+    },
+    costByModel: sumBy(modelRows, "providedModelName"),
+    costByFeature: sumBy(modelRows, "name"),
+    unpricedGroups,
+    coverageNote:
+      "Coverage is group-based: a priced aggregate can still contain individual unpriced observations.",
+  };
+};
 
 const sleep = (milliseconds) =>
   new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -105,7 +219,11 @@ const requestMetrics = async ({ baseUrl, auth, query }, attempt = 0) => {
 
   if (response.status === 429) {
     const retryAfter = Number(response.headers.get("retry-after"));
-    if (attempt === 0 && Number.isFinite(retryAfter) && retryAfter <= MAX_RETRY_AFTER_SECONDS) {
+    if (
+      attempt === 0 &&
+      Number.isFinite(retryAfter) &&
+      retryAfter <= MAX_RETRY_AFTER_SECONDS
+    ) {
       console.error(`Rate limited; retrying once after ${retryAfter}s.`);
       await sleep(retryAfter * 1000);
       return requestMetrics({ baseUrl, auth, query }, 1);
@@ -125,6 +243,9 @@ const requestMetrics = async ({ baseUrl, auth, query }, attempt = 0) => {
 const options = parseArgs(process.argv.slice(2));
 const query = loadQuery(options);
 
+options.from = query.fromTimestamp;
+options.to = query.toTimestamp;
+
 if (options["dry-run"]) {
   console.log(JSON.stringify(query, null, options.compact ? 0 : 2));
   process.exit(0);
@@ -136,10 +257,15 @@ if (!publicKey || !secretKey) {
   fail("LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY are required");
 }
 
-const baseUrl = (process.env.LANGFUSE_BASE_URL || DEFAULT_BASE_URL).replace(/\/$/, "");
+const baseUrl = (process.env.LANGFUSE_BASE_URL || DEFAULT_BASE_URL).replace(
+  /\/$/,
+  "",
+);
 const auth = Buffer.from(`${publicKey}:${secretKey}`).toString("base64");
 const payload = await requestMetrics({ baseUrl, auth, query });
-let data = Array.isArray(payload.data) ? payload.data.map(normalizeNumbers) : [];
+let data = Array.isArray(payload.data)
+  ? payload.data.map(normalizeNumbers)
+  : [];
 
 if (options["model-prefix"]) {
   data = data.filter((row) =>
@@ -147,10 +273,9 @@ if (options["model-prefix"]) {
   );
 }
 
-console.log(
-  JSON.stringify(
-    { query, rowCount: data.length, data },
-    null,
-    options.compact ? 0 : 2,
-  ),
-);
+const output =
+  options.command === "cost-report"
+    ? { query, report: buildCostReport(data, options) }
+    : { query, rowCount: data.length, data };
+
+console.log(JSON.stringify(output, null, options.compact ? 0 : 2));

--- a/.codex/skills/langfuse-metrics/scripts/query-metrics-v2.mjs
+++ b/.codex/skills/langfuse-metrics/scripts/query-metrics-v2.mjs
@@ -91,6 +91,26 @@ const loadQuery = (options) => {
   return parsed;
 };
 
+const applyModelPrefix = (query, options) => {
+  const prefix = options["model-prefix"];
+  if (!prefix) return query;
+  if (query.view !== "observations") {
+    fail("--model-prefix requires an observations query");
+  }
+  return {
+    ...query,
+    filters: [
+      ...(query.filters || []),
+      {
+        column: "providedModelName",
+        operator: "starts with",
+        value: prefix,
+        type: "string",
+      },
+    ],
+  };
+};
+
 const normalizeNumbers = (row) =>
   Object.fromEntries(
     Object.entries(row).map(([key, value]) => {
@@ -241,7 +261,7 @@ const requestMetrics = async ({ baseUrl, auth, query }, attempt = 0) => {
 };
 
 const options = parseArgs(process.argv.slice(2));
-const query = loadQuery(options);
+const query = applyModelPrefix(loadQuery(options), options);
 
 options.from = query.fromTimestamp;
 options.to = query.toTimestamp;
@@ -266,12 +286,6 @@ const payload = await requestMetrics({ baseUrl, auth, query });
 let data = Array.isArray(payload.data)
   ? payload.data.map(normalizeNumbers)
   : [];
-
-if (options["model-prefix"]) {
-  data = data.filter((row) =>
-    String(row.providedModelName || "").startsWith(options["model-prefix"]),
-  );
-}
 
 const output =
   options.command === "cost-report"

--- a/docs/audio-transcription.md
+++ b/docs/audio-transcription.md
@@ -37,17 +37,26 @@ When Langfuse tracing is enabled, each transcription snippet uploads an audio at
 
 ## Langfuse usage and cost
 
-Transcription traces report duration-based usage so Langfuse can calculate costs without audio token math.
+Transcription traces report the exact token usage returned by OpenAI so
+Langfuse can calculate costs using the provider's input and output rates.
 
-- Usage details include `input_audio_seconds`, rounded to three decimals.
-- Configure Langfuse model pricing to charge per second using `input_audio_seconds`.
-- We do not derive audio token counts for transcription, we keep it duration-based.
+- Usage details use Langfuse's `input`, `output`, and `total` keys.
+- When the prompt/no-prompt vote makes two requests, usage includes both billed
+  requests.
+- Each trace records whether accounting is `priced`, `partial`, or `unpriced`
+  and the corresponding request counts.
+- If OpenAI omits token usage, `input_audio_seconds` remains available as a
+  rounded operational fallback. Do not treat that fallback as attributed cost.
 
 Pricing checklist:
 
-- Add custom model definitions for `gpt-4o-transcribe` and `gpt-4o-transcribe-diarize` in Langfuse.
-- Set pricing to use the `input_audio_seconds` usage key with a per-second rate.
-- Set output token pricing to 0 if the model does not bill output tokens.
+- Match the deployed `gpt-4o-transcribe` model definition against that exact
+  model name.
+- Set `input` and `output` per-token prices to the current OpenAI rates.
+- Keep the usage keys and model definition aligned; Langfuse price keys must
+  exactly match the generation's usage-detail keys.
+- Verify new production observations show both token usage and non-null cost
+  before treating cost coverage as complete.
 
 ## Config keys
 

--- a/src/observability/langfuseUsageDetails.ts
+++ b/src/observability/langfuseUsageDetails.ts
@@ -1,8 +1,22 @@
+import type { Transcription } from "openai/resources/audio";
+
 export const LANGFUSE_AUDIO_SECONDS_USAGE_KEY = "input_audio_seconds";
 
-export function buildLangfuseTranscriptionUsageDetails(
-  audioSeconds?: number,
-): Record<string, number> | undefined {
+export type TranscriptionCostAccountingStatus =
+  "priced" | "partial" | "unpriced";
+
+export type LangfuseTranscriptionAccounting = {
+  usageDetails?: Record<string, number>;
+  status: TranscriptionCostAccountingStatus;
+  requestCount: number;
+  pricedRequestCount: number;
+  unpricedRequestCount: number;
+};
+
+const isValidUsageNumber = (value: number) =>
+  Number.isFinite(value) && value >= 0;
+
+const roundedPositiveSeconds = (audioSeconds?: number) => {
   if (typeof audioSeconds !== "number" || !Number.isFinite(audioSeconds)) {
     return undefined;
   }
@@ -13,5 +27,65 @@ export function buildLangfuseTranscriptionUsageDetails(
   if (rounded <= 0) {
     return undefined;
   }
-  return { [LANGFUSE_AUDIO_SECONDS_USAGE_KEY]: rounded };
+  return rounded;
+};
+
+export function buildLangfuseTranscriptionAccounting(
+  usages: Array<Transcription["usage"]>,
+  fallbackAudioSeconds?: number,
+): LangfuseTranscriptionAccounting {
+  let input = 0;
+  let output = 0;
+  let pricedRequestCount = 0;
+  let providerAudioSeconds = 0;
+
+  for (const usage of usages) {
+    if (
+      usage?.type === "tokens" &&
+      isValidUsageNumber(usage.input_tokens) &&
+      isValidUsageNumber(usage.output_tokens)
+    ) {
+      pricedRequestCount += 1;
+      input += usage.input_tokens;
+      output += usage.output_tokens;
+    } else if (
+      usage?.type === "duration" &&
+      isValidUsageNumber(usage.seconds)
+    ) {
+      providerAudioSeconds += usage.seconds;
+    }
+  }
+
+  const requestCount = usages.length;
+  const unpricedRequestCount = requestCount - pricedRequestCount;
+  const status: TranscriptionCostAccountingStatus =
+    pricedRequestCount === requestCount && requestCount > 0
+      ? "priced"
+      : pricedRequestCount > 0
+        ? "partial"
+        : "unpriced";
+
+  if (pricedRequestCount > 0) {
+    return {
+      usageDetails: { input, output, total: input + output },
+      status,
+      requestCount,
+      pricedRequestCount,
+      unpricedRequestCount,
+    };
+  }
+
+  const audioSeconds = roundedPositiveSeconds(
+    providerAudioSeconds > 0 ? providerAudioSeconds : fallbackAudioSeconds,
+  );
+  return {
+    usageDetails:
+      audioSeconds === undefined
+        ? undefined
+        : { [LANGFUSE_AUDIO_SECONDS_USAGE_KEY]: audioSeconds },
+    status,
+    requestCount,
+    pricedRequestCount,
+    unpricedRequestCount,
+  };
 }

--- a/src/services/transcriptionService.ts
+++ b/src/services/transcriptionService.ts
@@ -1,5 +1,8 @@
 import type OpenAI from "openai";
-import type { TranscriptionCreateParamsNonStreaming } from "openai/resources/audio";
+import type {
+  Transcription,
+  TranscriptionCreateParamsNonStreaming,
+} from "openai/resources/audio";
 import {
   createReadStream,
   existsSync,
@@ -64,7 +67,7 @@ import {
   updateActiveObservation,
 } from "@langfuse/tracing";
 import { buildLangfuseTranscriptionAudioAttachment } from "../observability/langfuseAudioAttachment";
-import { buildLangfuseTranscriptionUsageDetails } from "../observability/langfuseUsageDetails";
+import { buildLangfuseTranscriptionAccounting } from "../observability/langfuseUsageDetails";
 import { toLangfuseAttributeMetadata } from "../observability/langfuseMetadata";
 import { ensureMeetingTempDirSync } from "./tempFileService";
 import { evaluateNoiseGate } from "../utils/audioNoiseGate";
@@ -282,6 +285,7 @@ async function transcribeInternal(
     return {
       text: transcription.text ?? "",
       logprobs: transcription.logprobs ?? [],
+      usage: transcription.usage,
     };
   };
 
@@ -300,6 +304,7 @@ async function transcribeInternal(
     rateMinWords: number;
     rateMinSyllables: number;
     maxSyllablesPerSecond: number;
+    usage?: Transcription["usage"];
   };
 
   const toLogSafeTextQuality = (
@@ -317,6 +322,7 @@ async function transcribeInternal(
     raw: {
       text: string;
       logprobs?: { logprob?: number }[];
+      usage?: Transcription["usage"];
     },
     candidate: {
       id: "prompt" | "no_prompt";
@@ -403,6 +409,7 @@ async function transcribeInternal(
       rateMinWords: guardConfig.rateMinWords,
       rateMinSyllables: guardConfig.rateMinSyllables,
       maxSyllablesPerSecond: guardConfig.maxSyllablesPerSecond,
+      usage: raw.usage,
     };
   };
 
@@ -577,14 +584,35 @@ async function transcribeInternal(
             maxSyllablesPerSecond,
           } = selection.selected;
 
-          const usageDetails = buildLangfuseTranscriptionUsageDetails(
+          const accounting = buildLangfuseTranscriptionAccounting(
+            [
+              selection.promptCandidate.usage,
+              ...(selection.noPromptCandidate
+                ? [selection.noPromptCandidate.usage]
+                : []),
+            ],
             context?.audioSeconds,
           );
+          if (accounting.unpricedRequestCount > 0) {
+            console.warn("Transcription cost accounting is incomplete.", {
+              ...traceMetadata,
+              transcriptionCostAccountingStatus: accounting.status,
+              transcriptionRequestCount: accounting.requestCount,
+              transcriptionPricedRequestCount: accounting.pricedRequestCount,
+              transcriptionUnpricedRequestCount:
+                accounting.unpricedRequestCount,
+            });
+          }
           updateActiveObservation(
             {
               output: guardResult.text,
-              usageDetails,
+              usageDetails: accounting.usageDetails,
               metadata: {
+                transcriptionCostAccountingStatus: accounting.status,
+                transcriptionRequestCount: accounting.requestCount,
+                transcriptionPricedRequestCount: accounting.pricedRequestCount,
+                transcriptionUnpricedRequestCount:
+                  accounting.unpricedRequestCount,
                 transcriptionFlags: guardResult.flags,
                 transcriptionCandidate: selection.selected.candidateId,
                 quietAudio: guardResult.quietAudio,

--- a/test/observability/langfuseMetricsScript.test.ts
+++ b/test/observability/langfuseMetricsScript.test.ts
@@ -81,7 +81,7 @@ describe("Langfuse Metrics v2 cost report", () => {
       const output = JSON.parse(stdout);
       expect(output.report).toMatchObject({
         totalAttributedCost: 1.5,
-        billableObservationCount: 5,
+        modelObservationCount: 5,
         observationsInPricedGroups: 3,
         observationsInUnpricedGroups: 2,
         pricedGroupObservationRatio: 0.6,

--- a/test/observability/langfuseMetricsScript.test.ts
+++ b/test/observability/langfuseMetricsScript.test.ts
@@ -9,28 +9,42 @@ const execFileAsync = promisify(execFile);
 
 describe("Langfuse Metrics v2 cost report", () => {
   it("reports priced and unpriced groups without estimating missing cost", async () => {
-    const server = createServer((_request, response) => {
+    const receivedQueries: Array<Record<string, unknown>> = [];
+    const rows = [
+      {
+        providedModelName: "priced-model",
+        name: "notes",
+        count_count: "3",
+        sum_totalCost: "1.5",
+        avg_latency: "2",
+        p95_latency: "3",
+      },
+      {
+        providedModelName: "unpriced-model",
+        name: "tts",
+        count_count: "2",
+        sum_totalCost: null,
+        avg_latency: "1",
+        p95_latency: "1.5",
+      },
+    ];
+    const server = createServer((request, response) => {
+      const url = new URL(request.url || "/", "http://127.0.0.1");
+      const query = JSON.parse(url.searchParams.get("query") || "{}");
+      receivedQueries.push(query);
+      const prefixFilter = query.filters?.find(
+        (filter: Record<string, unknown>) =>
+          filter.column === "providedModelName" &&
+          filter.operator === "starts with",
+      );
       response.setHeader("content-type", "application/json");
       response.end(
         JSON.stringify({
-          data: [
-            {
-              providedModelName: "priced-model",
-              name: "notes",
-              count_count: "3",
-              sum_totalCost: "1.5",
-              avg_latency: "2",
-              p95_latency: "3",
-            },
-            {
-              providedModelName: "unpriced-model",
-              name: "tts",
-              count_count: "2",
-              sum_totalCost: null,
-              avg_latency: "1",
-              p95_latency: "1.5",
-            },
-          ],
+          data: prefixFilter
+            ? rows.filter((row) =>
+                row.providedModelName.startsWith(String(prefixFilter.value)),
+              )
+            : rows,
         }),
       );
     });
@@ -125,6 +139,42 @@ describe("Langfuse Metrics v2 cost report", () => {
       expect(JSON.parse(zeroDenominatorStdout).report.unitCosts).toEqual({
         costPerCompletedMeeting: null,
         costPerTranscribedMinute: null,
+      });
+
+      const { stdout: prefixStdout } = await execFileAsync(
+        process.execPath,
+        [
+          script,
+          "cost-report",
+          "--from",
+          "2026-08-27T00:00:00Z",
+          "--to",
+          "2026-08-28T00:00:00Z",
+          "--model-prefix",
+          "priced-",
+          "--compact",
+        ],
+        {
+          env: {
+            ...process.env,
+            LANGFUSE_PUBLIC_KEY: "test-public",
+            LANGFUSE_SECRET_KEY: "test-secret",
+            LANGFUSE_BASE_URL: `http://127.0.0.1:${address.port}`,
+          },
+        },
+      );
+      expect(receivedQueries.at(-1)?.filters).toEqual([
+        {
+          column: "providedModelName",
+          operator: "starts with",
+          value: "priced-",
+          type: "string",
+        },
+      ]);
+      expect(JSON.parse(prefixStdout).report).toMatchObject({
+        modelObservationCount: 3,
+        observationsInPricedGroups: 3,
+        observationsInUnpricedGroups: 0,
       });
     } finally {
       await new Promise<void>((resolve, reject) =>

--- a/test/observability/langfuseMetricsScript.test.ts
+++ b/test/observability/langfuseMetricsScript.test.ts
@@ -1,0 +1,135 @@
+/** @jest-environment node */
+
+import { execFile } from "node:child_process";
+import { createServer } from "node:http";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+describe("Langfuse Metrics v2 cost report", () => {
+  it("reports priced and unpriced groups without estimating missing cost", async () => {
+    const server = createServer((_request, response) => {
+      response.setHeader("content-type", "application/json");
+      response.end(
+        JSON.stringify({
+          data: [
+            {
+              providedModelName: "priced-model",
+              name: "notes",
+              count_count: "3",
+              sum_totalCost: "1.5",
+              avg_latency: "2",
+              p95_latency: "3",
+            },
+            {
+              providedModelName: "unpriced-model",
+              name: "tts",
+              count_count: "2",
+              sum_totalCost: null,
+              avg_latency: "1",
+              p95_latency: "1.5",
+            },
+          ],
+        }),
+      );
+    });
+
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("Test server did not expose a TCP port.");
+    }
+
+    try {
+      const script = path.join(
+        process.cwd(),
+        ".codex",
+        "skills",
+        "langfuse-metrics",
+        "scripts",
+        "query-metrics-v2.mjs",
+      );
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        [
+          script,
+          "cost-report",
+          "--from",
+          "2026-08-27T00:00:00Z",
+          "--to",
+          "2026-08-28T00:00:00Z",
+          "--completed-meetings",
+          "5",
+          "--transcribed-minutes",
+          "10",
+          "--compact",
+        ],
+        {
+          env: {
+            ...process.env,
+            LANGFUSE_PUBLIC_KEY: "test-public",
+            LANGFUSE_SECRET_KEY: "test-secret",
+            LANGFUSE_BASE_URL: `http://127.0.0.1:${address.port}`,
+          },
+        },
+      );
+
+      const output = JSON.parse(stdout);
+      expect(output.report).toMatchObject({
+        totalAttributedCost: 1.5,
+        billableObservationCount: 5,
+        observationsInPricedGroups: 3,
+        observationsInUnpricedGroups: 2,
+        pricedGroupObservationRatio: 0.6,
+        unitCosts: {
+          costPerCompletedMeeting: 0.3,
+          costPerTranscribedMinute: 0.15,
+        },
+        unpricedGroups: [
+          {
+            providedModelName: "unpriced-model",
+            name: "tts",
+            observationCount: 2,
+          },
+        ],
+      });
+
+      const { stdout: zeroDenominatorStdout } = await execFileAsync(
+        process.execPath,
+        [
+          script,
+          "cost-report",
+          "--from",
+          "2026-08-27T00:00:00Z",
+          "--to",
+          "2026-08-28T00:00:00Z",
+          "--completed-meetings",
+          "0",
+          "--transcribed-minutes",
+          "0",
+          "--compact",
+        ],
+        {
+          env: {
+            ...process.env,
+            LANGFUSE_PUBLIC_KEY: "test-public",
+            LANGFUSE_SECRET_KEY: "test-secret",
+            LANGFUSE_BASE_URL: `http://127.0.0.1:${address.port}`,
+          },
+        },
+      );
+      expect(JSON.parse(zeroDenominatorStdout).report.unitCosts).toEqual({
+        costPerCompletedMeeting: null,
+        costPerTranscribedMinute: null,
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+});

--- a/test/observability/langfuseUsageDetails.test.ts
+++ b/test/observability/langfuseUsageDetails.test.ts
@@ -1,21 +1,118 @@
 import {
-  buildLangfuseTranscriptionUsageDetails,
+  buildLangfuseTranscriptionAccounting,
   LANGFUSE_AUDIO_SECONDS_USAGE_KEY,
 } from "../../src/observability/langfuseUsageDetails";
 
-describe("buildLangfuseTranscriptionUsageDetails", () => {
-  it("returns undefined for missing or non-positive values", () => {
-    expect(buildLangfuseTranscriptionUsageDetails()).toBeUndefined();
-    expect(buildLangfuseTranscriptionUsageDetails(Number.NaN)).toBeUndefined();
-    expect(buildLangfuseTranscriptionUsageDetails(0)).toBeUndefined();
-    expect(buildLangfuseTranscriptionUsageDetails(-1)).toBeUndefined();
+describe("buildLangfuseTranscriptionAccounting", () => {
+  it("maps token usage to Langfuse's priced generic token keys", () => {
+    expect(
+      buildLangfuseTranscriptionAccounting([
+        {
+          type: "tokens",
+          input_tokens: 120,
+          output_tokens: 30,
+          total_tokens: 150,
+        },
+      ]),
+    ).toEqual({
+      usageDetails: { input: 120, output: 30, total: 150 },
+      status: "priced",
+      requestCount: 1,
+      pricedRequestCount: 1,
+      unpricedRequestCount: 0,
+    });
   });
 
-  it("returns a rounded input_audio_seconds usage detail", () => {
-    const result = buildLangfuseTranscriptionUsageDetails(12.34567);
+  it("aggregates both requests made by a transcription vote", () => {
+    expect(
+      buildLangfuseTranscriptionAccounting([
+        {
+          type: "tokens",
+          input_tokens: 100,
+          output_tokens: 20,
+          total_tokens: 120,
+        },
+        {
+          type: "tokens",
+          input_tokens: 80,
+          output_tokens: 10,
+          total_tokens: 90,
+        },
+      ]),
+    ).toMatchObject({
+      usageDetails: { input: 180, output: 30, total: 210 },
+      status: "priced",
+      requestCount: 2,
+      pricedRequestCount: 2,
+      unpricedRequestCount: 0,
+    });
+  });
+
+  it("marks mixed token and missing usage as partial", () => {
+    expect(
+      buildLangfuseTranscriptionAccounting([
+        {
+          type: "tokens",
+          input_tokens: 100,
+          output_tokens: 20,
+          total_tokens: 120,
+        },
+        undefined,
+      ]),
+    ).toMatchObject({
+      usageDetails: { input: 100, output: 20, total: 120 },
+      status: "partial",
+      requestCount: 2,
+      pricedRequestCount: 1,
+      unpricedRequestCount: 1,
+    });
+  });
+
+  it("keeps duration usage visible without calling it priced", () => {
+    const result = buildLangfuseTranscriptionAccounting([
+      { type: "duration", seconds: 12.34567 },
+    ]);
 
     expect(result).toEqual({
-      [LANGFUSE_AUDIO_SECONDS_USAGE_KEY]: 12.346,
+      usageDetails: {
+        [LANGFUSE_AUDIO_SECONDS_USAGE_KEY]: 12.346,
+      },
+      status: "unpriced",
+      requestCount: 1,
+      pricedRequestCount: 0,
+      unpricedRequestCount: 1,
+    });
+  });
+
+  it("uses valid fallback audio seconds when provider usage is missing", () => {
+    expect(buildLangfuseTranscriptionAccounting([undefined], 8.7654)).toEqual({
+      usageDetails: { [LANGFUSE_AUDIO_SECONDS_USAGE_KEY]: 8.765 },
+      status: "unpriced",
+      requestCount: 1,
+      pricedRequestCount: 0,
+      unpricedRequestCount: 1,
+    });
+    expect(
+      buildLangfuseTranscriptionAccounting([undefined], Number.NaN)
+        .usageDetails,
+    ).toBeUndefined();
+  });
+
+  it("does not call invalid provider token usage priced", () => {
+    expect(
+      buildLangfuseTranscriptionAccounting([
+        {
+          type: "tokens",
+          input_tokens: Number.NaN,
+          output_tokens: 20,
+          total_tokens: 20,
+        },
+      ]),
+    ).toMatchObject({
+      usageDetails: undefined,
+      status: "unpriced",
+      pricedRequestCount: 0,
+      unpricedRequestCount: 1,
     });
   });
 });


### PR DESCRIPTION
[AGENT]

## Summary
- capture exact OpenAI token usage for every live transcription request, including both prompt/no-prompt vote calls, and aggregate it onto the existing Langfuse generation
- mark transcription accounting as priced, partial, or unpriced while preserving audio seconds as an operational fallback
- add a one-request Metrics API v2 cost report with attributed cost, model/feature breakdowns, fully unpriced groups, and optional per-meeting/per-minute denominators
- document the reusable Chronote product analytics and Langfuse query workflows

## Scope and safety
- no model routing, prompts, transcription output, feature flags, or production configuration changed
- no OpenAI billing-admin credential or invoice API dependency added
- TTS and image activity remains visible when unpriced; this PR does not estimate or alter their schemas/providers
- the report explicitly labels coverage as group-based because a priced aggregate may still contain individual unpriced observations

## Evidence
A read-only 2026-08-27 UTC Metrics v2 check returned $0.0725324 attributed cost across 483 model observations and identified 439 fully unpriced gpt-4o-transcribe/transcription observations. That is the high-volume path this change instruments.

## Verification
- focused exact-head Jest: 2 suites, 7 tests passed
- full Jest: 204 suites, 1,157 tests passed
- TypeScript build passed
- ESLint over src and test passed
- changed files pass Prettier and git diff --check
- live read-only Metrics v2 cost-report smoke check passed

Repository-wide Prettier still flags five pre-existing memory-bank Markdown files not touched by this PR.