### PR TITLE
Improve crawler discovery and search metadata

### DIFF
--- a/.github/actions/sync-frontend/action.yml
+++ b/.github/actions/sync-frontend/action.yml
@@ -44,7 +44,7 @@ runs:
         # short TTL instead and are re-uploaded below.
         aws s3 sync "$BUILD_DIR" "s3://$BUCKET" --delete --exclude "index.html" --cache-control "public,max-age=31536000,immutable"
         aws s3 cp "$BUILD_DIR/index.html" "s3://$BUCKET/index.html" --cache-control "public,max-age=600"
-        for stable in manifest.json sitemap.xml robots.txt; do
+        for stable in manifest.json sitemap.xml robots.txt llms.txt; do
           if [ -f "$BUILD_DIR/$stable" ]; then
             aws s3 cp "$BUILD_DIR/$stable" "s3://$BUCKET/$stable" --cache-control "public,max-age=600"
           fi

--- a/.github/actions/sync-frontend/action.yml
+++ b/.github/actions/sync-frontend/action.yml
@@ -44,7 +44,7 @@ runs:
         # short TTL instead and are re-uploaded below.
         aws s3 sync "$BUILD_DIR" "s3://$BUCKET" --delete --exclude "index.html" --cache-control "public,max-age=31536000,immutable"
         aws s3 cp "$BUILD_DIR/index.html" "s3://$BUCKET/index.html" --cache-control "public,max-age=600"
-        for stable in manifest.json sitemap.xml robots.txt llms.txt; do
+        for stable in manifest.json sitemap.xml robots.txt llms.txt 404.html; do
           if [ -f "$BUILD_DIR/$stable" ]; then
             aws s3 cp "$BUILD_DIR/$stable" "s3://$BUCKET/$stable" --cache-control "public,max-age=600"
           fi

--- a/_infra/functions/__tests__/frontend-route-rewrite.test.ts
+++ b/_infra/functions/__tests__/frontend-route-rewrite.test.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+
+type CloudFrontRequest = { uri: string };
+type CloudFrontResponse = {
+  statusCode: number;
+  headers?: Record<string, { value: string }>;
+  body?: string;
+};
+
+const source = fs.readFileSync(
+  path.join(__dirname, "..", "frontend-route-rewrite.js"),
+  "utf8",
+);
+const handler = vm.runInNewContext(`${source}\nhandler;`) as (event: {
+  request: CloudFrontRequest;
+}) => CloudFrontRequest | CloudFrontResponse;
+
+const publicRouteConfig = JSON.parse(
+  fs.readFileSync(
+    path.join(__dirname, "..", "..", "..", "scripts", "public-routes.json"),
+    "utf8",
+  ),
+) as { routes: { path: string }[] };
+
+const invoke = (uri: string) => handler({ request: { uri } });
+
+describe("frontend route rewrite", () => {
+  it("serves the homepage document for the root", () => {
+    expect(invoke("/")).toEqual({ uri: "/index.html" });
+  });
+
+  it("leaves every extensionless public-route object intact", () => {
+    for (const route of publicRouteConfig.routes) {
+      if (route.path === "/") continue;
+      expect(invoke(route.path)).toEqual({ uri: route.path });
+    }
+  });
+
+  it("serves public-route trailing slash variants from the canonical object", () => {
+    for (const route of publicRouteConfig.routes) {
+      if (route.path === "/") continue;
+      expect(invoke(`${route.path}/`)).toEqual({ uri: route.path });
+    }
+  });
+
+  it("rewrites the frontend's dynamic and authenticated routes", () => {
+    for (const uri of [
+      "/promo/summer",
+      "/upgrade/select-server",
+      "/upgrade/success",
+      "/live/123/meeting-1",
+      "/admin",
+      "/admin/config",
+      "/portal",
+      "/portal/server/123/library",
+      "/share/ask/123/conversation-1",
+      "/share/meeting/123/share-1",
+    ]) {
+      expect(invoke(uri)).toEqual({ uri: "/index.html" });
+    }
+  });
+
+  it("returns a real noindex 404 for unknown extensionless paths", () => {
+    for (const uri of [
+      "/definitely-not-real",
+      "/promo/",
+      "/live/123",
+      "/share/ask/123",
+    ]) {
+      expect(invoke(uri)).toMatchObject({
+        statusCode: 404,
+        headers: { "x-robots-tag": { value: "noindex, nofollow" } },
+        body: "Not Found",
+      });
+    }
+  });
+
+  it("lets real file requests reach the origin", () => {
+    for (const uri of [
+      "/robots.txt",
+      "/sitemap.xml",
+      "/llms.txt",
+      "/og-image.png",
+      "/assets/index.abc123.js",
+    ]) {
+      expect(invoke(uri)).toEqual({ uri });
+    }
+  });
+});

--- a/_infra/functions/__tests__/frontend-route-rewrite.test.ts
+++ b/_infra/functions/__tests__/frontend-route-rewrite.test.ts
@@ -62,6 +62,19 @@ describe("frontend route rewrite", () => {
     }
   });
 
+  it("preserves common trailing slash variants of known SPA routes", () => {
+    for (const uri of [
+      "/promo/summer/",
+      "/upgrade/select-server/",
+      "/upgrade/success/",
+      "/live/123/meeting-1/",
+      "/share/ask/123/conversation-1/",
+      "/share/meeting/123/share-1/",
+    ]) {
+      expect(invoke(uri)).toEqual({ uri: "/index.html" });
+    }
+  });
+
   it("returns a real noindex 404 for unknown extensionless paths", () => {
     for (const uri of [
       "/definitely-not-real",

--- a/_infra/functions/__tests__/frontend-route-rewrite.test.ts
+++ b/_infra/functions/__tests__/frontend-route-rewrite.test.ts
@@ -85,7 +85,6 @@ describe("frontend route rewrite", () => {
       expect(invoke(uri)).toMatchObject({
         statusCode: 404,
         headers: { "x-robots-tag": { value: "noindex, nofollow" } },
-        body: "Not Found",
       });
     }
   });

--- a/_infra/functions/frontend-route-rewrite.js
+++ b/_infra/functions/frontend-route-rewrite.js
@@ -1,0 +1,85 @@
+// Serves the SPA only for routes the frontend actually owns.
+//
+// The old CloudFront fallback converted every missing S3 object into index.html
+// with a 200 response. That made direct SPA navigation work, but it also made
+// every typo and nonexistent crawler URL look like a valid copy of the home
+// page. Keep the known app routes, preserve the extensionless public-route
+// objects that carry route-specific metadata, and return a real 404 for other
+// extensionless paths.
+
+// Keep this list aligned with scripts/public-routes.json. The function test
+// reads that registry and fails if a public route is missing here.
+var publicRoutes = ["/join", "/upgrade", "/feedback"];
+
+function isPublicRoute(uri) {
+  for (var i = 0; i < publicRoutes.length; i += 1) {
+    if (uri === publicRoutes[i]) return true;
+  }
+  return false;
+}
+
+function publicRouteWithoutTrailingSlash(uri) {
+  for (var i = 0; i < publicRoutes.length; i += 1) {
+    if (uri === publicRoutes[i] + "/") return publicRoutes[i];
+  }
+  return null;
+}
+
+function isSpaRoute(uri) {
+  return (
+    uri === "/admin" ||
+    uri.indexOf("/admin/") === 0 ||
+    uri === "/portal" ||
+    uri.indexOf("/portal/") === 0 ||
+    uri === "/upgrade/select-server" ||
+    uri === "/upgrade/success" ||
+    /^\/promo\/[^/]+$/.test(uri) ||
+    /^\/live\/[^/]+\/[^/]+$/.test(uri) ||
+    /^\/share\/ask\/[^/]+\/[^/]+$/.test(uri) ||
+    /^\/share\/meeting\/[^/]+\/[^/]+$/.test(uri)
+  );
+}
+
+// CloudFront invokes a global named `handler`; there is no module system and
+// nothing imports this, so it reads as unused to eslint.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+
+  if (uri === "/") {
+    request.uri = "/index.html";
+    return request;
+  }
+
+  if (isPublicRoute(uri)) return request;
+
+  var canonicalPublicRoute = publicRouteWithoutTrailingSlash(uri);
+  if (canonicalPublicRoute) {
+    // Rewrite rather than redirect so campaign query parameters remain intact.
+    // The served document carries the no-slash canonical URL.
+    request.uri = canonicalPublicRoute;
+    return request;
+  }
+
+  if (isSpaRoute(uri)) {
+    request.uri = "/index.html";
+    return request;
+  }
+
+  // Let real files reach S3. Missing files receive the distribution's real
+  // 404 response, while deployed assets and crawler files continue to work.
+  var lastSegment = uri.substring(uri.lastIndexOf("/") + 1);
+  if (lastSegment.indexOf(".") !== -1) return request;
+
+  return {
+    statusCode: 404,
+    statusDescription: "Not Found",
+    headers: {
+      "cache-control": { value: "public, max-age=60" },
+      "content-type": { value: "text/plain; charset=utf-8" },
+      "x-robots-tag": { value: "noindex, nofollow" },
+    },
+    body: "Not Found",
+  };
+}

--- a/_infra/functions/frontend-route-rewrite.js
+++ b/_infra/functions/frontend-route-rewrite.js
@@ -79,6 +79,5 @@ function handler(event) {
       "content-type": { value: "text/plain; charset=utf-8" },
       "x-robots-tag": { value: "noindex, nofollow" },
     },
-    body: "Not Found",
   };
 }

--- a/_infra/functions/frontend-route-rewrite.js
+++ b/_infra/functions/frontend-route-rewrite.js
@@ -31,12 +31,11 @@ function isSpaRoute(uri) {
     uri.indexOf("/admin/") === 0 ||
     uri === "/portal" ||
     uri.indexOf("/portal/") === 0 ||
-    uri === "/upgrade/select-server" ||
-    uri === "/upgrade/success" ||
-    /^\/promo\/[^/]+$/.test(uri) ||
-    /^\/live\/[^/]+\/[^/]+$/.test(uri) ||
-    /^\/share\/ask\/[^/]+\/[^/]+$/.test(uri) ||
-    /^\/share\/meeting\/[^/]+\/[^/]+$/.test(uri)
+    /^\/upgrade\/(?:select-server|success)\/?$/.test(uri) ||
+    /^\/promo\/[^/]+\/?$/.test(uri) ||
+    /^\/live\/[^/]+\/[^/]+\/?$/.test(uri) ||
+    /^\/share\/ask\/[^/]+\/[^/]+\/?$/.test(uri) ||
+    /^\/share\/meeting\/[^/]+\/[^/]+\/?$/.test(uri)
   );
 }
 

--- a/_infra/main.tf
+++ b/_infra/main.tf
@@ -1069,6 +1069,36 @@ resource "aws_cloudfront_origin_access_control" "docs_oac" {
   signing_protocol                  = "sigv4"
 }
 
+resource "aws_cloudfront_function" "frontend_route_rewrite" {
+  name    = "${local.name_prefix}-frontend-route-rewrite"
+  runtime = "cloudfront-js-2.0"
+  comment = "Routes known frontend paths to the SPA while preserving real 404 responses"
+  publish = true
+  code    = file("${path.module}/functions/frontend-route-rewrite.js")
+}
+
+resource "aws_cloudfront_response_headers_policy" "crawler_noindex" {
+  name    = "${local.name_prefix}-crawler-noindex"
+  comment = "Keeps private share pages and utility search pages out of indexes"
+
+  security_headers_config {
+    strict_transport_security {
+      access_control_max_age_sec = 31536000
+      include_subdomains         = true
+      override                   = true
+      preload                    = true
+    }
+  }
+
+  custom_headers_config {
+    items {
+      header   = "X-Robots-Tag"
+      value    = "noindex, nofollow"
+      override = true
+    }
+  }
+}
+
 resource "aws_cloudfront_distribution" "frontend" {
   #checkov:skip=CKV_AWS_86 reason: Access logging not enabled yet; will add if/when audit requirements demand it.
   #checkov:skip=CKV_AWS_310 reason: Origin failover not configured; single-origin setup is acceptable for now.
@@ -1091,6 +1121,11 @@ resource "aws_cloudfront_distribution" "frontend" {
     viewer_protocol_policy = "redirect-to-https"
     allowed_methods        = ["GET", "HEAD"]
     cached_methods         = ["GET", "HEAD"]
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.frontend_route_rewrite.arn
+    }
 
     forwarded_values {
       query_string = false
@@ -1136,15 +1171,39 @@ resource "aws_cloudfront_distribution" "frontend" {
   custom_error_response {
     error_caching_min_ttl = 0
     error_code            = 403
-    response_code         = 200
-    response_page_path    = "/index.html"
+    response_code         = 404
+  }
+
+  ordered_cache_behavior {
+    path_pattern               = "/share/*"
+    target_origin_id           = "frontend-s3"
+    viewer_protocol_policy     = "redirect-to-https"
+    allowed_methods            = ["GET", "HEAD"]
+    cached_methods             = ["GET", "HEAD"]
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.crawler_noindex.id
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.frontend_route_rewrite.arn
+    }
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    compress    = true
+    min_ttl     = 0
+    default_ttl = 600
+    max_ttl     = 3600
   }
 
   custom_error_response {
     error_caching_min_ttl = 0
     error_code            = 404
-    response_code         = 200
-    response_page_path    = "/index.html"
+    response_code         = 404
   }
 
   viewer_certificate {
@@ -1226,6 +1285,32 @@ resource "aws_cloudfront_distribution" "docs" {
     min_ttl     = 3600
     default_ttl = 86400
     max_ttl     = 31536000
+  }
+
+  ordered_cache_behavior {
+    path_pattern               = "/search*"
+    target_origin_id           = "docs-s3"
+    viewer_protocol_policy     = "redirect-to-https"
+    allowed_methods            = ["GET", "HEAD"]
+    cached_methods             = ["GET", "HEAD"]
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.crawler_noindex.id
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.docs_index_rewrite.arn
+    }
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    compress    = true
+    min_ttl     = 0
+    default_ttl = 600
+    max_ttl     = 3600
   }
 
   price_class = "PriceClass_100"

--- a/_infra/main.tf
+++ b/_infra/main.tf
@@ -1172,6 +1172,7 @@ resource "aws_cloudfront_distribution" "frontend" {
     error_caching_min_ttl = 0
     error_code            = 403
     response_code         = 404
+    response_page_path    = "/404.html"
   }
 
   ordered_cache_behavior {
@@ -1198,12 +1199,6 @@ resource "aws_cloudfront_distribution" "frontend" {
     min_ttl     = 0
     default_ttl = 600
     max_ttl     = 3600
-  }
-
-  custom_error_response {
-    error_caching_min_ttl = 0
-    error_code            = 404
-    response_code         = 404
   }
 
   viewer_certificate {

--- a/apps/docs-site/docs/discord-meeting-notes.md
+++ b/apps/docs-site/docs/discord-meeting-notes.md
@@ -4,7 +4,7 @@ slug: /discord-meeting-notes
 description: Record Discord voice calls, create structured meeting notes, and retrieve past decisions with Chronote.
 ---
 
-Chronote turns a Discord voice conversation into a shared record without moving the meeting into another app. It records the active voice channel, transcribes each participant, posts structured notes back to Discord, and keeps the meeting available for later questions and corrections.
+Chronote records a Discord voice call, writes the meeting notes, and posts them back to the channel—without asking anyone to leave Discord. It transcribes each speaker separately and keeps the meeting available for later questions and corrections.
 
 ## When Chronote fits
 
@@ -14,17 +14,17 @@ Chronote is useful when important decisions happen in voice and the people invol
 - Project standups, retrospectives, and design reviews.
 - Study groups and tutoring sessions.
 - Game, event, and campaign planning.
-- Any recurring Discord call where decisions or assignments otherwise disappear into memory.
+- Any recurring Discord call where decisions or assignments otherwise live only in someone's memory.
 
-The bot is server-oriented: one installation serves the Discord server, and notes return to the channel where the group already works.
+One install covers the whole server, and notes land in the channel where the group already talks.
 
 ## What happens in a meeting
 
 1. **Start recording.** Join a voice channel and run `/startmeeting`, use the Start meeting app action, or let an administrator configure auto-recording for selected channels.
-2. **Keep talking normally.** Chronote records visible participants, captures meeting-channel chat and attendance, and transcribes speakers separately.
+2. **Keep talking normally.** Chronote records the voice channel, captures meeting-channel chat and attendance, and transcribes each speaker separately.
 3. **End the meeting.** Use the End Meeting button, disconnect Chronote, or leave the voice channel. Auto-recorded meetings also end when the channel empties.
 4. **Read the result in Discord.** Chronote posts a summary, decisions, open questions, and next steps back to the notes channel.
-5. **Find it later.** The web portal stores the meeting record, and `/ask` can answer questions over recent meetings with a source meeting and timestamp.
+5. **Find it later.** The web portal stores the meeting record, and `/ask` answers questions about recent meetings, citing the source meeting and timestamp.
 
 See [Meeting Lifecycle](/core-concepts/meeting-lifecycle/) for the complete recording and processing flow.
 
@@ -37,7 +37,7 @@ A transcript preserves what was said; useful meeting notes make that conversatio
 - Use server context and a managed dictionary for project names and specialized terms.
 - Include text chat and attendance alongside the spoken conversation.
 - Let attendees suggest corrections, with an authorized person approving the change.
-- Download audio and transcripts from the portal, or export current notes to Notion.
+- Provide audio and transcript downloads from the portal, and export current notes to Notion.
 - Auto-record only the channels an administrator chooses.
 
 The [Features reference](/features/) lists the current commands, permissions, and output for each capability.
@@ -46,7 +46,7 @@ The [Features reference](/features/) lists the current commands, permissions, an
 
 Chronote only records while a meeting is running. It appears in the voice channel and posts a meeting status message so participants can see that recording is active. Administrators decide whether to enable auto-recording and can independently control viewer access to stored transcripts and audio.
 
-Meeting data is not published as website content. Access in Discord, the portal, shared links, and Remote MCP follows the product's documented permission rules. Read the [Privacy Policy](/legal/privacy/) for the data collected during a meeting, storage, service providers, and deletion requests.
+Meeting content is not part of Chronote's public website. Access through Discord, the portal, shared links, and Remote MCP follows the documented permission rules. Read the [Privacy Policy](/legal/privacy/) for the data collected during a meeting, storage, service providers, and deletion requests.
 
 ## Try a first meeting
 

--- a/apps/docs-site/docs/discord-meeting-notes.md
+++ b/apps/docs-site/docs/discord-meeting-notes.md
@@ -1,0 +1,59 @@
+---
+title: Discord Meeting Notes
+slug: /discord-meeting-notes
+description: Record Discord voice calls, create structured meeting notes, and retrieve past decisions with Chronote.
+---
+
+Chronote turns a Discord voice conversation into a shared record without moving the meeting into another app. It records the active voice channel, transcribes each participant, posts structured notes back to Discord, and keeps the meeting available for later questions and corrections.
+
+## When Chronote fits
+
+Chronote is useful when important decisions happen in voice and the people involved need more than a raw recording afterward. Common examples include:
+
+- Community planning calls and moderator meetings.
+- Project standups, retrospectives, and design reviews.
+- Study groups and tutoring sessions.
+- Game, event, and campaign planning.
+- Any recurring Discord call where decisions or assignments otherwise disappear into memory.
+
+The bot is server-oriented: one installation serves the Discord server, and notes return to the channel where the group already works.
+
+## What happens in a meeting
+
+1. **Start recording.** Join a voice channel and run `/startmeeting`, use the Start meeting app action, or let an administrator configure auto-recording for selected channels.
+2. **Keep talking normally.** Chronote records visible participants, captures meeting-channel chat and attendance, and transcribes speakers separately.
+3. **End the meeting.** Use the End Meeting button, disconnect Chronote, or leave the voice channel. Auto-recorded meetings also end when the channel empties.
+4. **Read the result in Discord.** Chronote posts a summary, decisions, open questions, and next steps back to the notes channel.
+5. **Find it later.** The web portal stores the meeting record, and `/ask` can answer questions over recent meetings with a source meeting and timestamp.
+
+See [Meeting Lifecycle](/core-concepts/meeting-lifecycle/) for the complete recording and processing flow.
+
+## More than transcription
+
+A transcript preserves what was said; useful meeting notes make that conversation easier to act on. Chronote can:
+
+- Highlight decisions, unresolved questions, and next steps.
+- Assign action items using valid Discord member or role mentions.
+- Use server context and a managed dictionary for project names and specialized terms.
+- Include text chat and attendance alongside the spoken conversation.
+- Let attendees suggest corrections, with an authorized person approving the change.
+- Export audio, transcripts, notes, and current notes to Notion.
+- Auto-record only the channels an administrator chooses.
+
+The [Features reference](/features/) lists the current commands, permissions, and output for each capability.
+
+## Recording visibility and access
+
+Chronote only records while a meeting is running. It appears in the voice channel and posts a meeting status message so participants can see that recording is active. Administrators decide whether to enable auto-recording and can independently control viewer access to stored transcripts and audio.
+
+Meeting data is not published as website content. Access in Discord, the portal, shared links, and Remote MCP follows the product's documented permission rules. Read the [Privacy Policy](/legal/privacy/) for the data collected during a meeting, storage, service providers, and deletion requests.
+
+## Try a first meeting
+
+Chronote has a free server plan. To test the workflow:
+
+1. [Add Chronote to your Discord server](https://chronote.gg/).
+2. Complete the short [Getting Started](/getting-started/) setup.
+3. Run one real voice meeting and review the notes with the participants.
+
+That first completed meeting is the best test: it shows whether the transcript recognizes your terminology, whether the note structure fits the group, and which context or dictionary entries would improve the next result.

--- a/apps/docs-site/docs/discord-meeting-notes.md
+++ b/apps/docs-site/docs/discord-meeting-notes.md
@@ -37,7 +37,7 @@ A transcript preserves what was said; useful meeting notes make that conversatio
 - Use server context and a managed dictionary for project names and specialized terms.
 - Include text chat and attendance alongside the spoken conversation.
 - Let attendees suggest corrections, with an authorized person approving the change.
-- Export audio, transcripts, notes, and current notes to Notion.
+- Download audio and transcripts from the portal, or export current notes to Notion.
 - Auto-record only the channels an administrator chooses.
 
 The [Features reference](/features/) lists the current commands, permissions, and output for each capability.

--- a/apps/docs-site/docs/discord-meeting-notes.md
+++ b/apps/docs-site/docs/discord-meeting-notes.md
@@ -4,7 +4,7 @@ slug: /discord-meeting-notes
 description: Record Discord voice calls, create structured meeting notes, and retrieve past decisions with Chronote.
 ---
 
-Chronote records a Discord voice call, writes the meeting notes, and posts them back to the channel—without asking anyone to leave Discord. It transcribes each speaker separately and keeps the meeting available for later questions and corrections.
+Chronote records a Discord voice call, writes the meeting notes, and posts them back to the channel, all without asking anyone to leave Discord. It transcribes each speaker separately and keeps the meeting available for later questions and corrections.
 
 ## When Chronote fits
 

--- a/apps/docs-site/docusaurus.config.ts
+++ b/apps/docs-site/docusaurus.config.ts
@@ -39,7 +39,7 @@ const crawlerFilesPlugin = () => ({
     const llms = [
       "# Chronote Documentation",
       "",
-      "> Public documentation for Chronote, a Discord bot that records voice meetings, transcribes each speaker, posts structured notes, and answers sourced questions about past meetings.",
+      "> Public documentation for Chronote, a Discord bot that records voice meetings, transcribes each speaker, posts structured notes, and answers questions about recent meetings with the source meeting and timestamp.",
       "",
       "Use these canonical public pages for current product behavior and setup. Portal pages, shared meetings, and meeting contents are not public documentation.",
       "",

--- a/apps/docs-site/docusaurus.config.ts
+++ b/apps/docs-site/docusaurus.config.ts
@@ -15,8 +15,8 @@ const forceLocalSearch = process.env.DOCS_SEARCH_PROVIDER === "local";
 const useLocalSearch = forceLocalSearch || !hasAlgoliaConfig;
 const useAlgolia = hasAlgoliaConfig && !forceLocalSearch;
 
-const robotsTxtPlugin = () => ({
-  name: "chronote-robots-txt",
+const crawlerFilesPlugin = () => ({
+  name: "chronote-crawler-files",
   // Written at build time rather than kept in static/, so sandbox and staging
   // advertise their own sitemap instead of the production one. Docusaurus
   // copies static/ verbatim and would hardcode whichever host was committed.
@@ -26,10 +26,44 @@ const robotsTxtPlugin = () => ({
       "User-agent: *",
       "Allow: /",
       "",
+      "# Public docs are intentionally available to ordinary search engines,",
+      "# OAI-SearchBot, GPTBot, and user-triggered assistants.",
+      "",
       `Sitemap: ${new URL("sitemap.xml", siteConfig.url).toString()}`,
       "",
     ].join("\n");
     await writeFile(path.join(outDir, "robots.txt"), body, "utf8");
+
+    const docsUrl = (pathname: string) =>
+      new URL(pathname, `${siteConfig.url}/`).toString();
+    const llms = [
+      "# Chronote Documentation",
+      "",
+      "> Public documentation for Chronote, a Discord bot that records voice meetings, transcribes each speaker, posts structured notes, and answers sourced questions about past meetings.",
+      "",
+      "Use these canonical public pages for current product behavior and setup. Portal pages, shared meetings, and meeting contents are not public documentation.",
+      "",
+      "## Start here",
+      "",
+      `- [Chronote](${docsUrl("/")}): Documentation home and product overview.`,
+      `- [Discord meeting notes guide](${docsUrl("/discord-meeting-notes/")}): What the bot does and how the workflow fits a Discord server.`,
+      `- [Getting started](${docsUrl("/getting-started/")}): Installation, permissions, onboarding, and the first meeting.`,
+      `- [Features](${docsUrl("/features/")}): Commands and product capabilities.`,
+      "",
+      "## Product documentation",
+      "",
+      `- [Meeting lifecycle](${docsUrl("/core-concepts/meeting-lifecycle/")}): Recording, processing, publishing, and revision stages.`,
+      `- [Integrations](${docsUrl("/integrations/")}): Web portal, Notion, Discord, and Remote MCP integrations.`,
+      `- [Troubleshooting](${docsUrl("/troubleshooting/common-issues/")}): Common setup and recording problems.`,
+      `- [What's New](${docsUrl("/whats-new/")}): Recent public product changes.`,
+      "",
+      "## Trust and policies",
+      "",
+      `- [Privacy Policy](${docsUrl("/legal/privacy/")}): What Chronote records, stores, and sends to service providers.`,
+      `- [Terms of Service](${docsUrl("/legal/terms/")}): Terms governing use of Chronote.`,
+      "",
+    ].join("\n");
+    await writeFile(path.join(outDir, "llms.txt"), llms, "utf8");
   },
 });
 
@@ -68,6 +102,11 @@ const config: Config = {
           editUrl:
             "https://github.com/Chronote-gg/Chronote/tree/master/apps/docs-site/",
         },
+        sitemap: {
+          ignorePatterns: ["/search/", "/search/**"],
+          changefreq: null,
+          priority: null,
+        },
         blog: false,
         pages: false,
         theme: {
@@ -89,9 +128,9 @@ const config: Config = {
             hashed: true,
           },
         ],
-        robotsTxtPlugin,
+        crawlerFilesPlugin,
       ]
-    : [robotsTxtPlugin],
+    : [crawlerFilesPlugin],
 
   themeConfig: {
     image: "img/chronote-social-card.png",

--- a/apps/docs-site/sidebars.ts
+++ b/apps/docs-site/sidebars.ts
@@ -3,6 +3,7 @@ import type { SidebarsConfig } from "@docusaurus/plugin-content-docs";
 const sidebars: SidebarsConfig = {
   docs: [
     "index",
+    "discord-meeting-notes",
     "getting-started/overview",
     {
       type: "category",

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Page not found - Chronote</title>
+  </head>
+  <body>
+    <main>
+      <h1>Page not found</h1>
+      <p>The requested Chronote page does not exist.</p>
+      <p><a href="/">Return to Chronote</a></p>
+    </main>
+  </body>
+</html>

--- a/public/404.html
+++ b/public/404.html
@@ -9,7 +9,7 @@
   <body>
     <main>
       <h1>Page not found</h1>
-      <p>The requested Chronote page does not exist.</p>
+      <p>This page doesn't exist.</p>
       <p><a href="/">Return to Chronote</a></p>
     </main>
   </body>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,28 @@
+# Chronote
+
+> Chronote is a Discord bot that records voice meetings, transcribes each speaker, posts structured notes back to the channel, and answers sourced questions about past meetings.
+
+Chronote is operated by BASIC BIT LLC. Use the canonical public pages below for current product behavior, setup, pricing, and privacy information. Meeting contents, shared meeting links, portal pages, and other signed-in surfaces are not public documentation.
+
+## Start here
+
+- [Chronote](https://chronote.gg/): Product overview, example output, current plans, and Add to Discord action.
+- [Discord meeting notes guide](https://docs.chronote.gg/discord-meeting-notes/): What the bot does, how a meeting works, and when it is a good fit.
+- [Getting started](https://docs.chronote.gg/getting-started/): Installation, permissions, onboarding, and the first meeting.
+- [Features](https://docs.chronote.gg/features/): Commands and product capabilities.
+
+## Product documentation
+
+- [Meeting lifecycle](https://docs.chronote.gg/core-concepts/meeting-lifecycle/): Recording, processing, publishing, and revision stages.
+- [Integrations](https://docs.chronote.gg/integrations/): Web portal, Notion, Discord, and Remote MCP integrations.
+- [Troubleshooting](https://docs.chronote.gg/troubleshooting/common-issues/): Common setup and recording problems.
+- [What's New](https://docs.chronote.gg/whats-new/): Recent public product changes.
+
+## Trust and policies
+
+- [Privacy Policy](https://docs.chronote.gg/legal/privacy/): What Chronote records, stores, and sends to service providers.
+- [Terms of Service](https://docs.chronote.gg/legal/terms/): Terms governing use of Chronote.
+
+## Optional
+
+- [Source code](https://github.com/Chronote-gg/Chronote): Public Chronote repository.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,8 +1,8 @@
 # Chronote
 
-> Chronote is a Discord bot that records voice meetings, transcribes each speaker, posts structured notes back to the channel, and answers sourced questions about past meetings.
+> Chronote is a Discord bot that records voice meetings, transcribes each speaker, posts structured notes back to the channel, and answers questions about recent meetings with the source meeting and timestamp.
 
-Chronote is operated by BASIC BIT LLC. Use the canonical public pages below for current product behavior, setup, pricing, and privacy information. Meeting contents, shared meeting links, portal pages, and other signed-in surfaces are not public documentation.
+Chronote is operated by BASIC BIT LLC. Use the canonical public pages below for current product behavior, setup, pricing, and privacy information. Meeting contents, shared meeting links, and signed-in portal pages are not public documentation.
 
 ## Start here
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,6 +2,10 @@
 User-agent: *
 Allow: /
 
+# Public product content is intentionally available to ordinary search engines,
+# OAI-SearchBot, GPTBot, and user-triggered assistants. Search discovery and
+# model-training access are separate policy choices; both remain allowed here.
+
 # Sign-in only, nothing to index. No trailing slashes: robots.txt matches on
 # prefix, so "/portal/" would miss the bare "/portal" route.
 Disallow: /portal

--- a/scripts/build-route-html.mjs
+++ b/scripts/build-route-html.mjs
@@ -86,10 +86,12 @@ const buildRouteHtml = (indexHtml, route) => {
       setTagValue(current, matcher, attribute, value),
     indexHtml,
   );
-  return html.replace(
-    /<title>[^<]*<\/title>/i,
-    `<title>${escapeHtml(route.title)}</title>`,
-  );
+  return html
+    .replace(/\s*<script id="chronote-structured-data"[\s\S]*?<\/script>/i, "")
+    .replace(
+      /<title>[^<]*<\/title>/i,
+      `<title>${escapeHtml(route.title)}</title>`,
+    );
 };
 
 const buildSitemap = () =>

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -41,6 +41,41 @@
       content="Saves the whole call, takes the notes so you don't have to, and finds the quote when you ask. Free tier on every server."
     />
     <meta name="twitter:image" content="https://chronote.gg/og-image.png" />
+    <script id="chronote-structured-data" type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": ["SoftwareApplication", "WebApplication"],
+            "@id": "https://chronote.gg/#application",
+            "name": "Chronote",
+            "url": "https://chronote.gg/",
+            "description": "Chronote records Discord voice calls, posts meeting notes back to the channel, and lets members ask what was said later.",
+            "applicationCategory": "CommunicationApplication",
+            "offers": {
+              "@type": "Offer",
+              "price": "0",
+              "priceCurrency": "USD"
+            },
+            "publisher": {
+              "@id": "https://chronote.gg/#organization"
+            }
+          },
+          {
+            "@type": "Organization",
+            "@id": "https://chronote.gg/#organization",
+            "name": "BASIC BIT LLC",
+            "alternateName": "Chronote",
+            "url": "https://chronote.gg/",
+            "logo": "https://chronote.gg/meeting_notes_original_logo.png",
+            "sameAs": [
+              "https://basicbit.net/",
+              "https://github.com/Chronote-gg/Chronote"
+            ]
+          }
+        ]
+      }
+    </script>
     <script>
       window.__API_BASE_URL__ = "%VITE_API_BASE_URL%";
       window.__MOCK_FIXED_NOW__ = "%VITE_MOCK_FIXED_NOW%";
@@ -50,7 +85,7 @@
     </script>
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.json" />
-    <title>Chronote</title>
+    <title>Chronote - AI meeting notes for Discord voice calls</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -21,7 +21,7 @@
     <meta property="og:site_name" content="Chronote" />
     <meta
       property="og:title"
-      content="Chronote - meeting notes for Discord voice calls"
+      content="Chronote - AI meeting notes for Discord voice calls"
     />
     <meta
       property="og:description"
@@ -34,7 +34,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta
       name="twitter:title"
-      content="Chronote - meeting notes for Discord voice calls"
+      content="Chronote - AI meeting notes for Discord voice calls"
     />
     <meta
       name="twitter:description"

--- a/test/scripts/buildRouteHtml.test.ts
+++ b/test/scripts/buildRouteHtml.test.ts
@@ -90,6 +90,16 @@ describe("build-route-html", () => {
     expect(readRoute("join")).toContain("/index.tsx");
   });
 
+  it("keeps homepage-only application schema off unrelated public routes", () => {
+    run(indexHtml);
+
+    for (const route of config.routes.filter((entry) => entry.emitHtml)) {
+      const html = readRoute(route.key);
+      expect(html).not.toContain('id="chronote-structured-data"');
+      expect(html).not.toContain('"price": "0"');
+    }
+  });
+
   it("advertises exactly the configured routes in the sitemap", () => {
     run(indexHtml);
     const sitemap = readFileSync(

--- a/test/scripts/crawlerAssets.test.ts
+++ b/test/scripts/crawlerAssets.test.ts
@@ -27,8 +27,20 @@ describe("crawler assets", () => {
     );
 
     expect(action).toContain(
-      "for stable in manifest.json sitemap.xml robots.txt llms.txt; do",
+      "for stable in manifest.json sitemap.xml robots.txt llms.txt 404.html; do",
     );
+  });
+
+  it("ships a noindex document for CloudFront's S3 error remap", () => {
+    const notFound = fs.readFileSync(
+      path.join(repoRoot, "public", "404.html"),
+      "utf8",
+    );
+
+    expect(notFound).toContain(
+      '<meta name="robots" content="noindex, nofollow"',
+    );
+    expect(notFound).not.toContain("window.__API_BASE_URL__");
   });
 
   it("publishes valid software application structured data", () => {

--- a/test/scripts/crawlerAssets.test.ts
+++ b/test/scripts/crawlerAssets.test.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = path.resolve(__dirname, "../..");
+
+describe("crawler assets", () => {
+  it("publishes a concise llms.txt containing only public canonical sources", () => {
+    const llms = fs.readFileSync(
+      path.join(repoRoot, "public", "llms.txt"),
+      "utf8",
+    );
+
+    expect(llms).toMatch(/^# Chronote\n/);
+    expect(llms).toContain("https://chronote.gg/");
+    expect(llms).toContain("https://docs.chronote.gg/getting-started/");
+    expect(llms).toContain("https://docs.chronote.gg/legal/privacy/");
+    expect(llms).not.toMatch(
+      /https:\/\/chronote\.gg\/(?:portal|admin|live|share)/,
+    );
+    expect(llms.length).toBeLessThan(5000);
+  });
+
+  it("keeps llms.txt on the short-lived stable-file deployment path", () => {
+    const action = fs.readFileSync(
+      path.join(repoRoot, ".github", "actions", "sync-frontend", "action.yml"),
+      "utf8",
+    );
+
+    expect(action).toContain(
+      "for stable in manifest.json sitemap.xml robots.txt llms.txt; do",
+    );
+  });
+
+  it("publishes valid software application structured data", () => {
+    const html = fs.readFileSync(
+      path.join(repoRoot, "src", "frontend", "index.html"),
+      "utf8",
+    );
+    const match = html.match(
+      /<script id="chronote-structured-data" type="application\/ld\+json">\s*([\s\S]*?)\s*<\/script>/,
+    );
+
+    expect(match).not.toBeNull();
+    const structuredData = JSON.parse(match![1]) as {
+      "@graph": Array<Record<string, unknown>>;
+    };
+    const application = structuredData["@graph"].find(
+      (entry) =>
+        Array.isArray(entry["@type"]) &&
+        entry["@type"].includes("SoftwareApplication"),
+    );
+
+    expect(application).toMatchObject({
+      name: "Chronote",
+      url: "https://chronote.gg/",
+      applicationCategory: "CommunicationApplication",
+      offers: { price: "0", priceCurrency: "USD" },
+    });
+  });
+});


### PR DESCRIPTION
[AGENT]

## Summary

- publish concise `llms.txt` files for the product and docs sites while treating the proposal as a discovery aid, not a ranking mechanism
- improve the homepage title and add homepage-only `SoftwareApplication`/organization structured data
- add a substantive Discord meeting-notes guide and exclude the docs search utility from the sitemap
- replace the frontend's catch-all soft 200 with an explicit CloudFront route map: known SPA routes still load, public metadata routes keep their dedicated HTML, and unknown paths return a real noindex 404
- apply response-level `X-Robots-Tag: noindex, nofollow` to shared-meeting/Q&A pages and docs search pages
- preserve the existing policy that allows ordinary search crawlers, OAI-SearchBot, GPTBot, and user-triggered assistants on public content

## Scope and rollout

This does not deploy or change live production configuration. The CloudFront behavior changes require the normal reviewed Terraform plan/apply, and the product/docs artifacts require their normal deploy workflows after merge. Signed-in portal, admin, live-meeting, and meeting-content surfaces remain outside the public discovery set.

## Verification

- full Jest suite: 206 suites / 1,167 tests passed
- focused crawler and route tests: 3 suites / 16 tests passed with coverage disabled for the focused run
- frontend production build and route HTML generation passed
- docs production build passed; generated sitemap includes `/discord-meeting-notes/` and excludes `/search/`
- TypeScript and changed-file ESLint passed
- Terraform validate passed (only existing DynamoDB `hash_key` deprecation warnings)
- Checkov: 380 passed, 0 failed, 60 skipped
- changed-file Prettier, Terraform fmt, and `git diff --check` passed

Known non-change gate: a whole-repository Prettier scan still flags five pre-existing `memory-bank/*.md` files; none are touched here and every changed file is clean.
